### PR TITLE
Add code-to-content skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
+- [code-to-content](https://github.com/arome3/code-to-content) - Transform codebases into developer content (blog, tutorial, Twitter, LinkedIn, README, newsletter, video script, conference talk) with 5-phase quality-gated workflow and 3 parallel agents. *By [@arome3](https://github.com/arome3)*
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.


### PR DESCRIPTION
## Summary

Adding [code-to-content](https://github.com/arome3/code-to-content) to the Communication & Writing section.

**What it does:** Transforms codebases into developer content with a 5-phase quality-gated workflow and 3 parallel agents. Supports 9 content formats: blog, tutorial, Twitter, LinkedIn, README, newsletter, video script, conference talk, and product launch.

**Category:** Communication & Writing

## Changes

- Added `code-to-content` entry to the Communication & Writing section (alphabetically placed after `brainstorming`)