### PR TITLE
Add YouTube Transcript skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -181,6 +181,12 @@
       "description": "Skills for working with Excel spreadsheets including creation, editing, formulas, and data manipulation.",
       "source": "./document-skills/xlsx",
       "category": "productivity-organization"
+    },
+    {
+      "name": "youtube-transcript",
+      "description": "Fetches transcripts from YouTube videos without API keys for note-taking, summarization, and text analysis.",
+      "source": "./youtube-transcript",
+      "category": "creative-media"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
-- [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
+- [YouTube Transcript](./youtube-transcript/) - Fetch transcripts from YouTube videos without API keys for note-taking, summarization, and text analysis.
 
 ### Productivity & Organization
 

--- a/youtube-transcript/SKILL.md
+++ b/youtube-transcript/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: youtube-transcript
+description: Use when user provides a YouTube URL and wants transcript, subtitles, captions, or to create notes from video content. Use when user says "transcribe", "get transcript", "fetch subtitles", or wants to process YouTube video text.
+---
+
+# YouTube Transcript
+
+Fetch transcripts from YouTube videos without API keys.
+
+## When to Use
+
+- User provides YouTube URL and wants transcript
+- User wants to create notes from a video
+- User needs video content as text for analysis
+- Keywords: "transcribe", "transcript", "subtitles", "captions"
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Fetch transcript | `python fetch.py <URL_OR_ID>` |
+| Specific language | `python fetch.py <URL> --lang en` |
+| List languages | `python fetch.py <URL> --list` |
+
+## Usage
+
+```bash
+# From URL
+python fetch.py "https://www.youtube.com/watch?v=VIDEO_ID"
+
+# From video ID only
+python fetch.py VIDEO_ID
+
+# Specify language (prioritizes en, falls back to others)
+python fetch.py VIDEO_ID --lang de
+
+# List available transcript languages
+python fetch.py VIDEO_ID --list
+```
+
+## Output Format
+
+Plain text with timestamps stripped. Ready for note-taking or analysis.
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| "Transcripts disabled" | Video owner disabled captions |
+| "No transcript found" | Try `--list` to see available languages |
+| IP blocked (cloud/VPN) | Run from local machine, not server |
+
+## Workflow
+
+1. User provides YouTube URL
+2. Run fetch script to get transcript
+3. Process transcript text as needed (summarize, create notes, etc.)
+
+## Prerequisites
+
+Install the required Python library:
+
+```bash
+pip install youtube-transcript-api
+```

--- a/youtube-transcript/fetch.py
+++ b/youtube-transcript/fetch.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+YouTube Transcript Fetcher
+Fetches transcripts from YouTube videos using youtube-transcript-api
+"""
+
+import sys
+import re
+import argparse
+from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api.formatters import TextFormatter
+
+
+def extract_video_id(url_or_id: str) -> str:
+    """Extract video ID from YouTube URL or return as-is if already an ID."""
+    # Common YouTube URL patterns
+    patterns = [
+        r'(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})',
+        r'^([a-zA-Z0-9_-]{11})$'  # Direct video ID
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, url_or_id)
+        if match:
+            return match.group(1)
+
+    # Return as-is and let the API handle validation
+    return url_or_id
+
+
+def list_transcripts(video_id: str) -> None:
+    """List all available transcripts for a video."""
+    try:
+        ytt_api = YouTubeTranscriptApi()
+        transcript_list = ytt_api.list(video_id)
+
+        print(f"Available transcripts for video {video_id}:\n")
+
+        for transcript in transcript_list:
+            transcript_type = "Manual" if not transcript.is_generated else "Auto-generated"
+            translatable = "Yes" if transcript.is_translatable else "No"
+            print(f"  - {transcript.language} ({transcript.language_code})")
+            print(f"    Type: {transcript_type}, Translatable: {translatable}")
+
+    except Exception as e:
+        print(f"Error listing transcripts: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def fetch_transcript(video_id: str, languages: list = None) -> str:
+    """Fetch transcript for a video."""
+    try:
+        ytt_api = YouTubeTranscriptApi()
+
+        if languages:
+            transcript = ytt_api.fetch(video_id, languages=languages)
+        else:
+            # Try English first, then any available
+            try:
+                transcript = ytt_api.fetch(video_id, languages=['en', 'en-US', 'en-GB'])
+            except:
+                # Fall back to any available transcript
+                transcript_list = ytt_api.list(video_id)
+                first_transcript = next(iter(transcript_list))
+                transcript = first_transcript.fetch()
+
+        # Format as plain text
+        formatter = TextFormatter()
+        text = formatter.format_transcript(transcript)
+
+        return text
+
+    except Exception as e:
+        print(f"Error fetching transcript: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Fetch YouTube video transcripts',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  %(prog)s "https://www.youtube.com/watch?v=VIDEO_ID"
+  %(prog)s VIDEO_ID
+  %(prog)s VIDEO_ID --lang de
+  %(prog)s VIDEO_ID --list
+        '''
+    )
+
+    parser.add_argument('video', help='YouTube URL or video ID')
+    parser.add_argument('--lang', '-l', help='Preferred language code (e.g., en, de, fr)')
+    parser.add_argument('--list', action='store_true', help='List available transcripts')
+
+    args = parser.parse_args()
+
+    video_id = extract_video_id(args.video)
+
+    if args.list:
+        list_transcripts(video_id)
+    else:
+        languages = [args.lang] if args.lang else None
+        transcript = fetch_transcript(video_id, languages)
+        print(transcript)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Adds a **YouTube Transcript** skill that fetches transcripts from YouTube videos without API keys
- Includes a Python `fetch.py` script supporting URL/ID input, language selection, and transcript listing
- Updates README.md to reference the local skill (replaces previous external link)
- Registers the skill in `.claude-plugin/marketplace.json` under the `creative-media` category

## Test plan
- [ ] Verify `fetch.py` runs correctly with a YouTube URL: `python fetch.py "https://www.youtube.com/watch?v=VIDEO_ID"`
- [ ] Verify `--list` flag shows available transcript languages
- [ ] Verify `--lang` flag fetches transcripts in a specific language
- [ ] Confirm SKILL.md follows the repository template conventions
- [ ] Confirm README.md entry is alphabetically ordered in Creative & Media section

🤖 Generated with [Claude Code](https://claude.com/claude-code)