### PR TITLE
Add AgentStore plugin marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [AgentStore](https://github.com/techgangboss/agentstore) - Open-source marketplace for Claude Code plugins and agents. Install plugins with `agentstore install`, or publish your own with a 3-field API call. Gasless USDC payments via x402. *By [@techgangboss](https://github.com/techgangboss)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## Summary

- Adds [AgentStore](https://github.com/techgangboss/agentstore) to the Development & Code Tools section (alphabetical order)
- AgentStore is an open-source marketplace for Claude Code plugins and agents
- Install plugins with `agentstore install`, or publish with a 3-field API call
- Gasless USDC payments via the x402 protocol; publishers earn 80% of sales

## What problem it solves

Plugin discovery and monetization for Claude Code. Developers can publish plugins and earn revenue without managing payment infrastructure. Users can browse and install plugins from a centralized marketplace.

## Who uses this workflow

Claude Code plugin developers who want to distribute and monetize their work, and users who want to discover and install community plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)