### PR TITLE
Add Arbitrum dApp Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [Arbitrum dApp Skill](https://github.com/hummusonrails/arbitrum-dapp-skill) - Build dApps on Arbitrum with Stylus Rust and Solidity smart contracts using Claude Code. *By [@hummusonrails](https://github.com/hummusonrails)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## What does this skill do?

The [Arbitrum dApp Skill](https://github.com/hummusonrails/arbitrum-dapp-skill) gives Claude Code structured knowledge for building complete dApps on Arbitrum. It covers:

- Stylus Rust smart contract development (sol_storage!, cargo-stylus CLI)
- Solidity contracts via Foundry
- Local devnode setup with Docker
- React frontend integration with viem and wagmi
- Deployment to testnet and mainnet

## Why is it useful?

Starting a new Arbitrum dApp involves coordinating multiple tools across contract languages, local chain setup, and frontend wiring. This skill provides Claude Code with decision trees and reference docs so it can scaffold and wire up these layers correctly.

- [Documentation](https://hummusonrails.github.io/arbitrum-dapp-skill/)
- [Demo Video](https://youtu.be/vsejiaOTmJA)