### PR TITLE
Add disclaimer distinguishing Composio integrations from Claude Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
 
 A curated list of practical Claude Skills for enhancing productivity across Claude.ai, Claude Code, and the Claude API.
 
+> **Note on naming**: This repository contains **Composio platform integrations** for Claude - connecting Claude to 500+ external apps via the Composio SDK and API. These are distinct from [Claude Agent Skills](https://github.com/anthropics/skills) (SKILL.md format), which are self-contained instruction packages following the [AgentSkills.io specification](https://agentskills.io). For the official Claude Agent Skills, see the [anthropics/skills](https://github.com/anthropics/skills) repository.
+
 
 > **Want skills that do more than generate text?** Claude can send emails, create issues, post to Slack, and take actions across 1000+ apps. [See how →](./connect/)
 


### PR DESCRIPTION
## Summary

- Adds a prominent blockquote notice near the top of the README (after the repo description, before the quickstart section) clarifying the distinction between Composio platform integrations and Claude Agent Skills in the SKILL.md format
- Links to the [anthropics/skills](https://github.com/anthropics/skills) repository and [AgentSkills.io specification](https://agentskills.io) for developers looking for SKILL.md-format Agent Skills

## Context

Relates to #184

This repo is named "awesome-claude-skills" and the term "Claude Skills" is used throughout, which can create confusion with the established Claude Agent Skills ecosystem (SKILL.md format, AgentSkills.io spec, anthropics/skills repo with 68k+ stars). The core offering here is Composio platform integrations connecting Claude to 500+ apps via Composio SDK/API.

This small README addition helps developers quickly understand what this repo offers and where to find SKILL.md-format Agent Skills if that is what they are looking for.

## Changes

A single blockquote added to `README.md`:

> **Note on naming**: This repository contains **Composio platform integrations** for Claude - connecting Claude to 500+ external apps via the Composio SDK and API. These are distinct from [Claude Agent Skills](https://github.com/anthropics/skills) (SKILL.md format), which are self-contained instruction packages following the [AgentSkills.io specification](https://agentskills.io). For the official Claude Agent Skills, see the [anthropics/skills](https://github.com/anthropics/skills) repository.

## Test plan

- [ ] Verify the blockquote renders correctly on GitHub
- [ ] Confirm links to anthropics/skills and agentskills.io resolve properly
- [ ] Check that no existing content was removed or altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)