### PR TITLE
Add Trail of Bits Security Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [Trail of Bits Security Skills](https://github.com/trailofbits/skills) - Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection.
 
 ## Getting Started
 


### PR DESCRIPTION
Adds Trail of Bits Security Skills to the Security & Systems section.

**Skill:** [Trail of Bits Security Skills](https://github.com/trailofbits/skills)

**Description:** Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection.

**Features:**
- 17 security-focused skills
- Static analysis toolkit integration
- Variant analysis across codebases
- Fix verification and differential code review

Licensed under CC BY-SA 4.0.