### PR TITLE
Fix YAML frontmatter: quote descriptions with colons

### DIFF
--- a/activecampaign-automation/SKILL.md
+++ b/activecampaign-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: activecampaign-automation
-description: Automate ActiveCampaign tasks via Rube MCP (Composio): manage contacts, tags, list subscriptions, automation enrollment, and tasks. Always search tools first for current schemas.
+description: "Automate ActiveCampaign tasks via Rube MCP (Composio): manage contacts, tags, list subscriptions, automation enrollment, and tasks. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate ActiveCampaign CRM and marketing automation operations through Composio
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `active_campaign`

--- a/airtable-automation/SKILL.md
+++ b/airtable-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: airtable-automation
-description: Automate Airtable tasks via Rube MCP (Composio): records, bases, tables, fields, views. Always search tools first for current schemas.
+description: "Automate Airtable tasks via Rube MCP (Composio): records, bases, tables, fields, views. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Airtable operations through Composio's Airtable toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `airtable`

--- a/amplitude-automation/SKILL.md
+++ b/amplitude-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amplitude-automation
-description: Automate Amplitude tasks via Rube MCP (Composio): events, user activity, cohorts, user identification. Always search tools first for current schemas.
+description: "Automate Amplitude tasks via Rube MCP (Composio): events, user activity, cohorts, user identification. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Amplitude product analytics through Composio's Amplitude toolkit via Ru
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `amplitude`

--- a/asana-automation/SKILL.md
+++ b/asana-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asana-automation
-description: Automate Asana tasks via Rube MCP (Composio): tasks, projects, sections, teams, workspaces. Always search tools first for current schemas.
+description: "Automate Asana tasks via Rube MCP (Composio): tasks, projects, sections, teams, workspaces. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Asana operations through Composio's Asana toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `asana`

--- a/bamboohr-automation/SKILL.md
+++ b/bamboohr-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bamboohr-automation
-description: Automate BambooHR tasks via Rube MCP (Composio): employees, time-off, benefits, dependents, employee updates. Always search tools first for current schemas.
+description: "Automate BambooHR tasks via Rube MCP (Composio): employees, time-off, benefits, dependents, employee updates. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate BambooHR human resources operations through Composio's BambooHR toolkit
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `bamboohr`

--- a/basecamp-automation/SKILL.md
+++ b/basecamp-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Basecamp operations including project management, to-do list creation, 
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `basecamp`
 3. If connection is not ACTIVE, follow the returned auth link to complete Basecamp OAuth

--- a/bitbucket-automation/SKILL.md
+++ b/bitbucket-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Bitbucket operations including repository management, pull request work
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `bitbucket`
 3. If connection is not ACTIVE, follow the returned auth link to complete Bitbucket OAuth

--- a/box-automation/SKILL.md
+++ b/box-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Box operations including file upload/download, content search, folder m
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `box`
 3. If connection is not ACTIVE, follow the returned auth link to complete Box OAuth

--- a/brevo-automation/SKILL.md
+++ b/brevo-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brevo-automation
-description: Automate Brevo (Sendinblue) tasks via Rube MCP (Composio): manage email campaigns, create/edit templates, track senders, and monitor campaign performance. Always search tools first for current schemas.
+description: "Automate Brevo (Sendinblue) tasks via Rube MCP (Composio): manage email campaigns, create/edit templates, track senders, and monitor campaign performance. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Brevo (formerly Sendinblue) email marketing operations through Composio
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `brevo`

--- a/cal-com-automation/SKILL.md
+++ b/cal-com-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cal-com-automation
-description: Automate Cal.com tasks via Rube MCP (Composio): manage bookings, check availability, configure webhooks, and handle teams. Always search tools first for current schemas.
+description: "Automate Cal.com tasks via Rube MCP (Composio): manage bookings, check availability, configure webhooks, and handle teams. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Cal.com scheduling operations through Composio's Cal toolkit via Rube M
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `cal`

