### PR TITLE
Add GitHub Trending Tracker skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [GitHub Trending Tracker](https://github.com/qingcaizz/github-trending-tracker) - Track and compare GitHub Trending repositories across daily, weekly, and monthly timeframes with auto-translated Chinese reports and ranking change detection. *By [@qingcaizz](https://github.com/qingcaizz)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 


### PR DESCRIPTION
## Add GitHub Trending Tracker

Adds [GitHub Trending Tracker](https://github.com/qingcaizz/github-trending-tracker) to the **Data & Analysis** section.

### What it does

- Fetches GitHub Trending repos across daily/weekly/monthly timeframes
- Compares with historical data to detect ranking changes (new entries, dropped, rising stars)
- Auto-translates English descriptions to Chinese
- Generates structured Markdown reports

### Category

Data & Analysis

### Author

上霜青菜 ([@qingcaizz](https://github.com/qingcaizz))