### PR TITLE
docs: add VS Code distribution info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 4. The skill loads automatically and activates when relevant.
 
+### Using Skills in VS Code Distribution
+In Cursor, Antigravity, Windsurf, Trae, etc., you can search for and install [AgentSkillsManager](https://github.com/lasoons/AgentSkillsManager) from the extension marketplace. This repository is already available as a preconfigured SKILL repository for direct use.
+
 ### Using Skills via API
 
 Use the Claude Skills API to programmatically load and manage skills:


### PR DESCRIPTION
I have already pre-installed it in the VS Code AgentSkills management extension I released.

<img width="1753" height="922" alt="image" src="https://github.com/user-attachments/assets/a718b476-ca4e-417e-8cdb-686f2ac22066" />
