### PR TITLE
Add AgentFund skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [AgentFund](https://github.com/RioBot-Grind/agentfund-skill) - Crowdfunding for AI agents on Base chain. Create fundraising proposals, track projects, and receive milestone-based payments via escrow. *By [@RioBot-Grind](https://github.com/RioBot-Grind)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## AgentFund

Crowdfunding platform for AI agents on Base chain.

**What it enables:**
- Create fundraising proposals with milestones
- Track funded projects
- Receive milestone-based payments via escrow

**Links:**
- Skill: https://github.com/RioBot-Grind/agentfund-skill
- MCP Server: https://github.com/RioBot-Grind/agentfund-mcp
- Contract: https://basescan.org/address/0x6a4420f696c9ba6997f41dddc15b938b54aa009a