### PR TITLE
docs: add Agnxi to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,3 +358,4 @@ Individual skills may have different licenses - please check each skill's folder
 **Note**: Claude Skills work across Claude.ai, Claude Code, and the Claude API. Once you create a skill, it's portable across all platforms, making your workflows consistent everywhere you use Claude.
 
 - [AgentsKB](https://agentskb.com) - Upgrade your AI with researched answers. We did the research so your AI gets it right the first time.
+- [Agnxi](https://agnxi.com) - A curated directory of 1000+ agent skills for AI coding agents.


### PR DESCRIPTION
Hi team,
I'd like to contribute **Agnxi.com** to the Community Resources list.
Agnxi is a comprehensive directory dedicated to AI Agent Skills . It currently indexes over 1000+ curated skills, making it a valuable discovery tool for developers building with Claude Code and other agentic frameworks.
I believe this will be very helpful for users looking for specialized skills beyond the official examples.
Thanks!