--- a/calendly-automation/SKILL.md
+++ b/calendly-automation/SKILL.md
@@ -18,6 +18,9 @@ Automate Calendly operations including event listing, invitee management, schedu
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `calendly`
 3. If connection is not ACTIVE, follow the returned auth link to complete Calendly OAuth

--- a/canva-automation/SKILL.md
+++ b/canva-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canva-automation
-description: Automate Canva tasks via Rube MCP (Composio): designs, exports, folders, brand templates, autofill. Always search tools first for current schemas.
+description: "Automate Canva tasks via Rube MCP (Composio): designs, exports, folders, brand templates, autofill. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Canva design operations through Composio's Canva toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `canva`

--- a/circleci-automation/SKILL.md
+++ b/circleci-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: circleci-automation
-description: Automate CircleCI tasks via Rube MCP (Composio): trigger pipelines, monitor workflows/jobs, retrieve artifacts and test metadata. Always search tools first for current schemas.
+description: "Automate CircleCI tasks via Rube MCP (Composio): trigger pipelines, monitor workflows/jobs, retrieve artifacts and test metadata. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate CircleCI CI/CD operations through Composio's CircleCI toolkit via Rube 
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `circleci`

--- a/clickup-automation/SKILL.md
+++ b/clickup-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate ClickUp project management workflows including task creation and update
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `clickup`
 3. If connection is not ACTIVE, follow the returned auth link to complete ClickUp OAuth

--- a/close-automation/SKILL.md
+++ b/close-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: close-automation
-description: Automate Close CRM tasks via Rube MCP (Composio): create leads, manage calls/SMS, handle tasks, and track notes. Always search tools first for current schemas.
+description: "Automate Close CRM tasks via Rube MCP (Composio): create leads, manage calls/SMS, handle tasks, and track notes. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Close CRM operations through Composio's Close toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `close`

--- a/coda-automation/SKILL.md
+++ b/coda-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coda-automation
-description: Automate Coda tasks via Rube MCP (Composio): manage docs, pages, tables, rows, formulas, permissions, and publishing. Always search tools first for current schemas.
+description: "Automate Coda tasks via Rube MCP (Composio): manage docs, pages, tables, rows, formulas, permissions, and publishing. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Coda document and data operations through Composio's Coda toolkit via R
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `coda`

--- a/confluence-automation/SKILL.md
+++ b/confluence-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Confluence operations including page creation and updates, content sear
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `confluence`
 3. If connection is not ACTIVE, follow the returned auth link to complete Confluence OAuth

--- a/convertkit-automation/SKILL.md
+++ b/convertkit-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: convertkit-automation
-description: Automate ConvertKit (Kit) tasks via Rube MCP (Composio): manage subscribers, tags, broadcasts, and broadcast stats. Always search tools first for current schemas.
+description: "Automate ConvertKit (Kit) tasks via Rube MCP (Composio): manage subscribers, tags, broadcasts, and broadcast stats. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate ConvertKit (now known as Kit) email marketing operations through Compos
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `kit`

--- a/datadog-automation/SKILL.md
+++ b/datadog-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: datadog-automation
-description: Automate Datadog tasks via Rube MCP (Composio): query metrics, search logs, manage monitors/dashboards, create events and downtimes. Always search tools first for current schemas.
+description: "Automate Datadog tasks via Rube MCP (Composio): query metrics, search logs, manage monitors/dashboards, create events and downtimes. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Datadog monitoring and observability operations through Composio's Data
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `datadog`

--- a/discord-automation/SKILL.md
+++ b/discord-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discord-automation
-description: Automate Discord tasks via Rube MCP (Composio): messages, channels, roles, webhooks, reactions. Always search tools first for current schemas.
+description: "Automate Discord tasks via Rube MCP (Composio): messages, channels, roles, webhooks, reactions. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Discord operations through Composio's Discord/Discordbot toolkits via R
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `discordbot` (bot operations) or `discord` (user operations)

