### PR TITLE
Add ClawFu: 169 expert-sourced marketing skills (MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [@clawfu/mcp-skills](https://github.com/guia-matthieu/clawfu-skills) - 169 expert-sourced marketing skills (Dunford, Schwartz, Ogilvy, Cialdini, Hormozi) as MCP server. Includes brand memory for voice consistency. MIT licensed.
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [ClawFu](https://github.com/guia-matthieu/clawfu-skills) to the **Business & Marketing** section.

**What it is:** An MCP server with 169 marketing methodology skills sourced from named experts (April Dunford, Eugene Schwartz, Ogilvy, Cialdini, Hormozi, and 80+ others). Includes brand memory for voice consistency.

- npm: `@clawfu/mcp-skills`
- License: MIT
- Website: https://clawfu.com