### PR TITLE
Add dev-agent-skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Collaboration & Project Management
 
+- [dev-agent-skills](https://github.com/fvadicamo/dev-agent-skills) - Complete GitHub workflow skills: git-commit (Conventional Commits), github-pr-creation, github-pr-merge, github-pr-review, and creating-skills guide. *By [@fvadicamo](https://github.com/fvadicamo)*
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.


### PR DESCRIPTION
## Summary
Adds dev-agent-skills to the Collaboration & Project Management section.

## Description
A collection of 5 agent skills organized in 2 plugins for Git and GitHub workflows:

### github-workflow plugin
- **git-commit**: Creates commits following Conventional Commits format
- **github-pr-creation**: PR creation with validation and task tracking
- **github-pr-merge**: Pre-merge checklist validation
- **github-pr-review**: Review comment resolution with severity classification

### skill-authoring plugin
- **creating-skills**: Guide for creating Claude Code skills following Anthropic's best practices

## Installation
```bash
/plugin marketplace add fvadicamo/dev-agent-skills
/plugin install github-workflow@dev-agent-skills
```

## Repository
https://github.com/fvadicamo/dev-agent-skills

## Checklist
- [x] Repository is public
- [x] Skills have SKILL.md with proper frontmatter
- [x] README with installation instructions
- [x] MIT License
- [x] Link tested and working