--- a/docusign-automation/SKILL.md
+++ b/docusign-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docusign-automation
-description: Automate DocuSign tasks via Rube MCP (Composio): templates, envelopes, signatures, document management. Always search tools first for current schemas.
+description: "Automate DocuSign tasks via Rube MCP (Composio): templates, envelopes, signatures, document management. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate DocuSign e-signature workflows through Composio's DocuSign toolkit via 
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `docusign`

--- a/dropbox-automation/SKILL.md
+++ b/dropbox-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Dropbox operations including file upload/download, search, folder manag
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `dropbox`
 3. If connection is not ACTIVE, follow the returned auth link to complete Dropbox OAuth

--- a/figma-automation/SKILL.md
+++ b/figma-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-automation
-description: Automate Figma tasks via Rube MCP (Composio): files, components, design tokens, comments, exports. Always search tools first for current schemas.
+description: "Automate Figma tasks via Rube MCP (Composio): files, components, design tokens, comments, exports. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Figma operations through Composio's Figma toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `figma`

--- a/freshdesk-automation/SKILL.md
+++ b/freshdesk-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Freshdesk customer support workflows including ticket management, conta
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `freshdesk`
 3. If connection is not ACTIVE, follow the returned auth link to complete Freshdesk authentication

--- a/freshservice-automation/SKILL.md
+++ b/freshservice-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: freshservice-automation
-description: Automate Freshservice ITSM tasks via Rube MCP (Composio): create/update tickets, bulk operations, service requests, and outbound emails. Always search tools first for current schemas.
+description: "Automate Freshservice ITSM tasks via Rube MCP (Composio): create/update tickets, bulk operations, service requests, and outbound emails. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Freshservice IT Service Management operations through Composio's Freshs
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `freshservice`

--- a/github-automation/SKILL.md
+++ b/github-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate GitHub repository management, issue tracking, pull request workflows, b
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `github`
 3. If connection is not ACTIVE, follow the returned auth link to complete GitHub OAuth

--- a/gitlab-automation/SKILL.md
+++ b/gitlab-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate GitLab operations including project management, issue tracking, merge r
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `gitlab`
 3. If connection is not ACTIVE, follow the returned auth link to complete GitLab OAuth

--- a/gmail-automation/SKILL.md
+++ b/gmail-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gmail-automation
-description: Automate Gmail tasks via Rube MCP (Composio): send/reply, search, labels, drafts, attachments. Always search tools first for current schemas.
+description: "Automate Gmail tasks via Rube MCP (Composio): send/reply, search, labels, drafts, attachments. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Gmail operations through Composio's Gmail toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `gmail`

--- a/google-analytics-automation/SKILL.md
+++ b/google-analytics-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: google-analytics-automation
-description: Automate Google Analytics tasks via Rube MCP (Composio): run reports, list accounts/properties, funnels, pivots, key events. Always search tools first for current schemas.
+description: "Automate Google Analytics tasks via Rube MCP (Composio): run reports, list accounts/properties, funnels, pivots, key events. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Google Analytics 4 (GA4) reporting and property management through Comp
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `google_analytics`

--- a/google-calendar-automation/SKILL.md
+++ b/google-calendar-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Google Calendar workflows including event creation, scheduling, availab
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `googlecalendar`
 3. If connection is not ACTIVE, follow the returned auth link to complete Google OAuth

--- a/google-drive-automation/SKILL.md
+++ b/google-drive-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Google Drive workflows including file upload/download, search, folder m
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `googledrive`
 3. If connection is not ACTIVE, follow the returned auth link to complete Google OAuth

--- a/googlesheets-automation/SKILL.md
+++ b/googlesheets-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Google Sheets workflows including reading/writing data, managing spread
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `googlesheets`
 3. If connection is not ACTIVE, follow the returned auth link to complete Google OAuth

