### PR TITLE
Add squads-cli to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
+- [squads-cli](https://github.com/agents-squads/squads-cli) - Organize AI agents into domain-aligned squads with persistent memory, goal tracking, and human-in-the-loop approval workflows. *By [@agents-squads](https://github.com/agents-squads)*
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
 
 ### Security & Systems


### PR DESCRIPTION
Adding [squads-cli](https://github.com/agents-squads/squads-cli) to the Collaboration & Project Management section.

**squads-cli** organizes AI agents into domain-aligned squads with:

- Persistent memory across sessions
- Goal tracking and progress monitoring
- Human-in-the-loop approval workflows
- Built on Claude Code

**GitHub**: https://github.com/agents-squads/squads-cli
**Website**: https://agents-squads.com

Entry follows existing format and is in alphabetical order.