### PR TITLE
docs: add skillkit as recommended multi-agent installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,37 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ## Getting Started
 
-### Using Skills in Claude.ai
+### Option 1: SkillKit (Multi-Agent Support - Recommended)
+
+Use [skillkit](https://github.com/rohitg00/skillkit) to install skills across multiple AI agents:
+
+```bash
+# Install skills from any repository
+npx skillkit install ComposioHQ/awesome-claude-skills
+
+# Install specific skills
+npx skillkit install ComposioHQ/awesome-claude-skills --skill skill-name
+
+# Install to multiple agents at once
+npx skillkit install ComposioHQ/awesome-claude-skills --agent cursor --agent claude-code --agent windsurf
+
+# List available skills without installing
+npx skillkit install ComposioHQ/awesome-claude-skills --list
+```
+
+**Why SkillKit?**
+- **Multi-agent sync**: Install and sync skills across 17+ AI agents (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Goose, Amp, GitHub Copilot, and more)
+- **Auto-detection**: Automatically detects which AI agent you're using
+- **Global or project-level**: Install skills globally (`--global`) or per-project
+- **Extended discovery**: Searches 20+ standard skill paths with recursive fallback
+
+### Option 2: Using Skills in Claude.ai
 
 1. Click the skill icon (🧩) in your chat interface.
 2. Add skills from the marketplace or upload custom skills.
 3. Claude automatically activates relevant skills based on your task.
 
-### Using Skills in Claude Code
+### Option 3: Using Skills in Claude Code (Manual)
 
 1. Place the skill in `~/.config/claude-code/skills/`:
    ```bash
@@ -218,7 +242,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 4. The skill loads automatically and activates when relevant.
 
-### Using Skills via API
+### Option 4: Using Skills via API
 
 Use the Claude Skills API to programmatically load and manage skills:
 


### PR DESCRIPTION
# Add SkillKit as Multi-Agent Installation Option

## Summary

This PR adds [SkillKit](https://github.com/rohitg00/skillkit) as a recommended installation option for installing skills across multiple AI coding agents.

## What is SkillKit?

SkillKit is a universal skills loader that supports **17+ AI coding agents** including Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Goose, Amp, GitHub Copilot, and more.

## Why SkillKit?

- **Multi-Agent Sync**: Install and sync skills across multiple AI agents with a single command
- **Auto-Detection**: Automatically detects which AI agent you're using
- **Universal Support**: Works across 17+ agents, not just Claude Code
- **Extended Discovery**: Searches 20+ standard skill paths with recursive fallback

## Example Usage

# Install all skills
`npx skillkit install ComposioHQ/awesome-claude-skills`

# Install to multiple agents at once
`npx skillkit install ComposioHQ/awesome-claude-skills --agent cursor --agent claude-code --agent windsurf`

Addresses: https://github.com/ComposioHQ/awesome-claude-skills/issues/69