--- a/helpdesk-automation/SKILL.md
+++ b/helpdesk-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helpdesk-automation
-description: Automate HelpDesk tasks via Rube MCP (Composio): list tickets, manage views, use canned responses, and configure custom fields. Always search tools first for current schemas.
+description: "Automate HelpDesk tasks via Rube MCP (Composio): list tickets, manage views, use canned responses, and configure custom fields. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate HelpDesk ticketing operations through Composio's HelpDesk toolkit via R
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `helpdesk`

--- a/hubspot-automation/SKILL.md
+++ b/hubspot-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate HubSpot CRM workflows including contact/company management, deal pipeli
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `hubspot`
 3. If connection is not ACTIVE, follow the returned auth link to complete HubSpot OAuth

--- a/instagram-automation/SKILL.md
+++ b/instagram-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: instagram-automation
-description: Automate Instagram tasks via Rube MCP (Composio): create posts, carousels, manage media, get insights, and publishing limits. Always search tools first for current schemas.
+description: "Automate Instagram tasks via Rube MCP (Composio): create posts, carousels, manage media, get insights, and publishing limits. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -17,6 +17,9 @@ Automate Instagram operations through Composio's Instagram toolkit via Rube MCP.
 - Instagram Business or Creator account required (personal accounts not supported)
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `instagram`

--- a/intercom-automation/SKILL.md
+++ b/intercom-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: intercom-automation
-description: Automate Intercom tasks via Rube MCP (Composio): conversations, contacts, companies, segments, admins. Always search tools first for current schemas.
+description: "Automate Intercom tasks via Rube MCP (Composio): conversations, contacts, companies, segments, admins. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Intercom operations through Composio's Intercom toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `intercom`

--- a/jira-automation/SKILL.md
+++ b/jira-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jira-automation
-description: Automate Jira tasks via Rube MCP (Composio): issues, projects, sprints, boards, comments, users. Always search tools first for current schemas.
+description: "Automate Jira tasks via Rube MCP (Composio): issues, projects, sprints, boards, comments, users. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Jira operations through Composio's Jira toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `jira`

--- a/klaviyo-automation/SKILL.md
+++ b/klaviyo-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: klaviyo-automation
-description: Automate Klaviyo tasks via Rube MCP (Composio): manage email/SMS campaigns, inspect campaign messages, track tags, and monitor send jobs. Always search tools first for current schemas.
+description: "Automate Klaviyo tasks via Rube MCP (Composio): manage email/SMS campaigns, inspect campaign messages, track tags, and monitor send jobs. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Klaviyo email and SMS marketing operations through Composio's Klaviyo t
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `klaviyo`

--- a/linear-automation/SKILL.md
+++ b/linear-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linear-automation
-description: Automate Linear tasks via Rube MCP (Composio): issues, projects, cycles, teams, labels. Always search tools first for current schemas.
+description: "Automate Linear tasks via Rube MCP (Composio): issues, projects, cycles, teams, labels. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Linear operations through Composio's Linear toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `linear`

--- a/linkedin-automation/SKILL.md
+++ b/linkedin-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linkedin-automation
-description: Automate LinkedIn tasks via Rube MCP (Composio): create posts, manage profile, company info, comments, and image uploads. Always search tools first for current schemas.
+description: "Automate LinkedIn tasks via Rube MCP (Composio): create posts, manage profile, company info, comments, and image uploads. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate LinkedIn operations through Composio's LinkedIn toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `linkedin`

--- a/mailchimp-automation/SKILL.md
+++ b/mailchimp-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Mailchimp email marketing workflows including campaign creation and sen
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `mailchimp`
 3. If connection is not ACTIVE, follow the returned auth link to complete Mailchimp OAuth

