### PR TITLE
Add Connect skill + improve CTAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 A curated list of practical Claude Skills for enhancing productivity across Claude.ai, Claude Code, and the Claude API.
 
 
-> If you want your skills to take actions across 500+ apps, wire them up with [Composio](https://platform.composio.dev/?utm_source=Github&utm_medium=Youtube&utm_campaign=2025-11&utm_content=AwesomeSkills)
+> **Want skills that do more than generate text?** Claude can send emails, create issues, post to Slack, and take actions across 1000+ apps. [See how →](./connect/)
 
 
 ## Contents
@@ -93,6 +93,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis
@@ -288,9 +289,21 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 
 ## Join the Community
 
-- Have questions about integrating Composio with your auth setup? [Hop on a quick call with us](https://calendly.com/thomas-composio/composio-enterprise-setup)
-- [Follow us on Twitter](https://x.com/composio)
-- [Join our Discord](https://discord.com/invite/composio)
+- [Join our Discord](https://discord.com/invite/composio) - Chat with other developers building Claude Skills
+- [Follow on Twitter/X](https://x.com/composio) - Stay updated on new skills and features
+- Questions? [support@composio.dev](mailto:support@composio.dev)
+
+---
+
+<p align="center">
+  <b>Join 20,000+ developers building agents that ship</b>
+</p>
+
+<p align="center">
+  <a href="https://platform.composio.dev/?utm_source=Github&utm_content=AwesomeSkills">
+    <img src="https://img.shields.io/badge/Get_Started_Free-4F46E5?style=for-the-badge" alt="Get Started"/>
+  </a>
+</p>
 
 ## License
 

--- a/connect/SKILL.md
+++ b/connect/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: connect
+description: Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
+---
+
+# Connect
+
+Connect Claude to any app. Stop generating text about what you could do - actually do it.
+
+## When to Use This Skill
+
+Use this skill when you need Claude to:
+
+- **Send that email** instead of drafting it
+- **Create that issue** instead of describing it
+- **Post that message** instead of suggesting it
+- **Update that database** instead of explaining how
+
+## What Changes
+
+| Without Connect | With Connect |
+|-----------------|--------------|
+| "Here's a draft email..." | Sends the email |
+| "You should create an issue..." | Creates the issue |
+| "Post this to Slack..." | Posts it |
+| "Add this to Notion..." | Adds it |
+
+## Supported Apps
+
+**1000+ integrations** including:
+
+- **Email:** Gmail, Outlook, SendGrid
+- **Chat:** Slack, Discord, Teams, Telegram
+- **Dev:** GitHub, GitLab, Jira, Linear
+- **Docs:** Notion, Google Docs, Confluence
+- **Data:** Sheets, Airtable, PostgreSQL
+- **CRM:** HubSpot, Salesforce, Pipedrive
+- **Storage:** Drive, Dropbox, S3
+- **Social:** Twitter, LinkedIn, Reddit
+
+## Setup
+
+### 1. Get API Key
+
+Get your free key at [platform.composio.dev](https://platform.composio.dev/?utm_source=Github&utm_content=AwesomeSkills)
+
+### 2. Set Environment Variable
+
+```bash
+export COMPOSIO_API_KEY="your-key"
+```
+
+### 3. Install
+
+```bash
+pip install composio          # Python
+npm install @composio/core    # TypeScript
+```
+
+Done. Claude can now connect to any app.
+
+## Examples
+
+### Send Email
+```
+Email sarah@acme.com - Subject: "Shipped!" Body: "v2.0 is live, let me know if issues"
+```
+
+### Create GitHub Issue
+```
+Create issue in my-org/repo: "Mobile timeout bug" with label:bug
+```
+
+### Post to Slack
+```
+Post to #engineering: "Deploy complete - v2.4.0 live"
+```
+
+### Chain Actions
+```
+Find GitHub issues labeled "bug" from this week, summarize, post to #bugs on Slack
+```
+
+## How It Works
+
+Uses Composio Tool Router:
+
+1. **You ask** Claude to do something
+2. **Tool Router finds** the right tool (1000+ options)
+3. **OAuth handled** automatically
+4. **Action executes** and returns result
+
+### Code
+
+```python
+from composio import Composio
+from claude_agent_sdk.client import ClaudeSDKClient
+from claude_agent_sdk.types import ClaudeAgentOptions
+import os
+
+composio = Composio(api_key=os.environ["COMPOSIO_API_KEY"])
+session = composio.create(user_id="user_123")
+
+options = ClaudeAgentOptions(
+    system_prompt="You can take actions in external apps.",
+    mcp_servers={
+        "composio": {
+            "type": "http",
+            "url": session.mcp.url,
+            "headers": {"x-api-key": os.environ["COMPOSIO_API_KEY"]},
+        }
+    },
+)
+
+async with ClaudeSDKClient(options) as client:
+    await client.query("Send Slack message to #general: Hello!")
+```
+
+## Auth Flow
+
+First time using an app:
+```
+To send emails, I need Gmail access.
+Authorize here: https://...
+Say "connected" when done.
+```
+
+Connection persists after that.
+
+## Framework Support
+
+| Framework | Install |
+|-----------|---------|
+| Claude Agent SDK | `pip install composio claude-agent-sdk` |
+| OpenAI Agents | `pip install composio openai-agents` |
+| Vercel AI | `npm install @composio/core @composio/vercel` |
+| LangChain | `pip install composio-langchain` |
+| Any MCP Client | Use `session.mcp.url` |
+
+## Troubleshooting
+
+- **Auth required** → Click link, authorize, say "connected"
+- **Action failed** → Check permissions in target app
+- **Tool not found** → Be specific: "Slack #general" not "send message"
+
+---
+
+<p align="center">
+  <b>Join 20,000+ developers building agents that ship</b>
+</p>
+
+<p align="center">
+  <a href="https://platform.composio.dev/?utm_source=Github&utm_content=AwesomeSkills">
+    <img src="https://img.shields.io/badge/Get_Started_Free-4F46E5?style=for-the-badge" alt="Get Started"/>
+  </a>
+</p>


### PR DESCRIPTION
## Summary

- **New skill: Connect** - Teaches users how to connect Claude to external apps (Gmail, Slack, GitHub, Notion, 1000+ services) using Composio Tool Router
- **Updated README Links** - Replaced "book a meeting" with signup 
- **Fixed skill listing** - Added Connect to Development & Code Tools section

## Changes

| File | Change |
|------|--------|
| `connect/SKILL.md` | New skill with setup guide, code examples, and visual CTA |
| `README.md` | Updated inline CTA link, added Connect to skills list, added signup badge at bottom |

## Why

- Improves conversion by showing clear value prop (before/after comparison)
- Maintains community trust with value-first approach
- Uses visual CTAs with social proof ("Join 20,000+ developers")

## Test plan

- [ ] Verify Connect skill renders correctly
- [ ] Verify README links work
- [ ] Check visual CTA badge displays properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)