### PR TITLE
Add claude-skills collection and workflow commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [claude-skills](https://github.com/jeffallan/claude-skills) - 65 full-stack development skills with progressive disclosure architecture covering React, NestJS, Python, DevOps, and 30+ frameworks. *By [@jeffallan](https://github.com/jeffallan)*
 
 ### Data & Analysis
 
@@ -181,6 +182,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
+- [claude-skills](https://github.com/jeffallan/claude-skills) - 9 project workflow commands (discovery, planning, execution, retrospectives) with Jira/Confluence integration. *By [@jeffallan](https://github.com/jeffallan)*
 
 ### Security & Systems
 


### PR DESCRIPTION
## Add jeffallan/claude-skills

Adding claude-skills to two categories:

### Development & Code Tools
65 specialized full-stack development skills with progressive disclosure architecture (50% token reduction). Covers React, NestJS, Python, DevOps, testing, security, and 30+ frameworks.

### Collaboration & Project Management
9 project workflow commands integrated with Jira and Confluence:
- **Discovery:** create-epic-discovery, synthesize-discovery
- **Planning:** create-epic-plan, create-implementation-plan
- **Execution:** execute-ticket, complete-ticket
- **Retrospectives:** complete-epic, complete-sprint

**Repository:** https://github.com/jeffallan/claude-skills
**License:** MIT