--- a/make-automation/SKILL.md
+++ b/make-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: make-automation
-description: Automate Make (Integromat) tasks via Rube MCP (Composio): operations, enums, language and timezone lookups. Always search tools first for current schemas.
+description: "Automate Make (Integromat) tasks via Rube MCP (Composio): operations, enums, language and timezone lookups. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Make (formerly Integromat) operations through Composio's Make toolkit v
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `make`

--- a/microsoft-teams-automation/SKILL.md
+++ b/microsoft-teams-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: microsoft-teams-automation
-description: Automate Microsoft Teams tasks via Rube MCP (Composio): send messages, manage channels, create meetings, handle chats, and search messages. Always search tools first for current schemas.
+description: "Automate Microsoft Teams tasks via Rube MCP (Composio): send messages, manage channels, create meetings, handle chats, and search messages. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Microsoft Teams operations through Composio's Microsoft Teams toolkit v
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `microsoft_teams`

--- a/miro-automation/SKILL.md
+++ b/miro-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: miro-automation
-description: Automate Miro tasks via Rube MCP (Composio): boards, items, sticky notes, frames, sharing, connectors. Always search tools first for current schemas.
+description: "Automate Miro tasks via Rube MCP (Composio): boards, items, sticky notes, frames, sharing, connectors. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Miro whiteboard operations through Composio's Miro toolkit via Rube MCP
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `miro`

--- a/mixpanel-automation/SKILL.md
+++ b/mixpanel-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mixpanel-automation
-description: Automate Mixpanel tasks via Rube MCP (Composio): events, segmentation, funnels, cohorts, user profiles, JQL queries. Always search tools first for current schemas.
+description: "Automate Mixpanel tasks via Rube MCP (Composio): events, segmentation, funnels, cohorts, user profiles, JQL queries. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Mixpanel product analytics through Composio's Mixpanel toolkit via Rube
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `mixpanel`

--- a/monday-automation/SKILL.md
+++ b/monday-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Monday.com work management workflows including board creation, item man
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `monday`
 3. If connection is not ACTIVE, follow the returned auth link to complete Monday.com OAuth

--- a/notion-automation/SKILL.md
+++ b/notion-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notion-automation
-description: Automate Notion tasks via Rube MCP (Composio): pages, databases, blocks, comments, users. Always search tools first for current schemas.
+description: "Automate Notion tasks via Rube MCP (Composio): pages, databases, blocks, comments, users. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Notion operations through Composio's Notion toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `notion`

--- a/one-drive-automation/SKILL.md
+++ b/one-drive-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate OneDrive operations including file upload/download, search, folder mana
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `one_drive`
 3. If connection is not ACTIVE, follow the returned auth link to complete Microsoft OAuth

--- a/outlook-automation/SKILL.md
+++ b/outlook-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outlook-automation
-description: Automate Outlook tasks via Rube MCP (Composio): emails, calendar, contacts, folders, attachments. Always search tools first for current schemas.
+description: "Automate Outlook tasks via Rube MCP (Composio): emails, calendar, contacts, folders, attachments. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Microsoft Outlook operations through Composio's Outlook toolkit via Rub
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `outlook`

--- a/outlook-calendar-automation/SKILL.md
+++ b/outlook-calendar-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outlook-calendar-automation
-description: Automate Outlook Calendar tasks via Rube MCP (Composio): create events, manage attendees, find meeting times, and handle invitations. Always search tools first for current schemas.
+description: "Automate Outlook Calendar tasks via Rube MCP (Composio): create events, manage attendees, find meeting times, and handle invitations. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Outlook Calendar operations through Composio's Outlook toolkit via Rube
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `outlook`

--- a/pagerduty-automation/SKILL.md
+++ b/pagerduty-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pagerduty-automation
-description: Automate PagerDuty tasks via Rube MCP (Composio): manage incidents, services, schedules, escalation policies, and on-call rotations. Always search tools first for current schemas.
+description: "Automate PagerDuty tasks via Rube MCP (Composio): manage incidents, services, schedules, escalation policies, and on-call rotations. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate PagerDuty incident management and operations through Composio's PagerDu
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `pagerduty`

