### PR TITLE
Add Reepl to Business & Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Reepl](https://github.com/reepl-io/skills) - AI-powered LinkedIn content creation, scheduling, and analytics. Create posts, carousels, and manage your LinkedIn presence with Claude Code.
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Summary

- Adds [Reepl](https://github.com/reepl-io/skills) to the **Business & Marketing** section
- Reepl is an AI-powered LinkedIn content creation, scheduling, and analytics skill for Claude Code
- Entry placed in alphabetical order within the section

## Details

Reepl enables users to create LinkedIn posts, carousels, and manage their LinkedIn presence directly through Claude Code. It fits naturally in the Business & Marketing category alongside other marketing and lead generation tools.