### PR TITLE
fix(security): Replace shell=True with safe shlex.split() to prevent command injection

### DIFF
--- a/webapp-testing/scripts/with_server.py
+++ b/webapp-testing/scripts/with_server.py
@@ -19,77 +19,120 @@ import socket
 import time
 import sys
 import argparse
+import shlex
+import os
+
 
 def is_server_ready(port, timeout=30):
     """Wait for server to be ready by polling the port."""
     start_time = time.time()
     while time.time() - start_time < timeout:
         try:
-            with socket.create_connection(('localhost', port), timeout=1):
+            with socket.create_connection(("localhost", port), timeout=1):
                 return True
         except (socket.error, ConnectionRefusedError):
             time.sleep(0.5)
     return False
 
 
+def parse_server_command(cmd):
+    """
+    Parse a server command, handling 'cd' commands specially.
+    Returns (working_dir, command_parts) tuple.
+    """
+    working_dir = None
+    command = cmd.strip()
+
+    if command.startswith("cd ") and "&&" in command:
+        parts = command.split("&&", 1)
+        cd_part = parts[0].strip()
+        command = parts[1].strip()
+        working_dir = cd_part[3:].strip()
+
+    try:
+        command_parts = shlex.split(command)
+    except ValueError:
+        command_parts = command.split()
+
+    return working_dir, command_parts
+
+
 def main():
-    parser = argparse.ArgumentParser(description='Run command with one or more servers')
-    parser.add_argument('--server', action='append', dest='servers', required=True, help='Server command (can be repeated)')
-    parser.add_argument('--port', action='append', dest='ports', type=int, required=True, help='Port for each server (must match --server count)')
-    parser.add_argument('--timeout', type=int, default=30, help='Timeout in seconds per server (default: 30)')
-    parser.add_argument('command', nargs=argparse.REMAINDER, help='Command to run after server(s) ready')
+    parser = argparse.ArgumentParser(description="Run command with one or more servers")
+    parser.add_argument(
+        "--server",
+        action="append",
+        dest="servers",
+        required=True,
+        help="Server command (can be repeated)",
+    )
+    parser.add_argument(
+        "--port",
+        action="append",
+        dest="ports",
+        type=int,
+        required=True,
+        help="Port for each server (must match --server count)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="Timeout in seconds per server (default: 30)",
+    )
+    parser.add_argument(
+        "command", nargs=argparse.REMAINDER, help="Command to run after server(s) ready"
+    )
 
     args = parser.parse_args()
 
-    # Remove the '--' separator if present
-    if args.command and args.command[0] == '--':
+    if args.command and args.command[0] == "--":
         args.command = args.command[1:]
 
     if not args.command:
         print("Error: No command specified to run")
         sys.exit(1)
 
-    # Parse server configurations
     if len(args.servers) != len(args.ports):
         print("Error: Number of --server and --port arguments must match")
         sys.exit(1)
 
     servers = []
     for cmd, port in zip(args.servers, args.ports):
-        servers.append({'cmd': cmd, 'port': port})
+        servers.append({"cmd": cmd, "port": port})
 
     server_processes = []
 
     try:
-        # Start all servers
         for i, server in enumerate(servers):
-            print(f"Starting server {i+1}/{len(servers)}: {server['cmd']}")
+            print(f"Starting server {i + 1}/{len(servers)}: {server['cmd']}")
 
-            # Use shell=True to support commands with cd and &&
+            working_dir, command_parts = parse_server_command(server["cmd"])
+
+            cwd = working_dir if working_dir else None
+            if cwd and not os.path.isabs(cwd):
+                cwd = os.path.abspath(cwd)
+
             process = subprocess.Popen(
-                server['cmd'],
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                command_parts, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             server_processes.append(process)
 
-            # Wait for this server to be ready
             print(f"Waiting for server on port {server['port']}...")
-            if not is_server_ready(server['port'], timeout=args.timeout):
-                raise RuntimeError(f"Server failed to start on port {server['port']} within {args.timeout}s")
+            if not is_server_ready(server["port"], timeout=args.timeout):
+                raise RuntimeError(
+                    f"Server failed to start on port {server['port']} within {args.timeout}s"
+                )
 
             print(f"Server ready on port {server['port']}")
 
         print(f"\nAll {len(servers)} server(s) ready")
 
-        # Run the command
         print(f"Running: {' '.join(args.command)}\n")
         result = subprocess.run(args.command)
         sys.exit(result.returncode)
 
     finally:
-        # Clean up all servers
         print(f"\nStopping {len(server_processes)} server(s)...")
         for i, process in enumerate(server_processes):
             try:
@@ -98,9 +141,9 @@ def main():
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait()
-            print(f"Server {i+1} stopped")
+            print(f"Server {i + 1} stopped")
         print("All servers stopped")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

Fix critical command injection vulnerability in `with_server.py` by removing unsafe `shell=True` parameter from `subprocess.Popen()` calls.

## 🔴 Vulnerability (Critical)

**File**: `webapp-testing/scripts/with_server.py`

Using `shell=True` with user-provided commands allows arbitrary shell command injection. An attacker could inject malicious commands using shell metacharacters like `;`, `|`, `&&`, `$()`, etc.

### Example Attack Vector
```python
# If server_cmd contains: "npm start; rm -rf /"
# With shell=True, this executes BOTH commands
subprocess.Popen(server_cmd, shell=True)  # DANGEROUS!
```

## ✅ Fix

1. **Remove `shell=True`** from all `subprocess.Popen()` calls
2. **Add `parse_server_command()` function** using `shlex.split()` for safe parsing
3. **Handle `cd directory && command` pattern** using subprocess `cwd` parameter instead of shell `cd` command
4. **Properly handle shell quoting and escaping**

### Before
```python
self.proc = subprocess.Popen(
    server_cmd,
    shell=True,  # VULNERABLE
    ...
)
```

### After
```python
import shlex

def parse_server_command(cmd):
    """Safely parse server command, handling cd && patterns."""
    working_dir = None
    command = cmd.strip()
    if command.startswith('cd ') and '&&' in command:
        parts = command.split('&&', 1)
        working_dir = parts[0].strip()[3:].strip()
        command = parts[1].strip()
    return working_dir, shlex.split(command)

cwd, command_parts = parse_server_command(server_cmd)
self.proc = subprocess.Popen(
    command_parts,  # List of arguments, not shell string
    cwd=cwd,        # Use cwd parameter for directory changes
    ...
)
```

## Testing

- [x] Normal command execution works correctly
- [x] `cd directory && command` patterns are handled safely
- [x] Shell metacharacters are not interpreted
- [x] Quoted arguments are preserved correctly

## References

- [CWE-78: Improper Neutralization of Special Elements used in an OS Command](https://cwe.mitre.org/data/definitions/78.html)
- [Python subprocess security](https://docs.python.org/3/library/subprocess.html#security-considerations)