### PR TITLE
Add adversarial-spec skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [Adversarial Spec](https://github.com/zscole/adversarial-spec) - Iteratively refines product specifications through multi-model debate (GPT, Gemini, Grok, Claude) until consensus. Includes focus modes, personas, session persistence, and Telegram notifications. *By [@zscole](https://github.com/zscole)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## Summary

Adds [adversarial-spec](https://github.com/zscole/adversarial-spec) to the Development & Code Tools section.

## What it does

A Claude Code plugin that iteratively refines product specifications through multi-model debate until consensus is reached. Multiple LLMs (GPT, Gemini, Grok, Claude) critique specs in parallel, and the debate continues until all models agree.

**Features:**
- PRD and Technical Specification document types
- Focus modes (security, scalability, performance, ux, reliability, cost)
- Professional personas (security-engineer, oncall-engineer, qa-engineer, etc.)
- AWS Bedrock support for enterprise routing
- Session persistence and auto-checkpointing
- Telegram notifications for async review
- Cost tracking across providers
- 286 tests, 90%+ coverage

## Checklist

- [x] Based on a real use case
- [x] No duplicates in existing skills
- [x] Follows the skill structure template
- [x] Tested in Claude Code
- [x] Clear documentation