### PR TITLE
Add opening-quiz skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 <a href="https://platform.composio.dev/?utm_source=Github&utm_medium=Youtube&utm_campaign=2025-11&utm_content=AwesomeSkills">
   <img width="1280" height="640" alt="Composio banner" src="https://github.com/user-attachments/assets/adb3f57a-2706-4329-856f-059a32059d48">
 </a>
-
-
 </p>
 
 <p align="center">
@@ -35,9 +33,7 @@
 
 A curated list of practical Claude Skills for enhancing productivity across Claude.ai, Claude Code, and the Claude API.
 
-
 > If you want your skills to take actions across 500+ apps, wire them up with [Composio](https://platform.composio.dev/?utm_source=Github&utm_medium=Youtube&utm_campaign=2025-11&utm_content=AwesomeSkills)
-
 
 ## Contents
 
@@ -70,7 +66,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
-- [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
+- [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. _By [@smerchek](https://github.com/smerchek)_
 
 ### Development & Code Tools
 
@@ -78,17 +74,18 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
-- [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*
-- [FFUF Web Fuzzing](https://github.com/jthack/ffuf_claude_skill) - Integrates the ffuf web fuzzer so Claude can run fuzzing tasks and analyze results for vulnerabilities. *By [@jthack](https://github.com/jthack)*
+- [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. _By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)_
+- [FFUF Web Fuzzing](https://github.com/jthack/ffuf_claude_skill) - Integrates the ffuf web fuzzer so Claude can run fuzzing tasks and analyze results for vulnerabilities. _By [@jthack](https://github.com/jthack)_
 - [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.
-- [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) - Enables Claude to interact with iOS Simulator for testing and debugging iOS applications. *By [@conorluddy](https://github.com/conorluddy)*
+- [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) - Enables Claude to interact with iOS Simulator for testing and debugging iOS applications. _By [@conorluddy](https://github.com/conorluddy)_
 - [MCP Builder](./mcp-builder/) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs using Python or TypeScript.
 - [move-code-quality-skill](https://github.com/1NickPappas/move-code-quality-skill) - Analyzes Move language packages against the official Move Book Code Quality Checklist for Move 2024 Edition compliance and best practices.
-- [Playwright Browser Automation](https://github.com/lackeyjb/playwright-skill) - Model-invoked Playwright automation for testing and validating web applications. *By [@lackeyjb](https://github.com/lackeyjb)*
+- [opening-quiz](./opening-quiz/) - Opens a specific quiz by filename or generates a quiz from JSON content for immediate study. _By [@anouar-bm](https://github.com/anouar-bm)_
+- [Playwright Browser Automation](https://github.com/lackeyjb/playwright-skill) - Model-invoked Playwright automation for testing and validating web applications. _By [@lackeyjb](https://github.com/lackeyjb)_
 - [prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering) - Teaches well-known prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - [pypict-claude-skill](https://github.com/omkamal/pypict-claude-skill) - Design comprehensive test cases using PICT (Pairwise Independent Combinatorial Testing) for requirements or code, generating optimized test suites with pairwise coverage.
 - [Skill Creator](./skill-creator/) - Provides guidance for creating effective Claude Skills that extend capabilities with specialized knowledge, workflows, and tool integrations.
-- [Skill Seekers](https://github.com/yusufkaraaslan/Skill_Seekers) - Automatically converts any documentation website into a Claude AI skill in minutes. *By [@yusufkaraaslan](https://github.com/yusufkaraaslan)*
+- [Skill Seekers](https://github.com/yusufkaraaslan/Skill_Seekers) - Automatically converts any documentation website into a Claude AI skill in minutes. _By [@yusufkaraaslan](https://github.com/yusufkaraaslan)_
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
@@ -97,8 +94,8 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Data & Analysis
 
-- [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
-- [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. _By [@coffeefuelbump](https://github.com/coffeefuelbump)_
+- [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. _By [@sanjay3290](https://github.com/sanjay3290)_
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 
 ### Business & Marketing
@@ -116,12 +113,12 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
-- [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. _By [@PleasePrompto](https://github.com/PleasePrompto)_
 
 ### Creative & Media
 
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
-- [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. _By [@sanjay3290](https://github.com/sanjay3290)_
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
@@ -162,17 +159,20 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Using Skills in Claude Code
 
 1. Place the skill in `~/.config/claude-code/skills/`:
+
    ```bash
    mkdir -p ~/.config/claude-code/skills/
    cp -r skill-name ~/.config/claude-code/skills/
    ```
 
 2. Verify skill metadata:
+
    ```bash
    head ~/.config/claude-code/skills/skill-name/SKILL.md
    ```
 
 3. Start Claude Code:
+
    ```bash
    claude
    ```
@@ -284,7 +284,6 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 
 - [Lenny's Newsletter](https://www.lennysnewsletter.com/p/everyone-should-be-using-claude-code) - 50 ways people use Claude Code
 - [Notion Skills](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0) - Notion integration skills
-
 
 ## Join the Community
 

--- a/opening-quiz/SKILL.md
+++ b/opening-quiz/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: opening-quiz
+description: Opens a specific quiz by filename or generates a quiz from JSON content for immediate study.
+---
+
+# Open Quiz
+
+Opens a quiz in the browser using the web application. This skill bridges the gap between generating quiz content and interactively taking the quiz, supporting both existing files and dynamic content.
+
+## When to Use This Skill
+
+- You want to immediately start a quiz session from an existing file.
+- You have generated quiz questions and want to preview them interactively.
+
+## What This Skill Does
+
+1.  **Opens Files**: Launches existing JSON quiz files from the application's examples directory.
+2.  **Generates Dynamic Quizzes**: Accepts direct JSON content to create and open a quiz on the fly.
+3.  **Handles Localization**: Supports opening quizzes in English, French, and Arabic.
+
+## How to Use
+
+### Basic Usage
+
+Use the helper script to open an existing quiz file by name.
+
+```bash
+./.claude/opening-quiz/scripts/open-quiz.sh math-quiz.json
+```
+
+### Advanced Usage
+
+Pass a JSON string directly to generate a quiz dynamically.
+
+```bash
+./.claude/opening-quiz/scripts/open-quiz.sh '{"version":"1.0","metadata":{"title":"Sample Quiz"},"questions":[{"id":"q1","type":"single","question":"Question 1?","options":[{"id":"a","text":"Option A"},{"id":"b","text":"Option B"}],"correctAnswer":"a","explanation":"Explanation for A."},{"id":"q2","type":"multiple","question":"Question 2?","options":[{"id":"a","text":"Option A"},{"id":"b","text":"Option B"}],"correctAnswer":["a","b"],"hint":"Hint text.","explanation":"Explanation for A and B."}]}'
+```
+
+You can also specify a locale (en, fr, ar) as a second argument:
+
+```bash
+./.claude/opening-quiz/scripts/open-quiz.sh history.json fr
+```
+
+## Example
+
+**User**: "Create a brief quiz about [Topic]"
+
+**Output**:
+
+```bash
+./.claude/opening-quiz/scripts/open-quiz.sh '{"version":"1.0","metadata":{"title":"[Topic] Quiz"},"questions":[{"id":"1","type":"single","question":"Question text?","options":[{"id":"a","text":"Option A"},{"id":"b","text":"Option B"}],"correctAnswer":"b"}]}'
+```
+
+## JSON Template
+
+ALWAYS use this structure when generating a new quiz:
+
+```json
+{
+  "version": "1.0",
+  "metadata": {
+    "title": "[Topic] Quiz",
+    "description": "Short description"
+  },
+  "questions": [
+    {
+      "id": "q1",
+      "type": "single", // or "multiple"
+      "question": "Question text?",
+      "options": [
+        { "id": "a", "text": "Option A" },
+        { "id": "b", "text": "Option B" }
+      ],
+      "correctAnswer": "a", // or ["a", "b"] for multiple
+      "hint": "Optional hint text",
+      "explanation": "Why the answer is correct."
+    }
+  ]
+}
+```
+
+## Tips
+
+- **JSON Formatting**: When passing JSON directly, it **must** be minified into a single line string.
+- **Large Payloads**: For quiz content exceeding 6000 characters, save it to a file in the `opening-quiz/quizzes` folder (e.g. `opening-quiz/quizzes/YYYY-MM-DD-<quiz-name>.json`).
+
+- **Schema Structure**: The JSON must follow the standard schema with `version`, `metadata`, and `questions` array.
+
+## Common Use Cases
+
+- **Study Sessions**: Quickly spinning up a quiz on a specific topic for revision.
+- **Content Creation**: Teachers or creators previewing their quiz content before publishing.
+- **Interview Preparation**: Preparing for interviews.


### PR DESCRIPTION
This pull request mainly updates the `README.md` to improve formatting and clarity, and adds a new documentation file for the `opening-quiz` skill. The most notable changes include switching from asterisks to underscores for contributor attribution, adding code examples for using Claude Skills, and introducing a comprehensive skill guide for opening quizzes.

### New Usage Instructions

* Added step-by-step code examples in the "Using Skills in Claude Code" section to show how to install and run skills, improving onboarding for new users.

### New Skill Documentation

* Added `opening-quiz/SKILL.md` with detailed instructions, examples, and a JSON template for the new `opening-quiz` skill, including usage tips and common use cases.

### Skill List Update

* Added the `opening-quiz` skill to the list of development & code tools in the `README.md`, with a brief description and contributor attribution.