### PR TITLE
Add gog-cli skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Collaboration & Project Management
 
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
-- [gog-cli](https://github.com/mjfork/gog-cli-skill) - Command reference for gog CLI, a fast CLI for Google Workspace (Gmail, Calendar, Drive, Chat, Tasks, Sheets, Docs, Slides). *Credit: [gog](https://github.com/steipete/gogcli) by [@steipete](https://github.com/steipete)*
+- [gog-cli](https://github.com/mjfork/mjfork-claude-plugins) - Command reference for gog CLI, a fast CLI for Google Workspace (Gmail, Calendar, Drive, Chat, Tasks, Sheets, Docs, Slides). *Credit: [gog](https://github.com/steipete/gogcli) by [@steipete](https://github.com/steipete)*
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.


### PR DESCRIPTION
## Summary

Adds command reference skill for [gog CLI](https://github.com/steipete/gogcli) - a fast, script-friendly CLI for Google Workspace services.

## What problem does this skill solve?

Teaches Claude how to use gog CLI commands for Google Workspace operations (Gmail, Calendar, Drive, Chat, Tasks, Sheets, Docs, Slides, Contacts, People, Groups, Classroom, Keep).

## Who uses this workflow?

- Developers and power users who prefer CLI over web UI
- Users managing multiple Google accounts
- Automation/scripting workflows with Google Workspace
- Anyone using gog CLI who wants Claude assistance with commands

## Example usage

```
User: "Check my unread emails from the last week"
Claude: gog gmail search 'is:unread newer_than:7d'

User: "What's on my calendar today?"
Claude: gog calendar events --today

User: "Send an email to john@example.com about the meeting"
Claude: gog gmail send --to="john@example.com" --subject="Meeting" --body="..."
```

## Difference from existing google-workspace-skills

The existing `google-workspace-skills` by @sanjay3290 provides API-based OAuth integration. This skill is for users of the **gog CLI tool** - a command-line approach that requires the CLI installed locally.

## Attribution

**Credit:** [gog CLI](https://github.com/steipete/gogcli) by [@steipete](https://github.com/steipete)

## Skill repo

https://github.com/mjfork/gog-cli-skill