--- a/pipedrive-automation/SKILL.md
+++ b/pipedrive-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Pipedrive CRM workflows including deal management, contact and organiza
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `pipedrive`
 3. If connection is not ACTIVE, follow the returned auth link to complete Pipedrive OAuth

--- a/posthog-automation/SKILL.md
+++ b/posthog-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: posthog-automation
-description: Automate PostHog tasks via Rube MCP (Composio): events, feature flags, projects, user profiles, annotations. Always search tools first for current schemas.
+description: "Automate PostHog tasks via Rube MCP (Composio): events, feature flags, projects, user profiles, annotations. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate PostHog product analytics and feature flag management through Composio'
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `posthog`

--- a/postmark-automation/SKILL.md
+++ b/postmark-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: postmark-automation
-description: Automate Postmark email delivery tasks via Rube MCP (Composio): send templated emails, manage templates, monitor delivery stats and bounces. Always search tools first for current schemas.
+description: "Automate Postmark email delivery tasks via Rube MCP (Composio): send templated emails, manage templates, monitor delivery stats and bounces. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Postmark transactional email operations through Composio's Postmark too
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `postmark`

--- a/reddit-automation/SKILL.md
+++ b/reddit-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reddit-automation
-description: Automate Reddit tasks via Rube MCP (Composio): search subreddits, create posts, manage comments, and browse top content. Always search tools first for current schemas.
+description: "Automate Reddit tasks via Rube MCP (Composio): search subreddits, create posts, manage comments, and browse top content. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Reddit operations through Composio's Reddit toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `reddit`

--- a/render-automation/SKILL.md
+++ b/render-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: render-automation
-description: Automate Render tasks via Rube MCP (Composio): services, deployments, projects. Always search tools first for current schemas.
+description: "Automate Render tasks via Rube MCP (Composio): services, deployments, projects. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Render cloud platform operations through Composio's Render toolkit via 
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `render`

--- a/salesforce-automation/SKILL.md
+++ b/salesforce-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: salesforce-automation
-description: Automate Salesforce tasks via Rube MCP (Composio): leads, contacts, accounts, opportunities, SOQL queries. Always search tools first for current schemas.
+description: "Automate Salesforce tasks via Rube MCP (Composio): leads, contacts, accounts, opportunities, SOQL queries. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Salesforce CRM operations through Composio's Salesforce toolkit via Rub
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `salesforce`

--- a/segment-automation/SKILL.md
+++ b/segment-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: segment-automation
-description: Automate Segment tasks via Rube MCP (Composio): track events, identify users, manage groups, page views, aliases, batch operations. Always search tools first for current schemas.
+description: "Automate Segment tasks via Rube MCP (Composio): track events, identify users, manage groups, page views, aliases, batch operations. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Segment customer data platform operations through Composio's Segment to
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `segment`

