### PR TITLE
Add 26 new toolkit skills + composio.dev links to all skills

### DIFF
--- a/activecampaign-automation/SKILL.md
+++ b/activecampaign-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate ActiveCampaign CRM and marketing automation operations through Composio's ActiveCampaign toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/active_campaign](https://composio.dev/toolkits/active_campaign)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -207,3 +209,6 @@ Automate ActiveCampaign CRM and marketing automation operations through Composio
 | Subscribe/unsubscribe | ACTIVE_CAMPAIGN_MANAGE_LIST_SUBSCRIPTION | action, list_id, email |
 | Add to automation | ACTIVE_CAMPAIGN_ADD_CONTACT_TO_AUTOMATION | contact_email, automation_id |
 | Create task | ACTIVE_CAMPAIGN_CREATE_CONTACT_TASK | relid, duedate, dealTasktype, title |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/airtable-automation/SKILL.md
+++ b/airtable-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Airtable operations through Composio's Airtable toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/airtable](https://composio.dev/toolkits/airtable)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -168,3 +170,6 @@ Automate Airtable operations through Composio's Airtable toolkit via Rube MCP.
 | Update field | AIRTABLE_UPDATE_FIELD | baseId, tableIdOrName, fieldId |
 | Update table | AIRTABLE_UPDATE_TABLE | baseId, tableIdOrName, name |
 | List comments | AIRTABLE_LIST_COMMENTS | baseId, tableIdOrName, recordId |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/amplitude-automation/SKILL.md
+++ b/amplitude-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Amplitude product analytics through Composio's Amplitude toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/amplitude](https://composio.dev/toolkits/amplitude)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -214,3 +216,6 @@ For cohort membership updates:
 | Update cohort members | AMPLITUDE_UPDATE_COHORT_MEMBERSHIP | cohort_id, memberships |
 | Check cohort status | AMPLITUDE_CHECK_COHORT_STATUS | request_id |
 | List event categories | AMPLITUDE_GET_EVENT_CATEGORIES | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/anthropic_administrator-automation/SKILL.md
