### PR TITLE
Add claude-ai-models skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
+- [claude-ai-models](https://github.com/Tontoon7/claude-ai-models) - Fetches latest AI model IDs from Anthropic, OpenAI & Google so Claude always uses up-to-date model names in code. No API keys needed. *By [@Tontoon7](https://github.com/Tontoon7)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*


### PR DESCRIPTION
Adds [claude-ai-models](https://github.com/Tontoon7/claude-ai-models) — a Claude Code skill that fetches the latest AI model IDs from Anthropic, OpenAI & Google so Claude always uses up-to-date model names in code. No API keys needed.

Placed alphabetically in the **Development & Code Tools** section.