### PR TITLE
Add claude-starter: Production-ready configuration template with 40 skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
+- [claude-starter](https://github.com/raintree-technology/claude-starter) - Production-ready Claude Code configuration template with 40 auto-activating skills across 8 domains, TOON format support for 30-60% token savings, and native Zig encoder/decoder. *By [@zacharyr0th](https://github.com/zacharyr0th)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*


### PR DESCRIPTION
## Description

This PR adds **[claude-starter](https://github.com/raintree-technology/claude-starter)** to the **Development & Code Tools** section.

## What is claude-starter?

A production-ready Claude Code configuration template that provides a comprehensive `.claude/` directory ready to drop into any project. It includes:

- **40 auto-activating skills** organized across 8 domains
- **TOON format support** for 30-60% token savings on tabular data
- **7 slash commands** for format conversion and skill marketplace integration
- **Native Zig encoder/decoder** (20x faster than JavaScript)
- **Complete documentation** with examples and customization guides

## Features Overview

**8 Skill Domains (40 total skills):**
1. **AI & Claude Code** (7) - Anthropic API, Claude Code CLI, builders for commands/hooks/skills/MCP
2. **Payments & Commerce** (3) - Stripe, Whop, Shopify
3. **Banking** (5) - Plaid with Auth, Transactions, Identity, Accounts
4. **Blockchain** (18) - Aptos, Shelby Protocol, Decibel perpetual futures
5. **Backend** (1) - Supabase (PostgreSQL, auth, realtime, storage, edge functions)
6. **Mobile** (5) - Expo (EAS Build/Update/Router), iOS
7. **Data** (1) - TOON formatter with auto-detection
8. **Documentation** - Optional pull via docpull (8,224 files available)

**TOON Format:**
- 30-60% token savings on arrays (5+ items) and uniform objects (60%+ field similarity)
- Native Zig implementation (357KB binary, compiled for performance)
- 5 slash commands: `/convert-to-toon`, `/toon-encode`, `/toon-decode`, `/toon-validate`, `/analyze-tokens`
- Complete specification with 13 passing tests

**Marketplace Integration:**
- Browse 13,000+ community skills via SkillsMP
- 2 slash commands: `/discover-skills`, `/install-skill`

## Use Cases

**Full template deployment:**
```bash
cp -r claude-starter/.claude /your-project/.claude
```

**Selective domain installation:**
```bash
# Just payment processing
cp -r claude-starter/.claude/skills/{stripe,whop} /your-project/.claude/skills/

# Just blockchain
cp -r claude-starter/.claude/skills/aptos /your-project/.claude/skills/

# Just TOON optimization tools
cp -r claude-starter/.claude/utils/toon /your-project/.claude/utils/
cp -r claude-starter/.claude/commands/toon* /your-project/.claude/commands/
```

## Documentation

Skills work immediately with built-in knowledge. Comprehensive API documentation (8,224 files) can optionally be pulled from official sources:

```bash
pipx install docpull
docpull https://docs.stripe.com -o .claude/skills/stripe/docs  # 3,253 files
docpull https://supabase.com/docs -o .claude/skills/supabase/docs  # 2,616 files
# See README for complete list
```

## Why Development & Code Tools?

claude-starter is a comprehensive development toolkit and configuration template that:
- Provides reusable development workflows across multiple domains
- Includes native tooling (Zig encoder/decoder) for code optimization
- Follows Claude Code best practices and skill structure
- Enables systematic skill organization and marketplace integration

## Links

- **Repository:** https://github.com/raintree-technology/claude-starter
- **Documentation:** `.claude/README.md` and `.claude/DIRECTORY.md`
- **License:** MIT
- **Author:** [@zacharyr0th](https://github.com/zacharyr0th)

## Checklist

- [x] Added to appropriate category (Development & Code Tools)
- [x] Follows established formatting (link, description, author attribution)
- [x] Repository is public and accessible
- [x] MIT License
- [x] Skills follow Claude Code best practices
- [x] Includes clear, concise description
- [x] Author attribution included