+++ b/anthropic_administrator-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: anthropic_administrator-automation
+description: "Automate Anthropic Admin tasks via Rube MCP (Composio): API keys, usage, workspaces, and organization management. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Anthropic Admin Automation via Rube MCP
+
+Automate Anthropic Admin operations through Composio's Anthropic Admin toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/anthropic_administrator](https://composio.dev/toolkits/anthropic_administrator)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Anthropic Admin connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `anthropic_administrator`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `anthropic_administrator`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "API keys, usage, workspaces, and organization management", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Anthropic Admin
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Anthropic Admin Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Anthropic Admin tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Anthropic Admin Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Anthropic Admin operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Anthropic Admin connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Anthropic Admin-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `anthropic_administrator` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/anthropic_administrator](https://composio.dev/toolkits/anthropic_administrator)

--- a/asana-automation/SKILL.md
+++ b/asana-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Asana operations through Composio's Asana toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/asana](https://composio.dev/toolkits/asana)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -169,3 +171,6 @@ Automate Asana operations through Composio's Asana toolkit via Rube MCP.
 | Workspace users | ASANA_GET_USERS_FOR_WORKSPACE | workspace_gid |
 | Current user | ASANA_GET_CURRENT_USER | (none) |
 | Parallel requests | ASANA_SUBMIT_PARALLEL_REQUESTS | actions |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/bamboohr-automation/SKILL.md
+++ b/bamboohr-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate BambooHR human resources operations through Composio's BambooHR toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/bamboohr](https://composio.dev/toolkits/bamboohr)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -218,3 +220,6 @@ For keeping external systems in sync with BambooHR:
 | Update employee | BAMBOOHR_UPDATE_EMPLOYEE | id, (field updates) |
 | List dependents | BAMBOOHR_DEPENDENTS_GET_ALL | employeeId |
 | Benefit coverages | BAMBOOHR_BENEFIT_GET_COVERAGES | (check schema) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/basecamp-automation/SKILL.md
+++ b/basecamp-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Basecamp operations including project management, to-do list creation, task management, message board posting, people management, and to-do group organization through Composio's Basecamp toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/basecamp](https://composio.dev/toolkits/basecamp)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -232,3 +234,6 @@ Basecamp uses page-based pagination on list endpoints:
 | List all people | `BASECAMP_GET_PEOPLE` | (none) |
 | List project people | `BASECAMP_LIST_PROJECT_PEOPLE` | `project_id` |
 | Manage access | `BASECAMP_PUT_PROJECTS_PEOPLE_USERS` | `project_id`, `grant`, `revoke`, `create` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/bitbucket-automation/SKILL.md
+++ b/bitbucket-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Bitbucket operations including repository management, pull request workflows, branch operations, issue tracking, and workspace administration through Composio's Bitbucket toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/bitbucket](https://composio.dev/toolkits/bitbucket)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -222,3 +224,6 @@ Bitbucket Query Language is available on list endpoints:
 | Comment on issue | `BITBUCKET_CREATE_ISSUE_COMMENT` | `workspace`, `repo_slug`, `issue_id`, `content` |
 | Delete issue | `BITBUCKET_DELETE_ISSUE` | `workspace`, `repo_slug`, `issue_id` |
 | List members | `BITBUCKET_LIST_WORKSPACE_MEMBERS` | `workspace` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/box-automation/SKILL.md
+++ b/box-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Box operations including file upload/download, content search, folder management, collaboration, metadata queries, and sign requests through Composio's Box toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/box](https://composio.dev/toolkits/box)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -231,3 +233,6 @@ Box tools use double underscore notation for nested objects:
 | Cancel sign request | `BOX_CANCEL_BOX_SIGN_REQUEST` | `sign_request_id` |
 | Recent items | `BOX_LIST_RECENTLY_ACCESSED_ITEMS` | (none) |
 | Create zip download | `BOX_CREATE_ZIP_DOWNLOAD` | item IDs |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/brevo-automation/SKILL.md
+++ b/brevo-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Brevo (formerly Sendinblue) email marketing operations through Composio's Brevo toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/brevo](https://composio.dev/toolkits/brevo)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -195,3 +197,6 @@ Automate Brevo (formerly Sendinblue) email marketing operations through Composio
 | Update template | BREVO_CREATE_OR_UPDATE_EMAIL_TEMPLATE | templateId, htmlContent |
 | Delete template | BREVO_DELETE_EMAIL_TEMPLATE | templateId |
 | List senders | BREVO_GET_ALL_SENDERS | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/cal-com-automation/SKILL.md
+++ b/cal-com-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Cal.com scheduling operations through Composio's Cal toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/cal](https://composio.dev/toolkits/cal)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -201,3 +203,6 @@ Automate Cal.com scheduling operations through Composio's Cal toolkit via Rube M
 | Create team | CAL_CREATE_TEAM_IN_ORGANIZATION | name, slug |
 | Team event types | CAL_RETRIEVE_TEAM_EVENT_TYPES | teamId |
 | Get org ID | CAL_GET_ORGANIZATION_ID | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/calendly-automation/SKILL.md
+++ b/calendly-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Calendly operations including event listing, invitee management, scheduling link creation, availability queries, and organization administration through Composio's Calendly toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/calendly](https://composio.dev/toolkits/calendly)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -209,3 +211,6 @@ Most Calendly list endpoints use token-based pagination:
 | List org invitations | `CALENDLY_LIST_ORGANIZATION_INVITATIONS` | `uuid`, `status` |
 | Revoke org invitation | `CALENDLY_REVOKE_USER_S_ORGANIZATION_INVITATION` | org UUID, invitation UUID |
 | Remove from org | `CALENDLY_REMOVE_USER_FROM_ORGANIZATION` | membership UUID |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/canva-automation/SKILL.md
+++ b/canva-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Canva design operations through Composio's Canva toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/canva](https://composio.dev/toolkits/canva)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -215,3 +217,6 @@ Many Canva operations are asynchronous:
 | Move to folder | CANVA_MOVE_ITEM_TO_SPECIFIED_FOLDER | item_id, folder_id |
 | List templates | CANVA_ACCESS_USER_SPECIFIC_BRAND_TEMPLATES_LIST | (none) |
 | Autofill template | CANVA_INITIATE_CANVA_DESIGN_AUTOFILL_JOB | brand_template_id, data |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/capsule_crm-automation/SKILL.md
+++ b/capsule_crm-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: capsule_crm-automation
+description: "Automate Capsule CRM tasks via Rube MCP (Composio): contacts, opportunities, cases, tasks, and pipeline management. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Capsule CRM Automation via Rube MCP
+
+Automate Capsule CRM operations through Composio's Capsule CRM toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/capsule_crm](https://composio.dev/toolkits/capsule_crm)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Capsule CRM connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `capsule_crm`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `capsule_crm`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "contacts, opportunities, cases, tasks, and pipeline management", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Capsule CRM
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Capsule CRM Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Capsule CRM tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Capsule CRM Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Capsule CRM operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Capsule CRM connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Capsule CRM-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `capsule_crm` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/capsule_crm](https://composio.dev/toolkits/capsule_crm)

--- a/circleci-automation/SKILL.md
+++ b/circleci-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate CircleCI CI/CD operations through Composio's CircleCI toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/circleci](https://composio.dev/toolkits/circleci)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -175,3 +177,6 @@ Format: {vcs_type}/{org_name}/{repo_name}
 | Get job details | CIRCLECI_GET_JOB_DETAILS | project_slug, job_number |
 | Get job artifacts | CIRCLECI_GET_JOB_ARTIFACTS | project_slug, job_number |
 | Get test metadata | CIRCLECI_GET_TEST_METADATA | project_slug, job_number |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/clickup-automation/SKILL.md
+++ b/clickup-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate ClickUp project management workflows including task creation and updates, workspace hierarchy navigation, comments, and team member management through Composio's ClickUp toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/clickup](https://composio.dev/toolkits/clickup)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -232,3 +234,6 @@ Always resolve names to IDs through the hierarchy:
 | List user groups | `CLICKUP_GET_TEAMS` | `team_id` |
 | Get user details | `CLICKUP_GET_USER` | `team_id`, `user_id` |
 | Custom roles | `CLICKUP_GET_CUSTOM_ROLES` | `team_id` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/close-automation/SKILL.md
+++ b/close-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Close CRM operations through Composio's Close toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/close](https://composio.dev/toolkits/close)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -210,3 +212,6 @@ Close data model:
 | Create task | CLOSE_CREATE_TASK | lead_id, text, date, assigned_to |
 | Get note | CLOSE_GET_NOTE | note_id |
 | Delete call | CLOSE_DELETE_CALL | call_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/coda-automation/SKILL.md
+++ b/coda-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Coda document and data operations through Composio's Coda toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/coda](https://composio.dev/toolkits/coda)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -239,3 +241,6 @@ Automate Coda document and data operations through Composio's Coda toolkit via R
 | Publish doc | CODA_PUBLISH_DOC | docId, slug |
 | Unpublish doc | CODA_UNPUBLISH_DOC | docId |
 | List packs | CODA_LIST_PACKS | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/confluence-automation/SKILL.md
+++ b/confluence-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Confluence operations including page creation and updates, content search with CQL, space management, label tagging, and page hierarchy navigation through Composio's Confluence toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/confluence](https://composio.dev/toolkits/confluence)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -206,3 +208,6 @@ Confluence uses two pagination styles:
 | Add label | `CONFLUENCE_ADD_CONTENT_LABEL` | content ID, label |
 | Page versions | `CONFLUENCE_GET_PAGE_VERSIONS` | `id` |
 | Space labels | `CONFLUENCE_GET_LABELS_FOR_SPACE` | space ID |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/convertkit-automation/SKILL.md
+++ b/convertkit-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate ConvertKit (now known as Kit) email marketing operations through Composio's Kit toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/kit](https://composio.dev/toolkits/kit)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -193,3 +195,6 @@ Kit uses cursor-based pagination:
 | Get broadcast | KIT_GET_BROADCAST | id |
 | Get broadcast stats | KIT_GET_BROADCAST_STATS | id |
 | Delete broadcast | KIT_DELETE_BROADCAST | id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/datadog-automation/SKILL.md
+++ b/datadog-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Datadog monitoring and observability operations through Composio's Datadog toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/datadog](https://composio.dev/toolkits/datadog)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -233,3 +235,6 @@ logs("service:web status:error").index("main").rollup("count").last("5m") > 10
 | Create downtime | DATADOG_CREATE_DOWNTIME | scope, start, end |
 | List hosts | DATADOG_LIST_HOSTS | filter, sort_field |
 | Get trace | DATADOG_GET_TRACE_BY_ID | trace_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/discord-automation/SKILL.md
+++ b/discord-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Discord operations through Composio's Discord/Discordbot toolkits via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/discord](https://composio.dev/toolkits/discord)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -185,3 +187,6 @@ Permissions are combined using bitwise OR:
 | Clear reactions | DISCORDBOT_DELETE_ALL_MESSAGE_REACTIONS | channel_id, message_id |
 | Test auth | DISCORDBOT_TEST_AUTH | (none) |
 | Get channel | DISCORDBOT_GET_CHANNEL | channel_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/docker_hub-automation/SKILL.md
+++ b/docker_hub-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: docker_hub-automation
+description: "Automate Docker Hub tasks via Rube MCP (Composio): repositories, images, tags, and container registry management. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Docker Hub Automation via Rube MCP
+
+Automate Docker Hub operations through Composio's Docker Hub toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/docker_hub](https://composio.dev/toolkits/docker_hub)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Docker Hub connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `docker_hub`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `docker_hub`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "repositories, images, tags, and container registry management", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Docker Hub
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Docker Hub Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Docker Hub tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Docker Hub Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Docker Hub operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Docker Hub connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Docker Hub-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `docker_hub` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/docker_hub](https://composio.dev/toolkits/docker_hub)

--- a/docusign-automation/SKILL.md
+++ b/docusign-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate DocuSign e-signature workflows through Composio's DocuSign toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/docusign](https://composio.dev/toolkits/docusign)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -206,3 +208,6 @@ created (draft) -> sent -> delivered -> signed -> completed
 | Send envelope | DOCUSIGN_SEND_ENVELOPE | envelopeId |
 | Get envelope status | DOCUSIGN_GET_ENVELOPE | envelopeId |
 | Add template to envelope | DOCUSIGN_ADD_TEMPLATES_TO_DOCUMENT_IN_ENVELOPE | envelopeId, documentId, templateId |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/dropbox-automation/SKILL.md
+++ b/dropbox-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Dropbox operations including file upload/download, search, folder management, sharing links, batch operations, and metadata retrieval through Composio's Dropbox toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/dropbox](https://composio.dev/toolkits/dropbox)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -228,3 +230,6 @@ Several Dropbox operations run asynchronously:
 | Delete batch | `DROPBOX_DELETE_BATCH` | `entries` |
 | Copy file/folder | `DROPBOX_COPY_FILE_OR_FOLDER` | `from_path`, `to_path` |
 | Check batch status | `DROPBOX_CHECK_MOVE_BATCH` | `async_job_id` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/figma-automation/SKILL.md
+++ b/figma-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Figma operations through Composio's Figma toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/figma](https://composio.dev/toolkits/figma)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -179,3 +181,6 @@ Extract IDs from Figma URLs:
 | Team styles | FIGMA_GET_TEAM_STYLES | team_id |
 | File styles | FIGMA_GET_FILE_STYLES | file_key |
 | Image fills | FIGMA_GET_IMAGE_FILLS | file_key |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/fillout_forms-automation/SKILL.md
+++ b/fillout_forms-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: fillout_forms-automation
+description: "Automate Fillout tasks via Rube MCP (Composio): forms, submissions, workflows, and form builder. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Fillout Automation via Rube MCP
+
+Automate Fillout operations through Composio's Fillout toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/fillout_forms](https://composio.dev/toolkits/fillout_forms)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Fillout connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `fillout_forms`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `fillout_forms`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "forms, submissions, workflows, and form builder", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Fillout
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Fillout Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Fillout tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Fillout Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Fillout operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Fillout connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Fillout-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `fillout_forms` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/fillout_forms](https://composio.dev/toolkits/fillout_forms)

--- a/freshdesk-automation/SKILL.md
+++ b/freshdesk-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Freshdesk customer support workflows including ticket management, contact and company operations, notes, replies, and ticket search through Composio's Freshdesk toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/freshdesk](https://composio.dev/toolkits/freshdesk)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -217,3 +219,6 @@ Freshdesk uses page-based pagination:
 | List companies | `FRESHDESK_GET_COMPANIES` | `page` |
 | List ticket fields | `FRESHDESK_LIST_TICKET_FIELDS` | (none) |
 | List company fields | `FRESHDESK_LIST_COMPANY_FIELDS` | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/freshservice-automation/SKILL.md
+++ b/freshservice-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Freshservice IT Service Management operations through Composio's Freshservice toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/freshservice](https://composio.dev/toolkits/freshservice)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -211,3 +213,6 @@ Automate Freshservice IT Service Management operations through Composio's Freshs
 | Bulk update | FRESHSERVICE_BULK_UPDATE_TICKETS | ids, update_fields |
 | Outbound email ticket | FRESHSERVICE_CREATE_TICKET_OUTBOUND_EMAIL | email, subject, description |
 | Service request | FRESHSERVICE_CREATE_SERVICE_REQUEST | item_display_id, email, quantity |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/github-automation/SKILL.md
+++ b/github-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate GitHub repository management, issue tracking, pull request workflows, branch operations, and CI/CD through Composio's GitHub toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/github](https://composio.dev/toolkits/github)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -225,3 +227,6 @@ All list endpoints use page-based pagination:
 | Check CI | `GITHUB_LIST_CHECK_RUNS_FOR_A_REF` | `owner`, `repo`, ref |
 | List collaborators | `GITHUB_LIST_REPOSITORY_COLLABORATORS` | `owner`, `repo` |
 | Branch protection | `GITHUB_GET_BRANCH_PROTECTION` | `owner`, `repo`, `branch` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/gitlab-automation/SKILL.md
+++ b/gitlab-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate GitLab operations including project management, issue tracking, merge request workflows, CI/CD pipeline monitoring, branch management, and user administration through Composio's GitLab toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/gitlab](https://composio.dev/toolkits/gitlab)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -252,3 +254,6 @@ When using project paths as identifiers:
 | User status | `GITLAB_GET_USERS_ID_STATUS` | user ID |
 | List project members | `GITLAB_LIST_ALL_PROJECT_MEMBERS` | `id`, `query`, `state` |
 | List project users | `GITLAB_LIST_PROJECT_USERS` | `id`, `search` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/gmail-automation/SKILL.md
+++ b/gmail-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Gmail operations through Composio's Gmail toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/gmail](https://composio.dev/toolkits/gmail)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -268,3 +270,5 @@ Automate Gmail operations through Composio's Gmail toolkit via Rube MCP.
 | Get attachment | GMAIL_GET_ATTACHMENT | message_id, attachment_id |
 | Search contacts | GMAIL_SEARCH_PEOPLE | query |
 | Get profile | GMAIL_GET_PROFILE | (none) |
+---
+*Powered by [Composio](https://composio.dev)*

--- a/google-analytics-automation/SKILL.md
+++ b/google-analytics-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Google Analytics 4 (GA4) reporting and property management through Composio's Google Analytics toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/google_analytics](https://composio.dev/toolkits/google_analytics)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -225,3 +227,6 @@ Automate Google Analytics 4 (GA4) reporting and property management through Comp
 | Pivot report | GOOGLE_ANALYTICS_RUN_PIVOT_REPORT | property, dateRanges, pivots |
 | Funnel report | GOOGLE_ANALYTICS_RUN_FUNNEL_REPORT | property, dateRanges, funnel |
 | List key events | GOOGLE_ANALYTICS_LIST_KEY_EVENTS | parent, pageSize |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/google-calendar-automation/SKILL.md
+++ b/google-calendar-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Google Calendar workflows including event creation, scheduling, availability checks, attendee management, and calendar browsing through Composio's Google Calendar toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/googlecalendar](https://composio.dev/toolkits/googlecalendar)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -174,3 +176,6 @@ Automate Google Calendar workflows including event creation, scheduling, availab
 | Remove attendee | `GOOGLECALENDAR_REMOVE_ATTENDEE` | `event_id`, `attendee_email` |
 | Get current time | `GOOGLECALENDAR_GET_CURRENT_DATE_TIME` | `timezone` |
 | Get calendar | `GOOGLECALENDAR_GET_CALENDAR` | `calendar_id` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/google-drive-automation/SKILL.md
+++ b/google-drive-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Google Drive workflows including file upload/download, search, folder management, sharing/permissions, and organization through Composio's Google Drive toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/googledrive](https://composio.dev/toolkits/googledrive)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -191,3 +193,6 @@ For Google Workspace files, set `mime_type` to export:
 | List shared drives | `GOOGLEDRIVE_LIST_SHARED_DRIVES` | `pageSize` |
 | Drive info | `GOOGLEDRIVE_GET_ABOUT` | (none) |
 | Create shortcut | `GOOGLEDRIVE_CREATE_SHORTCUT_TO_FILE` | target file_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/google_admin-automation/SKILL.md
+++ b/google_admin-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: google_admin-automation
+description: "Automate Google Admin tasks via Rube MCP (Composio): user management, org units, groups, and domain administration. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Google Admin Automation via Rube MCP
+
+Automate Google Admin operations through Composio's Google Admin toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/google_admin](https://composio.dev/toolkits/google_admin)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Google Admin connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `google_admin`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `google_admin`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "user management, org units, groups, and domain administration", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Google Admin
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Google Admin Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Google Admin tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Google Admin Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Google Admin operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Google Admin connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Google Admin-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `google_admin` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/google_admin](https://composio.dev/toolkits/google_admin)

--- a/google_classroom-automation/SKILL.md
+++ b/google_classroom-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: google_classroom-automation
+description: "Automate Google Classroom tasks via Rube MCP (Composio): course management, assignments, student rosters, and announcements. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Google Classroom Automation via Rube MCP
+
+Automate Google Classroom operations through Composio's Google Classroom toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/google_classroom](https://composio.dev/toolkits/google_classroom)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Google Classroom connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `google_classroom`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `google_classroom`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "course management, assignments, student rosters, and announcements", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Google Classroom
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Google Classroom Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Google Classroom tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Google Classroom Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Google Classroom operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Google Classroom connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Google Classroom-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `google_classroom` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/google_classroom](https://composio.dev/toolkits/google_classroom)

--- a/google_maps-automation/SKILL.md
+++ b/google_maps-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: google_maps-automation
+description: "Automate Google Maps tasks via Rube MCP (Composio): geocoding, directions, place search, and distance calculations. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Google Maps Automation via Rube MCP
+
+Automate Google Maps operations through Composio's Google Maps toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/google_maps](https://composio.dev/toolkits/google_maps)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Google Maps connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `google_maps`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `google_maps`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "geocoding, directions, place search, and distance calculations", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Google Maps
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Google Maps Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Google Maps tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Google Maps Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Google Maps operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Google Maps connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Google Maps-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `google_maps` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/google_maps](https://composio.dev/toolkits/google_maps)

--- a/google_search_console-automation/SKILL.md
+++ b/google_search_console-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: google_search_console-automation
+description: "Automate Google Search Console tasks via Rube MCP (Composio): search performance, URL inspection, sitemaps, and indexing status. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Google Search Console Automation via Rube MCP
+
+Automate Google Search Console operations through Composio's Google Search Console toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/google_search_console](https://composio.dev/toolkits/google_search_console)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Google Search Console connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `google_search_console`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `google_search_console`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "search performance, URL inspection, sitemaps, and indexing status", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Google Search Console
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Google Search Console Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Google Search Console tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Google Search Console Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Google Search Console operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Google Search Console connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Google Search Console-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `google_search_console` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/google_search_console](https://composio.dev/toolkits/google_search_console)

--- a/googlesheets-automation/SKILL.md
+++ b/googlesheets-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Google Sheets workflows including reading/writing data, managing spreadsheets and tabs, formatting cells, filtering rows, and upserting records through Composio's Google Sheets toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/googlesheets](https://composio.dev/toolkits/googlesheets)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -195,3 +197,6 @@ Google Sheets enforces strict rate limits:
 | Delete rows/cols | `GOOGLESHEETS_DELETE_DIMENSION` | `spreadsheet_id`, `sheet_name`, dimension |
 | Spreadsheet info | `GOOGLESHEETS_GET_SPREADSHEET_INFO` | `spreadsheet_id` |
 | Update tab props | `GOOGLESHEETS_UPDATE_SHEET_PROPERTIES` | `spreadsheetId`, properties |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/helpdesk-automation/SKILL.md
+++ b/helpdesk-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate HelpDesk ticketing operations through Composio's HelpDesk toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/helpdesk](https://composio.dev/toolkits/helpdesk)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -164,3 +166,6 @@ Backward pagination:
 | List views | HELPDESK_LIST_VIEWS | (none) |
 | List canned responses | HELPDESK_LIST_CANNED_RESPONSES | (none) |
 | List custom fields | HELPDESK_LIST_CUSTOM_FIELDS | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/hubspot-automation/SKILL.md
+++ b/hubspot-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate HubSpot CRM workflows including contact/company management, deal pipeline tracking, ticket search, and custom property creation through Composio's HubSpot toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/hubspot](https://composio.dev/toolkits/hubspot)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -176,3 +178,5 @@ Automate HubSpot CRM workflows including contact/company management, deal pipeli
 | Create property | `HUBSPOT_CREATE_PROPERTY_FOR_SPECIFIED_OBJECT_TYPE` | `objectType, name, label, type, fieldType` |
 | Get owners | `HUBSPOT_RETRIEVE_OWNERS` | None |
 | Verify connection | `HUBSPOT_GET_ACCOUNT_INFO` | None |
+---
+*Powered by [Composio](https://composio.dev)*

--- a/instagram-automation/SKILL.md
+++ b/instagram-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Instagram operations through Composio's Instagram toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/instagram](https://composio.dev/toolkits/instagram)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -190,3 +192,6 @@ Automate Instagram operations through Composio's Instagram toolkit via Rube MCP.
 | Get publishing limit | INSTAGRAM_GET_IG_USER_CONTENT_PUBLISHING_LIMIT | ig_user_id |
 | Get media comments | INSTAGRAM_GET_IG_MEDIA_COMMENTS | ig_media_id |
 | Get carousel children | INSTAGRAM_GET_IG_MEDIA_CHILDREN | ig_media_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/intercom-automation/SKILL.md
+++ b/intercom-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Intercom operations through Composio's Intercom toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/intercom](https://composio.dev/toolkits/intercom)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -246,3 +248,6 @@ Automate Intercom operations through Composio's Intercom toolkit via Rube MCP.
 | Company segments | INTERCOM_LIST_ATTACHED_SEGMENTS_FOR_COMPANIES | company_id |
 | Get counts | INTERCOM_GET_COUNTS | type, count |
 | List companies | INTERCOM_LIST_ALL_COMPANIES | page, per_page |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/jira-automation/SKILL.md
+++ b/jira-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Jira operations through Composio's Jira toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/jira](https://composio.dev/toolkits/jira)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -183,3 +185,6 @@ Automate Jira operations through Composio's Jira toolkit via Rube MCP.
 | List filters | JIRA_LIST_FILTERS | (none) |
 | Project roles | JIRA_GET_PROJECT_ROLES | projectIdOrKey |
 | Project versions | JIRA_GET_PROJECT_VERSIONS | projectIdOrKey |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/klaviyo-automation/SKILL.md
+++ b/klaviyo-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Klaviyo email and SMS marketing operations through Composio's Klaviyo toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/klaviyo](https://composio.dev/toolkits/klaviyo)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -188,3 +190,6 @@ fields__template=['name', 'html', 'text']
 | Get campaign message | KLAVIYO_GET_CAMPAIGN_MESSAGE | id, fields__campaign__message |
 | Get campaign tags | KLAVIYO_GET_CAMPAIGN_RELATIONSHIPS_TAGS | id |
 | Get send job status | KLAVIYO_GET_CAMPAIGN_SEND_JOB | id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/launch_darkly-automation/SKILL.md
+++ b/launch_darkly-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: launch_darkly-automation
+description: "Automate LaunchDarkly tasks via Rube MCP (Composio): feature flags, environments, segments, and rollout management. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# LaunchDarkly Automation via Rube MCP
+
+Automate LaunchDarkly operations through Composio's LaunchDarkly toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/launch_darkly](https://composio.dev/toolkits/launch_darkly)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active LaunchDarkly connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `launch_darkly`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `launch_darkly`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "feature flags, environments, segments, and rollout management", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for LaunchDarkly
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available LaunchDarkly Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available LaunchDarkly tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute LaunchDarkly Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple LaunchDarkly operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the LaunchDarkly connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with LaunchDarkly-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `launch_darkly` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/launch_darkly](https://composio.dev/toolkits/launch_darkly)

--- a/lemon_squeezy-automation/SKILL.md
+++ b/lemon_squeezy-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: lemon_squeezy-automation
+description: "Automate Lemon Squeezy tasks via Rube MCP (Composio): products, orders, subscriptions, checkouts, and digital sales. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Lemon Squeezy Automation via Rube MCP
+
+Automate Lemon Squeezy operations through Composio's Lemon Squeezy toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/lemon_squeezy](https://composio.dev/toolkits/lemon_squeezy)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Lemon Squeezy connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `lemon_squeezy`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `lemon_squeezy`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "products, orders, subscriptions, checkouts, and digital sales", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Lemon Squeezy
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Lemon Squeezy Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Lemon Squeezy tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Lemon Squeezy Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Lemon Squeezy operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Lemon Squeezy connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Lemon Squeezy-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `lemon_squeezy` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/lemon_squeezy](https://composio.dev/toolkits/lemon_squeezy)

--- a/linear-automation/SKILL.md
+++ b/linear-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Linear operations through Composio's Linear toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/linear](https://composio.dev/toolkits/linear)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -176,3 +178,6 @@ Automate Linear operations through Composio's Linear toolkit via Rube MCP.
 | List users | LINEAR_LIST_LINEAR_USERS | (none) |
 | Current user | LINEAR_GET_CURRENT_USER | (none) |
 | Run GraphQL | LINEAR_RUN_QUERY_OR_MUTATION | query, variables |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/linkedin-automation/SKILL.md
+++ b/linkedin-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate LinkedIn operations through Composio's LinkedIn toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/linkedin](https://composio.dev/toolkits/linkedin)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -173,3 +175,6 @@ Automate LinkedIn operations through Composio's LinkedIn toolkit via Rube MCP.
 | Get uploaded images | LINKEDIN_GET_IMAGES | image_id |
 | Delete post | LINKEDIN_DELETE_LINKED_IN_POST | post_id |
 | Comment on post | LINKEDIN_CREATE_COMMENT_ON_POST | post_id, text, actor |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/mailchimp-automation/SKILL.md
+++ b/mailchimp-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Mailchimp email marketing workflows including campaign creation and sending, audience/list management, subscriber operations, segmentation, and performance analytics through Composio's Mailchimp toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/mailchimp](https://composio.dev/toolkits/mailchimp)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -229,3 +231,6 @@ subscriber_hash = hashlib.md5(email.lower().encode()).hexdigest()
 | Subscriber activity | `MAILCHIMP_GET_SUBSCRIBER_EMAIL_ACTIVITY` | `campaign_id`, `subscriber_hash` |
 | Member recent activity | `MAILCHIMP_VIEW_RECENT_ACTIVITY` | `list_id`, `subscriber_hash` |
 | Campaign content | `MAILCHIMP_GET_CAMPAIGN_CONTENT` | `campaign_id` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/make-automation/SKILL.md
+++ b/make-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Make (formerly Integromat) operations through Composio's Make toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/make](https://composio.dev/toolkits/make)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -199,3 +201,6 @@ Instead of relying solely on Make's toolkit, build equivalent automation directl
 3. Connect all required toolkits
 4. Build the workflow step-by-step using individual app tools
 5. Save as a recipe via RUBE_CREATE_UPDATE_RECIPE for reuse
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/many_chat-automation/SKILL.md
+++ b/many_chat-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: many_chat-automation
+description: "Automate ManyChat tasks via Rube MCP (Composio): chatbot flows, subscribers, broadcasts, and messenger automation. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# ManyChat Automation via Rube MCP
+
+Automate ManyChat operations through Composio's ManyChat toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/many_chat](https://composio.dev/toolkits/many_chat)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active ManyChat connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `many_chat`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `many_chat`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "chatbot flows, subscribers, broadcasts, and messenger automation", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for ManyChat
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available ManyChat Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available ManyChat tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute ManyChat Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple ManyChat operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the ManyChat connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with ManyChat-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `many_chat` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/many_chat](https://composio.dev/toolkits/many_chat)

--- a/microsoft-teams-automation/SKILL.md
+++ b/microsoft-teams-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Microsoft Teams operations through Composio's Microsoft Teams toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/microsoft_teams](https://composio.dev/toolkits/microsoft_teams)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -209,3 +211,6 @@ Automate Microsoft Teams operations through Composio's Microsoft Teams toolkit v
 | Search messages | MICROSOFT_TEAMS_SEARCH_MESSAGES | query |
 | Get chat message | MICROSOFT_TEAMS_GET_CHAT_MESSAGE | chat_id, message_id |
 | List joined teams | MICROSOFT_TEAMS_LIST_USER_JOINED_TEAMS | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/microsoft_clarity-automation/SKILL.md
+++ b/microsoft_clarity-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: microsoft_clarity-automation
+description: "Automate Microsoft Clarity tasks via Rube MCP (Composio): session recordings, heatmaps, and user behavior analytics. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Microsoft Clarity Automation via Rube MCP
+
+Automate Microsoft Clarity operations through Composio's Microsoft Clarity toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/microsoft_clarity](https://composio.dev/toolkits/microsoft_clarity)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Microsoft Clarity connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `microsoft_clarity`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `microsoft_clarity`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "session recordings, heatmaps, and user behavior analytics", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Microsoft Clarity
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Microsoft Clarity Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Microsoft Clarity tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Microsoft Clarity Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Microsoft Clarity operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Microsoft Clarity connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Microsoft Clarity-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `microsoft_clarity` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/microsoft_clarity](https://composio.dev/toolkits/microsoft_clarity)

--- a/miro-automation/SKILL.md
+++ b/miro-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Miro whiteboard operations through Composio's Miro toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/miro](https://composio.dev/toolkits/miro)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -203,3 +205,6 @@ Automate Miro whiteboard operations through Composio's Miro toolkit via Rube MCP
 | Share board | MIRO_SHARE_BOARD | board_id, emails, role |
 | Get members | MIRO_GET_BOARD_MEMBERS | board_id |
 | Get connectors | MIRO_GET_CONNECTORS2 | board_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/mistral_ai-automation/SKILL.md
+++ b/mistral_ai-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: mistral_ai-automation
+description: "Automate Mistral AI tasks via Rube MCP (Composio): completions, embeddings, fine-tuning, and model management. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Mistral AI Automation via Rube MCP
+
+Automate Mistral AI operations through Composio's Mistral AI toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/mistral_ai](https://composio.dev/toolkits/mistral_ai)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Mistral AI connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `mistral_ai`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `mistral_ai`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "completions, embeddings, fine-tuning, and model management", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Mistral AI
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Mistral AI Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Mistral AI tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Mistral AI Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Mistral AI operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Mistral AI connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Mistral AI-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `mistral_ai` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/mistral_ai](https://composio.dev/toolkits/mistral_ai)

--- a/mixpanel-automation/SKILL.md
+++ b/mixpanel-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Mixpanel product analytics through Composio's Mixpanel toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/mixpanel](https://composio.dev/toolkits/mixpanel)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -222,3 +224,6 @@ Used in `where` and `on` parameters:
 | List cohorts | MIXPANEL_COHORTS_LIST | (none) |
 | JQL query | MIXPANEL_JQL_QUERY | script |
 | Query insight | MIXPANEL_QUERY_INSIGHT | bookmark_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/monday-automation/SKILL.md
+++ b/monday-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Monday.com work management workflows including board creation, item management, column value updates, group organization, subitems, and update/comment threads through Composio's Monday toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/monday](https://composio.dev/toolkits/monday)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -231,3 +233,6 @@ Different column types require different value formats:
 | List subitems | `MONDAY_LIST_SUBITEMS_BY_PARENT` | `parent_item_ids` |
 | Add comment/update | `MONDAY_CREATE_UPDATE` | `item_id`, `body` |
 | Raw GraphQL mutation | `MONDAY_CREATE_OBJECT` | `query`, `variables` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/new_relic-automation/SKILL.md
+++ b/new_relic-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: new_relic-automation
+description: "Automate New Relic tasks via Rube MCP (Composio): APM, alerts, dashboards, NRQL queries, and infrastructure monitoring. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# New Relic Automation via Rube MCP
+
+Automate New Relic operations through Composio's New Relic toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/new_relic](https://composio.dev/toolkits/new_relic)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active New Relic connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `new_relic`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `new_relic`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "APM, alerts, dashboards, NRQL queries, and infrastructure monitoring", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for New Relic
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available New Relic Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available New Relic tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute New Relic Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple New Relic operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the New Relic connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with New Relic-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `new_relic` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/new_relic](https://composio.dev/toolkits/new_relic)

--- a/notion-automation/SKILL.md
+++ b/notion-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Notion operations through Composio's Notion toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/notion](https://composio.dev/toolkits/notion)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -213,3 +215,6 @@ Automate Notion operations through Composio's Notion toolkit via Rube MCP.
 | List users | NOTION_LIST_USERS | (none) |
 | Create comment | NOTION_CREATE_COMMENT | page_id, rich_text |
 | List comments | NOTION_FETCH_COMMENTS | page_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/one-drive-automation/SKILL.md
+++ b/one-drive-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate OneDrive operations including file upload/download, search, folder management, sharing links, permissions management, and drive browsing through Composio's OneDrive toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/one_drive](https://composio.dev/toolkits/one_drive)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -236,3 +238,6 @@ Most OneDrive tools accept either paths or IDs:
 | Get quota | `ONE_DRIVE_GET_QUOTA` | (none) |
 | Track changes | `ONE_DRIVE_LIST_SITE_DRIVE_ITEMS_DELTA` | `site_id`, `token` |
 | Version history | `ONE_DRIVE_GET_ITEM_VERSIONS` | `item_id` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/onesignal_rest_api-automation/SKILL.md
+++ b/onesignal_rest_api-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: onesignal_rest_api-automation
+description: "Automate OneSignal tasks via Rube MCP (Composio): push notifications, segments, templates, and messaging. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# OneSignal Automation via Rube MCP
+
+Automate OneSignal operations through Composio's OneSignal toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/onesignal_rest_api](https://composio.dev/toolkits/onesignal_rest_api)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active OneSignal connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `onesignal_rest_api`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `onesignal_rest_api`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "push notifications, segments, templates, and messaging", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for OneSignal
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available OneSignal Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available OneSignal tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute OneSignal Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple OneSignal operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the OneSignal connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with OneSignal-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `onesignal_rest_api` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/onesignal_rest_api](https://composio.dev/toolkits/onesignal_rest_api)

--- a/outlook-automation/SKILL.md
+++ b/outlook-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Microsoft Outlook operations through Composio's Outlook toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/outlook](https://composio.dev/toolkits/outlook)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -189,3 +191,6 @@ Automate Microsoft Outlook operations through Composio's Outlook toolkit via Rub
 | List contacts | OUTLOOK_LIST_CONTACTS | top, filter |
 | Create contact | OUTLOOK_CREATE_CONTACT | givenName, emailAddresses |
 | Contact folders | OUTLOOK_GET_CONTACT_FOLDERS | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/outlook-calendar-automation/SKILL.md
+++ b/outlook-calendar-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Outlook Calendar operations through Composio's Outlook toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/outlook](https://composio.dev/toolkits/outlook)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -234,3 +236,6 @@ filter: "contains(subject, 'Review') and categories/any(c:c eq 'Work')"
 | Get schedule | OUTLOOK_GET_SCHEDULE | Schedules, StartTime, EndTime |
 | List calendars | OUTLOOK_LIST_CALENDARS | user_id |
 | Mailbox settings | OUTLOOK_GET_MAILBOX_SETTINGS | select |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/pagerduty-automation/SKILL.md
+++ b/pagerduty-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate PagerDuty incident management and operations through Composio's PagerDuty toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/pagerduty](https://composio.dev/toolkits/pagerduty)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -243,3 +245,6 @@ Automate PagerDuty incident management and operations through Composio's PagerDu
 | List escalation policies | PAGERDUTY_FETCH_ESCALATION_POLICES_LIST | (none) |
 | Create escalation policy | PAGERDUTY_CREATE_ESCALATION_POLICY | name, escalation_rules |
 | Create team | PAGERDUTY_CREATE_NEW_TEAM_WITH_DETAILS | name, description |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/pipedrive-automation/SKILL.md
+++ b/pipedrive-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Pipedrive CRM workflows including deal management, contact and organization operations, activity scheduling, notes, and pipeline/stage queries through Composio's Pipedrive toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/pipedrive](https://composio.dev/toolkits/pipedrive)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -222,3 +224,6 @@ Most list endpoints use offset-based pagination:
 | Deals in pipeline | `PIPEDRIVE_GET_DEALS_IN_A_PIPELINE` | `id`, `stage_id` |
 | Deals in stage | `PIPEDRIVE_GET_DEALS_IN_A_STAGE` | `id`, `start`, `limit` |
 | Add product to deal | `PIPEDRIVE_ADD_A_PRODUCT_TO_A_DEAL` | `id`, `product_id`, `item_price` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/posthog-automation/SKILL.md
+++ b/posthog-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate PostHog product analytics and feature flag management through Composio's PostHog toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/posthog](https://composio.dev/toolkits/posthog)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -222,3 +224,6 @@ Feature flags support sophisticated targeting:
 | List projects | POSTHOG_LIST_PROJECTS_IN_ORGANIZATION_WITH_PAGINATION | organization_id |
 | Who am I | POSTHOG_WHOAMI | (none) |
 | User profile | POSTHOG_RETRIEVE_CURRENT_USER_PROFILE | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/postmark-automation/SKILL.md
+++ b/postmark-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Postmark transactional email operations through Composio's Postmark toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/postmark](https://composio.dev/toolkits/postmark)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -185,3 +187,6 @@ Automate Postmark transactional email operations through Composio's Postmark too
 | Tracked email counts | POSTMARK_GET_TRACKED_EMAIL_COUNTS | fromdate, todate, tag |
 | Get server config | POSTMARK_GET_SERVER | (none) |
 | Edit server config | POSTMARK_EDIT_SERVER | Name, TrackOpens, TrackLinks |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/reddit-automation/SKILL.md
+++ b/reddit-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Reddit operations through Composio's Reddit toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/reddit](https://composio.dev/toolkits/reddit)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -210,3 +212,6 @@ t5_ = Subreddit
 | Get specific comment | REDDIT_RETRIEVE_SPECIFIC_COMMENT | comment_id |
 | List post flairs | REDDIT_LIST_SUBREDDIT_POST_FLAIRS | subreddit |
 | Get user flair | REDDIT_GET_USER_FLAIR | subreddit |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/render-automation/SKILL.md
+++ b/render-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Render cloud platform operations through Composio's Render toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/render](https://composio.dev/toolkits/render)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -179,3 +181,6 @@ Automate Render cloud platform operations through Composio's Render toolkit via 
 | Trigger deploy | RENDER_TRIGGER_DEPLOY | serviceId, clearCache |
 | Get deploy status | RENDER_RETRIEVE_DEPLOY | serviceId, deployId |
 | List projects | RENDER_LIST_PROJECTS | limit, cursor |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/ring_central-automation/SKILL.md
+++ b/ring_central-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: ring_central-automation
+description: "Automate RingCentral tasks via Rube MCP (Composio): calls, messages, meetings, and unified communications. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# RingCentral Automation via Rube MCP
+
+Automate RingCentral operations through Composio's RingCentral toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/ring_central](https://composio.dev/toolkits/ring_central)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active RingCentral connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `ring_central`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `ring_central`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "calls, messages, meetings, and unified communications", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for RingCentral
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available RingCentral Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available RingCentral tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute RingCentral Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple RingCentral operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the RingCentral connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with RingCentral-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `ring_central` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/ring_central](https://composio.dev/toolkits/ring_central)

--- a/salesforce-automation/SKILL.md
+++ b/salesforce-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Salesforce CRM operations through Composio's Salesforce toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/salesforce](https://composio.dev/toolkits/salesforce)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -188,3 +190,6 @@ SELECT Id, Name FROM Opportunity WHERE CloseDate = NEXT_MONTH
 | Custom objects | SALESFORCE_GET_ALL_CUSTOM_OBJECTS | (none) |
 | Create record | SALESFORCE_CREATE_A_RECORD | object_type, fields |
 | Transfer ownership | SALESFORCE_MASS_TRANSFER_OWNERSHIP | records, new_owner |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/segment-automation/SKILL.md
+++ b/segment-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Segment customer data platform operations through Composio's Segment toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/segment](https://composio.dev/toolkits/segment)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -223,3 +225,6 @@ Segment recommends consistent event naming:
 | Source schema | SEGMENT_LIST_SCHEMA_SETTINGS_IN_SOURCE | sourceId |
 | Update source | SEGMENT_UPDATE_SOURCE | sourceId |
 | Warehouses | SEGMENT_LIST_CONNECTED_WAREHOUSES_FROM_SOURCE | sourceId |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/sendgrid-automation/SKILL.md
+++ b/sendgrid-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate SendGrid email delivery workflows including marketing campaigns (Single Sends), contact and list management, sender identity setup, and email analytics through Composio's SendGrid toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/sendgrid](https://composio.dev/toolkits/sendgrid)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -226,3 +228,6 @@ Contact operations (`ADD_OR_UPDATE_A_CONTACT`, `IMPORT_CONTACTS`) are asynchrono
 | Suppression groups | `SENDGRID_GET_SUPPRESSION_GROUPS` | (none) |
 | Get template | `SENDGRID_RETRIEVE_A_SINGLE_TRANSACTIONAL_TEMPLATE` | `template_id` |
 | Duplicate template | `SENDGRID_DUPLICATE_A_TRANSACTIONAL_TEMPLATE` | `template_id`, `name` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/sentry-automation/SKILL.md
+++ b/sentry-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Sentry error tracking and monitoring operations through Composio's Sentry toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/sentry](https://composio.dev/toolkits/sentry)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -230,3 +232,6 @@ Automate Sentry error tracking and monitoring operations through Composio's Sent
 | Deploy release | SENTRY_CREATE_RELEASE_DEPLOY_FOR_ORG | organization_id_or_slug, version |
 | List releases | SENTRY_LIST_ORGANIZATION_RELEASES | organization_id_or_slug |
 | Update monitor | SENTRY_UPDATE_A_MONITOR | organization_id_or_slug, monitor_id_or_slug |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/share_point-automation/SKILL.md
+++ b/share_point-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: share_point-automation
+description: "Automate SharePoint tasks via Rube MCP (Composio): document libraries, sites, lists, and content management. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# SharePoint Automation via Rube MCP
+
+Automate SharePoint operations through Composio's SharePoint toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/share_point](https://composio.dev/toolkits/share_point)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active SharePoint connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `share_point`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `share_point`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "document libraries, sites, lists, and content management", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for SharePoint
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available SharePoint Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available SharePoint tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute SharePoint Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple SharePoint operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the SharePoint connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with SharePoint-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `share_point` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/share_point](https://composio.dev/toolkits/share_point)

--- a/shopify-automation/SKILL.md
+++ b/shopify-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Shopify operations through Composio's Shopify toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/shopify](https://composio.dev/toolkits/shopify)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -166,3 +168,6 @@ For advanced operations:
 | Fulfillment | SHOPIFY_GET_FULFILLMENT | order_id, fulfillment_id |
 | GraphQL | SHOPIFY_GRAPH_QL_QUERY | query |
 | Bulk query | SHOPIFY_BULK_QUERY_OPERATION | query |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/similarweb_digitalrank_api-automation/SKILL.md
+++ b/similarweb_digitalrank_api-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: similarweb_digitalrank_api-automation
+description: "Automate SimilarWeb tasks via Rube MCP (Composio): website traffic, rankings, and digital market intelligence. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# SimilarWeb Automation via Rube MCP
+
+Automate SimilarWeb operations through Composio's SimilarWeb toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/similarweb_digitalrank_api](https://composio.dev/toolkits/similarweb_digitalrank_api)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active SimilarWeb connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `similarweb_digitalrank_api`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `similarweb_digitalrank_api`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "website traffic, rankings, and digital market intelligence", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for SimilarWeb
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available SimilarWeb Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available SimilarWeb tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute SimilarWeb Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple SimilarWeb operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the SimilarWeb connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with SimilarWeb-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `similarweb_digitalrank_api` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/similarweb_digitalrank_api](https://composio.dev/toolkits/similarweb_digitalrank_api)

--- a/slack-automation/SKILL.md
+++ b/slack-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Slack workspace operations including messaging, search, channel management, and reaction workflows through Composio's Slack toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/slack](https://composio.dev/toolkits/slack)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -187,3 +189,6 @@ Most list endpoints use cursor-based pagination:
 | Get channel info | `SLACK_RETRIEVE_CONVERSATION_INFORMATION` | channel ID |
 | Channel history | `SLACK_FETCH_CONVERSATION_HISTORY` | `channel`, `oldest`, `latest` |
 | Workspace info | `SLACK_FETCH_TEAM_INFO` | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/square-automation/SKILL.md
+++ b/square-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Square payment processing, order management, and invoicing through Composio's Square toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/square](https://composio.dev/toolkits/square)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -174,3 +176,6 @@ Automate Square payment processing, order management, and invoicing through Comp
 | List invoices | SQUARE_LIST_INVOICES | location_id, cursor |
 | Get invoice | SQUARE_GET_INVOICE | invoice_id |
 | Cancel invoice | SQUARE_CANCEL_INVOICE | invoice_id, version |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/stripe-automation/SKILL.md
+++ b/stripe-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Stripe payment operations through Composio's Stripe toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/stripe](https://composio.dev/toolkits/stripe)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -196,3 +198,6 @@ Stripe uses smallest currency unit:
 | Payment methods | STRIPE_LIST_CUSTOMER_PAYMENT_METHODS | customer |
 | Checkout session | STRIPE_CREATE_CHECKOUT_SESSION | line_items |
 | List payment intents | STRIPE_LIST_PAYMENT_INTENTS | customer |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/supabase-automation/SKILL.md
+++ b/supabase-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Supabase operations including database queries, table schema inspection, SQL execution, project and organization management, storage buckets, edge functions, and service health monitoring through Composio's Supabase toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/supabase](https://composio.dev/toolkits/supabase)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -234,3 +236,6 @@ Automate Supabase operations including database queries, table schema inspection
 | Get edge function | `SUPABASE_RETRIEVE_A_FUNCTION` | `ref`, function slug |
 | List storage buckets | `SUPABASE_LISTS_ALL_BUCKETS` | `ref` |
 | List DB branches | `SUPABASE_LIST_ALL_DATABASE_BRANCHES` | `ref` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/survey_monkey-automation/SKILL.md
+++ b/survey_monkey-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: survey_monkey-automation
+description: "Automate SurveyMonkey tasks via Rube MCP (Composio): surveys, responses, collectors, and survey analytics. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# SurveyMonkey Automation via Rube MCP
+
+Automate SurveyMonkey operations through Composio's SurveyMonkey toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/survey_monkey](https://composio.dev/toolkits/survey_monkey)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active SurveyMonkey connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `survey_monkey`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `survey_monkey`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "surveys, responses, collectors, and survey analytics", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for SurveyMonkey
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available SurveyMonkey Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available SurveyMonkey tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute SurveyMonkey Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple SurveyMonkey operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the SurveyMonkey connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with SurveyMonkey-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `survey_monkey` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/survey_monkey](https://composio.dev/toolkits/survey_monkey)

--- a/telegram-automation/SKILL.md
+++ b/telegram-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Telegram operations through Composio's Telegram toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/telegram](https://composio.dev/toolkits/telegram)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -217,3 +219,6 @@ Automate Telegram operations through Composio's Telegram toolkit via Rube MCP.
 | Get chat history | TELEGRAM_GET_CHAT_HISTORY | chat_id |
 | Set bot commands | TELEGRAM_SET_MY_COMMANDS | commands |
 | Answer callback | TELEGRAM_ANSWER_CALLBACK_QUERY | callback_query_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/tiktok-automation/SKILL.md
+++ b/tiktok-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate TikTok content creation and profile operations through Composio's TikTok toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/tiktok](https://composio.dev/toolkits/tiktok)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -176,3 +178,6 @@ Automate TikTok content creation and profile operations through Composio's TikTo
 | Get user stats | TIKTOK_GET_USER_STATS | (none) |
 | Get basic info | TIKTOK_GET_USER_BASIC_INFO | (none) |
 | Check publish status | TIKTOK_FETCH_PUBLISH_STATUS | publish_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/todoist-automation/SKILL.md
+++ b/todoist-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Todoist operations including task creation and management, project organization, section management, filtering, and bulk task workflows through Composio's Todoist toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/todoist](https://composio.dev/toolkits/todoist)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -229,3 +231,6 @@ Always resolve human-readable names to IDs before operations:
 | Delete task | `TODOIST_DELETE_TASK` | `task_id` |
 | Completed tasks | `TODOIST_GET_COMPLETED_TASKS_BY_COMPLETION_DATE` | `since`, `until` |
 | List filters | `TODOIST_LIST_FILTERS` | `sync_token` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/trello-automation/SKILL.md
+++ b/trello-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Trello board management, card creation, and team workflows through Composio's Rube MCP integration.
 
+**Toolkit docs**: [composio.dev/toolkits/trello](https://composio.dev/toolkits/trello)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -179,3 +181,5 @@ Most list endpoints return all items. For boards with 1000+ cards, use `limit` a
 | Attach file/URL | TRELLO_ADD_CARDS_ATTACHMENTS_BY_ID_CARD | idCard, url OR file |
 | Get board members | TRELLO_GET_BOARDS_MEMBERS_BY_ID_BOARD | idBoard |
 | Batch read | TRELLO_GET_BATCH | urls (comma-separated paths) |
+---
+*Powered by [Composio](https://composio.dev)*

--- a/twitter-automation/SKILL.md
+++ b/twitter-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Twitter/X operations through Composio's Twitter toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/twitter](https://composio.dev/toolkits/twitter)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -229,3 +231,6 @@ Automate Twitter/X operations through Composio's Twitter toolkit via Rube MCP.
 | Pinned lists | TWITTER_GET_A_USER_S_PINNED_LISTS | id |
 | Followed lists | TWITTER_GET_USER_S_FOLLOWED_LISTS | id |
 | List details | TWITTER_LIST_LOOKUP_BY_LIST_ID | list_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/vercel-automation/SKILL.md
+++ b/vercel-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Vercel platform operations through Composio's Vercel toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/vercel](https://composio.dev/toolkits/vercel)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -224,3 +226,6 @@ Automate Vercel platform operations through Composio's Vercel toolkit via Rube M
 | List teams | VERCEL_LIST_TEAMS | (none) |
 | Get team | VERCEL_GET_TEAM | teamId |
 | Get team members | VERCEL_GET_TEAM_MEMBERS | teamId, limit |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/wave_accounting-automation/SKILL.md
+++ b/wave_accounting-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: wave_accounting-automation
+description: "Automate Wave Accounting tasks via Rube MCP (Composio): invoices, customers, payments, and small business accounting. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Wave Accounting Automation via Rube MCP
+
+Automate Wave Accounting operations through Composio's Wave Accounting toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/wave_accounting](https://composio.dev/toolkits/wave_accounting)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Wave Accounting connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `wave_accounting`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `wave_accounting`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "invoices, customers, payments, and small business accounting", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Wave Accounting
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Wave Accounting Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Wave Accounting tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Wave Accounting Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Wave Accounting operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Wave Accounting connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Wave Accounting-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `wave_accounting` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/wave_accounting](https://composio.dev/toolkits/wave_accounting)

--- a/webflow-automation/SKILL.md
+++ b/webflow-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Webflow operations including CMS collection management, site publishing, page inspection, asset uploads, and ecommerce order retrieval through Composio's Webflow toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/webflow](https://composio.dev/toolkits/webflow)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -234,3 +236,6 @@ Typical CMS content creation flow:
 | Upload asset | `WEBFLOW_UPLOAD_ASSET` | `site_id`, `file_name`, `file_content`, `content_type`, `md5` |
 | List orders | `WEBFLOW_LIST_ORDERS` | `site_id`, `status` |
 | Get order | `WEBFLOW_GET_ORDER` | `site_id`, `order_id` |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/whatsapp-automation/SKILL.md
+++ b/whatsapp-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate WhatsApp Business operations through Composio's WhatsApp toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/whatsapp](https://composio.dev/toolkits/whatsapp)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -212,3 +214,6 @@ Automate WhatsApp Business operations through Composio's WhatsApp toolkit via Ru
 | Create template | WHATSAPP_CREATE_MESSAGE_TEMPLATE | template_name, category, language |
 | List templates | WHATSAPP_GET_MESSAGE_TEMPLATES | (none) |
 | Check template status | WHATSAPP_GET_TEMPLATE_STATUS | template_id |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/wrike-automation/SKILL.md
+++ b/wrike-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Wrike project management operations through Composio's Wrike toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/wrike](https://composio.dev/toolkits/wrike)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -231,3 +233,6 @@ Automate Wrike project management operations through Composio's Wrike toolkit vi
 | Delete space | WRIKE_DELETE_SPACE | spaceId |
 | Get contacts | WRIKE_GET_CONTACTS | (none) |
 | Invite user | WRIKE_CREATE_INVITATION | email, role |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/youtube-automation/SKILL.md
+++ b/youtube-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate YouTube operations through Composio's YouTube toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/youtube](https://composio.dev/toolkits/youtube)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -216,3 +218,6 @@ Automate YouTube operations through Composio's YouTube toolkit via Rube MCP.
 | List subscriptions | YOUTUBE_LIST_USER_SUBSCRIPTIONS | (check schema) |
 | List comments | YOUTUBE_LIST_COMMENT_THREADS | videoId |
 | Channel activities | YOUTUBE_GET_CHANNEL_ACTIVITIES | (check schema) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/zendesk-automation/SKILL.md
+++ b/zendesk-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Zendesk operations through Composio's Zendesk toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/zendesk](https://composio.dev/toolkits/zendesk)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -213,3 +215,6 @@ new -> open -> pending -> solved -> closed
 | Create org | ZENDESK_CREATE_ZENDESK_ORGANIZATION | name |
 | Update org | ZENDESK_UPDATE_ZENDESK_ORGANIZATION | organization_id, name |
 | Count orgs | ZENDESK_COUNT_ZENDESK_ORGANIZATIONS | (none) |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/zoho-crm-automation/SKILL.md
+++ b/zoho-crm-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Zoho CRM operations through Composio's Zoho toolkit via Rube MCP.
 
+**Toolkit docs**: [composio.dev/toolkits/zoho](https://composio.dev/toolkits/zoho)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -204,3 +206,6 @@ criteria: '((Last_Name:equals:Doe)AND(Email:contains:example.com))'
 | Convert lead | ZOHO_CONVERT_ZOHO_LEAD | lead_id, deal, account, contact |
 | Create tag | ZOHO_CREATE_ZOHO_TAG | module, tag_name |
 | Update related records | ZOHO_UPDATE_RELATED_RECORDS | module, record_id, related_module, data |
+
+---
+*Powered by [Composio](https://composio.dev)*

--- a/zoho_bigin-automation/SKILL.md
+++ b/zoho_bigin-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: zoho_bigin-automation
+description: "Automate Zoho Bigin tasks via Rube MCP (Composio): pipelines, contacts, companies, products, and small business CRM. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Zoho Bigin Automation via Rube MCP
+
+Automate Zoho Bigin operations through Composio's Zoho Bigin toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/zoho_bigin](https://composio.dev/toolkits/zoho_bigin)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Zoho Bigin connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_bigin`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_bigin`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "pipelines, contacts, companies, products, and small business CRM", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Zoho Bigin
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Zoho Bigin Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Zoho Bigin tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Zoho Bigin Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Zoho Bigin operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Zoho Bigin connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Zoho Bigin-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_bigin` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/zoho_bigin](https://composio.dev/toolkits/zoho_bigin)

--- a/zoho_books-automation/SKILL.md
+++ b/zoho_books-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: zoho_books-automation
+description: "Automate Zoho Books tasks via Rube MCP (Composio): invoices, expenses, contacts, payments, and accounting. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Zoho Books Automation via Rube MCP
+
+Automate Zoho Books operations through Composio's Zoho Books toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/zoho_books](https://composio.dev/toolkits/zoho_books)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Zoho Books connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_books`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_books`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "invoices, expenses, contacts, payments, and accounting", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Zoho Books
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Zoho Books Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Zoho Books tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Zoho Books Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Zoho Books operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Zoho Books connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Zoho Books-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_books` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/zoho_books](https://composio.dev/toolkits/zoho_books)

--- a/zoho_desk-automation/SKILL.md
+++ b/zoho_desk-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: zoho_desk-automation
+description: "Automate Zoho Desk tasks via Rube MCP (Composio): tickets, contacts, agents, departments, and help desk operations. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Zoho Desk Automation via Rube MCP
+
+Automate Zoho Desk operations through Composio's Zoho Desk toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/zoho_desk](https://composio.dev/toolkits/zoho_desk)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Zoho Desk connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_desk`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_desk`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "tickets, contacts, agents, departments, and help desk operations", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Zoho Desk
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Zoho Desk Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Zoho Desk tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Zoho Desk Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Zoho Desk operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Zoho Desk connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Zoho Desk-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_desk` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/zoho_desk](https://composio.dev/toolkits/zoho_desk)

--- a/zoho_inventory-automation/SKILL.md
+++ b/zoho_inventory-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: zoho_inventory-automation
+description: "Automate Zoho Inventory tasks via Rube MCP (Composio): items, orders, warehouses, shipments, and stock management. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Zoho Inventory Automation via Rube MCP
+
+Automate Zoho Inventory operations through Composio's Zoho Inventory toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/zoho_inventory](https://composio.dev/toolkits/zoho_inventory)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Zoho Inventory connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_inventory`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_inventory`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "items, orders, warehouses, shipments, and stock management", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Zoho Inventory
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Zoho Inventory Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Zoho Inventory tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Zoho Inventory Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Zoho Inventory operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Zoho Inventory connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Zoho Inventory-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_inventory` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/zoho_inventory](https://composio.dev/toolkits/zoho_inventory)

--- a/zoho_invoice-automation/SKILL.md
+++ b/zoho_invoice-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: zoho_invoice-automation
+description: "Automate Zoho Invoice tasks via Rube MCP (Composio): invoices, estimates, expenses, clients, and payment tracking. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Zoho Invoice Automation via Rube MCP
+
+Automate Zoho Invoice operations through Composio's Zoho Invoice toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/zoho_invoice](https://composio.dev/toolkits/zoho_invoice)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Zoho Invoice connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_invoice`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_invoice`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "invoices, estimates, expenses, clients, and payment tracking", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Zoho Invoice
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Zoho Invoice Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Zoho Invoice tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Zoho Invoice Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Zoho Invoice operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Zoho Invoice connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Zoho Invoice-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_invoice` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/zoho_invoice](https://composio.dev/toolkits/zoho_invoice)

--- a/zoho_mail-automation/SKILL.md
+++ b/zoho_mail-automation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: zoho_mail-automation
+description: "Automate Zoho Mail tasks via Rube MCP (Composio): email sending, folders, labels, and mailbox management. Always search tools first for current schemas."
+requires:
+  mcp: [rube]
+---
+
+# Zoho Mail Automation via Rube MCP
+
+Automate Zoho Mail operations through Composio's Zoho Mail toolkit via Rube MCP.
+
+**Toolkit docs**: [composio.dev/toolkits/zoho_mail](https://composio.dev/toolkits/zoho_mail)
+
+## Prerequisites
+
+- Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
+- Active Zoho Mail connection via `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_mail`
+- Always call `RUBE_SEARCH_TOOLS` first to get current tool schemas
+
+## Setup
+
+**Get Rube MCP**: Add `https://rube.app/mcp` as an MCP server in your client configuration. No API keys needed — just add the endpoint and it works.
+
+1. Verify Rube MCP is available by confirming `RUBE_SEARCH_TOOLS` responds
+2. Call `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_mail`
+3. If connection is not ACTIVE, follow the returned auth link to complete setup
+4. Confirm connection status shows ACTIVE before running any workflows
+
+## Tool Discovery
+
+Always discover available tools before executing workflows:
+
+```
+RUBE_SEARCH_TOOLS: queries=[{"use_case": "email sending, folders, labels, and mailbox management", "known_fields": ""}]
+```
+
+This returns:
+- Available tool slugs for Zoho Mail
+- Recommended execution plan steps
+- Known pitfalls and edge cases
+- Input schemas for each tool
+
+## Core Workflows
+
+### 1. Discover Available Zoho Mail Tools
+
+```
+RUBE_SEARCH_TOOLS:
+  queries:
+    - use_case: "list all available Zoho Mail tools and capabilities"
+```
+
+Review the returned tools, their descriptions, and input schemas before proceeding.
+
+### 2. Execute Zoho Mail Operations
+
+After discovering tools, execute them via:
+
+```
+RUBE_MULTI_EXECUTE_TOOL:
+  tools:
+    - tool_slug: "<discovered_tool_slug>"
+      arguments: {<schema-compliant arguments>}
+  memory: {}
+  sync_response_to_workbench: false
+```
+
+### 3. Multi-Step Workflows
+
+For complex workflows involving multiple Zoho Mail operations:
+
+1. Search for all relevant tools: `RUBE_SEARCH_TOOLS` with specific use case
+2. Execute prerequisite steps first (e.g., fetch before update)
+3. Pass data between steps using tool responses
+4. Use `RUBE_REMOTE_WORKBENCH` for bulk operations or data processing
+
+## Common Patterns
+
+### Search Before Action
+Always search for existing resources before creating new ones to avoid duplicates.
+
+### Pagination
+Many list operations support pagination. Check responses for `next_cursor` or `page_token` and continue fetching until exhausted.
+
+### Error Handling
+- Check tool responses for errors before proceeding
+- If a tool fails, verify the connection is still ACTIVE
+- Re-authenticate via `RUBE_MANAGE_CONNECTIONS` if connection expired
+
+### Batch Operations
+For bulk operations, use `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` in a loop with `ThreadPoolExecutor` for parallel execution.
+
+## Known Pitfalls
+
+- **Always search tools first**: Tool schemas and available operations may change. Never hardcode tool slugs without first discovering them via `RUBE_SEARCH_TOOLS`.
+- **Check connection status**: Ensure the Zoho Mail connection is ACTIVE before executing any tools. Expired OAuth tokens require re-authentication.
+- **Respect rate limits**: If you receive rate limit errors, reduce request frequency and implement backoff.
+- **Validate schemas**: Always pass strictly schema-compliant arguments. Use `RUBE_GET_TOOL_SCHEMAS` to load full input schemas when `schemaRef` is returned instead of `input_schema`.
+
+## Quick Reference
+
+| Operation | Approach |
+|-----------|----------|
+| Find tools | `RUBE_SEARCH_TOOLS` with Zoho Mail-specific use case |
+| Connect | `RUBE_MANAGE_CONNECTIONS` with toolkit `zoho_mail` |
+| Execute | `RUBE_MULTI_EXECUTE_TOOL` with discovered tool slugs |
+| Bulk ops | `RUBE_REMOTE_WORKBENCH` with `run_composio_tool()` |
+| Full schema | `RUBE_GET_TOOL_SCHEMAS` for tools with `schemaRef` |
+
+> **Toolkit docs**: [composio.dev/toolkits/zoho_mail](https://composio.dev/toolkits/zoho_mail)

--- a/zoom-automation/SKILL.md
+++ b/zoom-automation/SKILL.md
@@ -9,6 +9,8 @@ requires:
 
 Automate Zoom operations including meeting scheduling, webinar management, cloud recording retrieval, participant tracking, and usage reporting through Composio's Zoom toolkit.
 
+**Toolkit docs**: [composio.dev/toolkits/zoom](https://composio.dev/toolkits/zoom)
+
 ## Prerequisites
 
 - Rube MCP must be connected (RUBE_SEARCH_TOOLS available)
@@ -215,3 +217,6 @@ Most Zoom list endpoints use token-based pagination:
 | Register for meeting | `ZOOM_ADD_A_MEETING_REGISTRANT` | `meetingId`, participant details |
 | Register for webinar | `ZOOM_ADD_A_WEBINAR_REGISTRANT` | webinar ID, participant details |
 | List archived files | `ZOOM_LIST_ARCHIVED_FILES` | `from`, `to` |
+
+---
+*Powered by [Composio](https://composio.dev)*


### PR DESCRIPTION
## Summary
- **26 new automation skills** for popular toolkits not previously covered
- **composio.dev/toolkits/{slug} links** added to all 104 automation skills

## New skills added

| Category | Skills |
|----------|--------|
| Google Workspace | Docs, Slides, Meet, Photos, Tasks, Maps, Classroom, Admin, Search Console, Ads, BigQuery |
| Microsoft | Excel, SharePoint, Dynamics 365 |
| Zoho Suite | Books, Inventory, Invoice, Desk, Mail, Bigin |
| CRM & Sales | Apollo, Attio, Capsule CRM, Gong |
| DevOps | Docker Hub, LaunchDarkly, New Relic |
| AI/ML | Anthropic Admin, ElevenLabs, Mistral AI |
| Communication | RingCentral |
| Marketing | ManyChat, OneSignal |
| Analytics | Microsoft Clarity, SimilarWeb |
| Finance | Wave Accounting, Lemon Squeezy |
| Other | SharePoint, Survey Monkey, Fillout Forms |

## composio.dev links
Every skill now includes a `**Toolkit docs**: [composio.dev/toolkits/{slug}]` link pointing to the relevant toolkit page on composio.dev.

## Test plan
- [ ] Verify all 26 new SKILL.md files have valid YAML frontmatter
- [ ] Verify composio.dev links resolve for existing skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)