### PR TITLE
Add dbt-agent-skills to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Data & Analysis
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
+- [dbt-agent-skills](https://github.com/dbt-labs/dbt-agent-skills) - Suite of dbt skills for analytics engineering, semantic layer development, unit testing, natural language querying, MCP server configuration, job troubleshooting, and Core-to-Fusion migration. *By [@dbt-labs](https://github.com/dbt-labs)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.


### PR DESCRIPTION
## Skills Added

### dbt-agent-skills

A suite of 8 skills for working with [dbt](https://www.getdbt.com/) — the standard for data transformation in analytics engineering.

**What problems they solve:** AI agents lack context about dbt conventions, the Semantic Layer, MetricFlow, and dbt Cloud platform operations. These skills teach agents how to build models, write tests, query data, configure tooling, troubleshoot jobs, and migrate projects.

**Who uses them:** Analytics engineers and data teams using dbt with AI coding assistants.

**Skills included:**
- **using-dbt-for-analytics-engineering** — Build/modify dbt models, debug errors, explore data sources, write tests
- **building-dbt-semantic-layer** — Create semantic models, metrics, and dimensions with MetricFlow
- **adding-dbt-unit-test** — Add unit tests and practice TDD in dbt
- **answering-natural-language-questions-with-dbt** — Translate business questions into SQL queries via dbt
- **configuring-dbt-mcp-server** — Set up the dbt MCP server for Claude Desktop, Claude Code, and Cursor
- **fetching-dbt-docs** — Look up dbt Cloud, dbt Core, and Semantic Layer documentation
- **troubleshooting-dbt-job-errors** — Diagnose dbt Cloud job failures
- **migrating-dbt-core-to-fusion** — Migrate projects from dbt Core to the Fusion engine

**GitHub:** https://github.com/dbt-labs/dbt-agent-skills