### PR TITLE
Add video prompting skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
+- [video-prompting-skill](https://github.com/Square-Zero-Labs/video-prompting-skill) - Drafts and refines prompts for video generation models (LTX-2, Sora, Veo 3, etc.).
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 
 ### Productivity & Organization


### PR DESCRIPTION
Description:
Video prompting skill applies best practices and correct formats to craft prompts for video generation models.

What problem it solves:
Reduces failed or low-quality video generations caused by incorrect or poorly drafted prompts.

Who uses this workflow:
Creators working with Veo 3, LTX-2, Sora, Wan 2.2, and Ovi.

Attribution / inspiration source:
Based on public prompting guides and practical experimentation across video models.

Example of how it’s used:
A user provides a rough scene idea, and an agent uses the video-prompting-skill to turn it into a well-specified, model-ready prompt.