--- a/sendgrid-automation/SKILL.md
+++ b/sendgrid-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate SendGrid email delivery workflows including marketing campaigns (Single
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `sendgrid`
 3. If connection is not ACTIVE, follow the returned auth link to complete SendGrid API key authentication

--- a/sentry-automation/SKILL.md
+++ b/sentry-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-automation
-description: Automate Sentry tasks via Rube MCP (Composio): manage issues/events, configure alerts, track releases, monitor projects and teams. Always search tools first for current schemas.
+description: "Automate Sentry tasks via Rube MCP (Composio): manage issues/events, configure alerts, track releases, monitor projects and teams. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Sentry error tracking and monitoring operations through Composio's Sent
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `sentry`

--- a/shopify-automation/SKILL.md
+++ b/shopify-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shopify-automation
-description: Automate Shopify tasks via Rube MCP (Composio): products, orders, customers, inventory, collections. Always search tools first for current schemas.
+description: "Automate Shopify tasks via Rube MCP (Composio): products, orders, customers, inventory, collections. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Shopify operations through Composio's Shopify toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `shopify`

--- a/slack-automation/SKILL.md
+++ b/slack-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Slack workspace operations including messaging, search, channel managem
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `slack`
 3. If connection is not ACTIVE, follow the returned auth link to complete Slack OAuth

--- a/square-automation/SKILL.md
+++ b/square-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: square-automation
-description: Automate Square tasks via Rube MCP (Composio): payments, orders, invoices, locations. Always search tools first for current schemas.
+description: "Automate Square tasks via Rube MCP (Composio): payments, orders, invoices, locations. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Square payment processing, order management, and invoicing through Comp
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `square`

--- a/stripe-automation/SKILL.md
+++ b/stripe-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stripe-automation
-description: Automate Stripe tasks via Rube MCP (Composio): customers, charges, subscriptions, invoices, products, refunds. Always search tools first for current schemas.
+description: "Automate Stripe tasks via Rube MCP (Composio): customers, charges, subscriptions, invoices, products, refunds. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Stripe payment operations through Composio's Stripe toolkit via Rube MC
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `stripe`

--- a/supabase-automation/SKILL.md
+++ b/supabase-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Supabase operations including database queries, table schema inspection
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `supabase`
 3. If connection is not ACTIVE, follow the returned auth link to complete Supabase authentication

--- a/telegram-automation/SKILL.md
+++ b/telegram-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram-automation
-description: Automate Telegram tasks via Rube MCP (Composio): send messages, manage chats, share photos/documents, and handle bot commands. Always search tools first for current schemas.
+description: "Automate Telegram tasks via Rube MCP (Composio): send messages, manage chats, share photos/documents, and handle bot commands. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -17,6 +17,9 @@ Automate Telegram operations through Composio's Telegram toolkit via Rube MCP.
 - Telegram Bot Token required (created via @BotFather)
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `telegram`

--- a/tiktok-automation/SKILL.md
+++ b/tiktok-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiktok-automation
-description: Automate TikTok tasks via Rube MCP (Composio): upload/publish videos, post photos, manage content, and view user profiles/stats. Always search tools first for current schemas.
+description: "Automate TikTok tasks via Rube MCP (Composio): upload/publish videos, post photos, manage content, and view user profiles/stats. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate TikTok content creation and profile operations through Composio's TikTo
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `tiktok`

--- a/todoist-automation/SKILL.md
+++ b/todoist-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Todoist operations including task creation and management, project orga
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `todoist`
 3. If connection is not ACTIVE, follow the returned auth link to complete Todoist OAuth

--- a/trello-automation/SKILL.md
+++ b/trello-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Trello board management, card creation, and team workflows through Comp
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `trello`
 3. If connection is not ACTIVE, follow the returned auth link to complete Trello auth

--- a/twitter-automation/SKILL.md
+++ b/twitter-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: twitter-automation
-description: Automate Twitter/X tasks via Rube MCP (Composio): posts, search, users, bookmarks, lists, media. Always search tools first for current schemas.
+description: "Automate Twitter/X tasks via Rube MCP (Composio): posts, search, users, bookmarks, lists, media. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Twitter/X operations through Composio's Twitter toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `twitter`

--- a/vercel-automation/SKILL.md
+++ b/vercel-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vercel-automation
-description: Automate Vercel tasks via Rube MCP (Composio): manage deployments, domains, DNS, env vars, projects, and teams. Always search tools first for current schemas.
+description: "Automate Vercel tasks via Rube MCP (Composio): manage deployments, domains, DNS, env vars, projects, and teams. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Vercel platform operations through Composio's Vercel toolkit via Rube M
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `vercel`

--- a/webflow-automation/SKILL.md
+++ b/webflow-automation/SKILL.md
@@ -17,6 +17,9 @@ Automate Webflow operations including CMS collection management, site publishing
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `webflow`
 3. If connection is not ACTIVE, follow the returned auth link to complete Webflow OAuth

--- a/whatsapp-automation/SKILL.md
+++ b/whatsapp-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whatsapp-automation
-description: Automate WhatsApp Business tasks via Rube MCP (Composio): send messages, manage templates, upload media, and handle contacts. Always search tools first for current schemas.
+description: "Automate WhatsApp Business tasks via Rube MCP (Composio): send messages, manage templates, upload media, and handle contacts. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -17,6 +17,9 @@ Automate WhatsApp Business operations through Composio's WhatsApp toolkit via Ru
 - WhatsApp Business API account required (not regular WhatsApp)
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `whatsapp`

--- a/wrike-automation/SKILL.md
+++ b/wrike-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wrike-automation
-description: Automate Wrike project management via Rube MCP (Composio): create tasks/folders, manage projects, assign work, and track progress. Always search tools first for current schemas.
+description: "Automate Wrike project management via Rube MCP (Composio): create tasks/folders, manage projects, assign work, and track progress. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Wrike project management operations through Composio's Wrike toolkit vi
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `wrike`

--- a/youtube-automation/SKILL.md
+++ b/youtube-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: youtube-automation
-description: Automate YouTube tasks via Rube MCP (Composio): upload videos, manage playlists, search content, get analytics, and handle comments. Always search tools first for current schemas.
+description: "Automate YouTube tasks via Rube MCP (Composio): upload videos, manage playlists, search content, get analytics, and handle comments. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate YouTube operations through Composio's YouTube toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `youtube`

--- a/zendesk-automation/SKILL.md
+++ b/zendesk-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zendesk-automation
-description: Automate Zendesk tasks via Rube MCP (Composio): tickets, users, organizations, replies. Always search tools first for current schemas.
+description: "Automate Zendesk tasks via Rube MCP (Composio): tickets, users, organizations, replies. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Zendesk operations through Composio's Zendesk toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `zendesk`

--- a/zoho-crm-automation/SKILL.md
+++ b/zoho-crm-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zoho-crm-automation
-description: Automate Zoho CRM tasks via Rube MCP (Composio): create/update records, search contacts, manage leads, and convert leads. Always search tools first for current schemas.
+description: "Automate Zoho CRM tasks via Rube MCP (Composio): create/update records, search contacts, manage leads, and convert leads. Always search tools first for current schemas."
 requires:
   mcp: [rube]
 ---
@@ -16,6 +16,9 @@ Automate Zoho CRM operations through Composio's Zoho toolkit via Rube MCP.
 - Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
 
 ## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
 
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho`

--- a/zoom-automation/SKILL.md
+++ b/zoom-automation/SKILL.md
@@ -18,6 +18,9 @@ Automate Zoom operations including meeting scheduling, webinar management, cloud
 
 ## Setup
 
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+
 1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
 2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `zoom`
 3. If connection is not ACTIVE, follow the returned auth link to complete Zoom OAuth


### PR DESCRIPTION
## Summary
- 53 automation skill SKILL.md files had unquoted descriptions containing `: ` (colon + space)
- This caused the `gray-matter` YAML parser (used by `npx skills` CLI) to fail with `"incomplete explicit mapping pair"` error
- As a result, `npx skills add ComposioHQ/awesome-claude-skills --all` only discovered 53/110 skills instead of all 110
- Fix: wrap affected descriptions in double quotes, making them valid YAML strings
- Also adds the Rube MCP setup section to skills that were missing it

## Test plan
- [ ] Run `npx skills add ComposioHQ/awesome-claude-skills --list` and verify all 110 skills appear
- [ ] Verify `node -e "require('gray-matter')(require('fs').readFileSync('gmail-automation/SKILL.md','utf-8'))"` parses without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)