### PR TITLE
Add Content Moderation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Security & Systems
 
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
+- [Content Moderation](./content-moderation/) - AI-powered content moderation for text, images, and video with auditable decisions via Vettly MCP server.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.

--- a/content-moderation/SKILL.md
+++ b/content-moderation/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: content-moderation
+description: Moderate text, images, and video using Vettly's AI-powered content moderation API via MCP server. Check content against policies, validate policy configs, and audit moderation decisions.
+---
+
+# Content Moderation
+
+Moderate user-generated content using Vettly's content moderation API. This skill uses the `@vettly/mcp` MCP server to check text, images, and video against configurable moderation policies with auditable decisions.
+
+## Setup
+
+Install the `@vettly/mcp` MCP server in your Claude Code settings:
+
+```json
+{
+  "mcpServers": {
+    "vettly": {
+      "command": "npx",
+      "args": ["-y", "@vettly/mcp"],
+      "env": {
+        "VETTLY_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+Get an API key at [vettly.dev](https://vettly.dev).
+
+## Available Tools
+
+### `moderate_content`
+
+Check text, image, or video content against a Vettly moderation policy. Returns a safety assessment with category scores, the action taken, provider used, latency, and cost.
+
+**Parameters:**
+- `content` (required) - The content to moderate (text string, or URL for images/video)
+- `policyId` (required) - The policy ID to use for moderation
+- `contentType` (optional, default: `text`) - Type of content: `text`, `image`, or `video`
+
+### `validate_policy`
+
+Validate a Vettly policy YAML without saving it. Returns validation results with any syntax or configuration errors. Use this to test policy changes before deploying them.
+
+**Parameters:**
+- `yamlContent` (required) - The YAML policy content to validate
+
+### `list_policies`
+
+List all moderation policies available in your Vettly account. Takes no parameters. Use this to discover available policy IDs before moderating content.
+
+### `get_usage_stats`
+
+Get usage statistics for your Vettly account including request counts, costs, and moderation outcomes.
+
+**Parameters:**
+- `days` (optional, default: `30`) - Number of days to include in statistics (1-365)
+
+### `get_recent_decisions`
+
+Get recent moderation decisions with optional filtering by outcome, content type, or policy.
+
+**Parameters:**
+- `limit` (optional, default: `10`) - Number of decisions to return (1-50)
+- `flagged` (optional) - Filter to only flagged content (`true`) or safe content (`false`)
+- `policyId` (optional) - Filter by specific policy ID
+- `contentType` (optional) - Filter by content type: `text`, `image`, or `video`
+
+## When to Use This Skill
+
+- Moderate user-generated content (comments, posts, uploads) before publishing
+- Test and validate moderation policy YAML configs during development
+- Audit recent moderation decisions to review flagged content
+- Monitor moderation costs and usage across your account
+- Compare moderation results across different policies
+
+## Examples
+
+### Moderate a user comment
+
+```
+Moderate this user comment for my community forum policy:
+"I hate this product, it's the worst thing I've ever used and the developers should be ashamed"
+```
+
+Claude will call `list_policies` to find available policies, then `moderate_content` with the appropriate policy ID and return the safety assessment.
+
+### Validate a policy before deploying
+
+```
+Validate this moderation policy YAML:
+
+categories:
+  - name: toxicity
+    threshold: 0.8
+    action: flag
+  - name: spam
+    threshold: 0.6
+    action: block
+```
+
+Claude will call `validate_policy` and report any syntax or configuration errors.
+
+### Review recent flagged content
+
+```
+Show me all flagged content from the last week
+```
+
+Claude will call `get_recent_decisions` with `flagged: true` to retrieve recent moderation decisions that were flagged.
+
+## Tips
+
+- Always call `list_policies` first if you don't know which policy ID to use
+- Use `validate_policy` to test policy changes before deploying to production
+- Use `get_usage_stats` to monitor costs and catch unexpected spikes
+- Filter `get_recent_decisions` by `contentType` or `policyId` to narrow results
+- For image and video moderation, pass the content URL rather than raw data


### PR DESCRIPTION
## Summary

Adds a **Content Moderation** skill to the Security & Systems category.

This skill teaches Claude how to use [Vettly](https://vettly.dev)'s content moderation API via the `@vettly/mcp` MCP server ([npm](https://www.npmjs.com/package/@vettly/mcp)) to moderate text, images, and video against configurable policies.

## What problem it solves

Developers building apps with user-generated content need a way to moderate that content before publishing. This skill gives Claude access to 5 MCP tools:

- **`moderate_content`** — Check text/image/video against a moderation policy
- **`validate_policy`** — Validate policy YAML config without saving
- **`list_policies`** — List available moderation policies
- **`get_usage_stats`** — Monitor request counts, costs, and outcomes
- **`get_recent_decisions`** — Browse and filter recent moderation decisions

## Who uses this workflow

Developers building applications with user-generated content (forums, social platforms, marketplaces) who want to integrate content moderation into their Claude Code workflow for testing policies, auditing decisions, and monitoring usage.

## Changes

- `content-moderation/SKILL.md` — New skill file with setup instructions, tool documentation, examples, and tips
- `README.md` — Added entry under Security & Systems (alphabetical order)