### PR TITLE
Add intel-skill to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [intel-skill](https://github.com/unisone/intel-skill) - Market intelligence in seconds — 7 modes for gaps, competitors, sentiment, pricing, trends, and pain points. No API keys required. *By [@alexxzay](https://twitter.com/alexxzay)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
## New Skill: intel-skill

**Repository:** https://github.com/unisone/intel-skill

**Category:** Business & Marketing

**Description:** Market intelligence in seconds — 7 modes for gaps, competitors, sentiment, pricing, trends, and pain points.

**Install:**
```bash
npx skills add unisone/intel-skill
```

No external API keys required.