### PR TITLE
feat: add pm-skills - 24 product management skills for Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If you receive the email, Claude is now connected to 500+ apps.
   - [Communication & Writing](#communication--writing)
   - [Creative & Media](#creative--media)
   - [Productivity & Organization](#productivity--organization)
+  - [Product Management](#product-management)
   - [Collaboration & Project Management](#collaboration--project-management)
   - [Security & Systems](#security--systems)
 - [Getting Started](#getting-started)
@@ -175,6 +176,10 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+
+### Product Management
+
+- [pm-skills](https://github.com/product-on-purpose/pm-skills) - Complete PM toolkit with 24 skills covering Discover, Define, Develop, Deliver, Measure, and Iterate phases. Includes PRDs, user stories, experiment design, retrospectives, and more. *By [@product-on-purpose](https://github.com/product-on-purpose)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
## What

Adding [pm-skills](https://github.com/product-on-purpose/pm-skills), a comprehensive collection of 24 product management skills for Claude Code and other AI assistants.

## Why

Product managers represent a significant user segment for Claude Code. This collection provides battle-tested frameworks for:

- **Problem framing** — problem statements, hypotheses, opportunity trees, JTBD canvases
- **Product specs** — PRDs, user stories, edge cases, launch checklists
- **Experimentation** — A/B test design, instrumentation specs, results analysis
- **Team collaboration** — retrospectives, lessons learned, refinement notes

## Skills Overview

| Phase | Skills |
|-------|--------|
| **Discover** | interview-synthesis, competitive-analysis, stakeholder-summary |
| **Define** | problem-statement, hypothesis, opportunity-tree, jtbd-canvas |
| **Develop** | solution-brief, spike-summary, adr, design-rationale |
| **Deliver** | prd, user-stories, edge-cases, launch-checklist, release-notes |
| **Measure** | experiment-design, instrumentation-spec, dashboard-requirements, experiment-results |
| **Iterate** | retrospective, lessons-log, refinement-notes, pivot-decision |

## Quality & Compatibility

- Follows [agentskills.io specification](https://agentskills.io/specification)
- Includes `AGENTS.md` for universal agent discovery (GitHub Copilot, Cursor, Windsurf)
- Apache 2.0 licensed
- Each skill includes `SKILL.md`, `TEMPLATE.md`, and `EXAMPLE.md`
- Comprehensive documentation with getting started guide

## Installation

```bash
git clone https://github.com/product-on-purpose/pm-skills.git
```

Or use directly in Claude Code via slash commands: `/prd`, `/user-stories`, `/hypothesis`, `/retrospective`, etc.

## Links

- **Repository:** https://github.com/product-on-purpose/pm-skills
- **Documentation:** https://github.com/product-on-purpose/pm-skills#getting-started
- **License:** Apache 2.0