### PR TITLE
Add QASkills.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Playwright Browser Automation](https://github.com/lackeyjb/playwright-skill) - Model-invoked Playwright automation for testing and validating web applications. *By [@lackeyjb](https://github.com/lackeyjb)*
 - [prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering) - Teaches well-known prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
 - [pypict-claude-skill](https://github.com/omkamal/pypict-claude-skill) - Design comprehensive test cases using PICT (Pairwise Independent Combinatorial Testing) for requirements or code, generating optimized test suites with pairwise coverage.
+- [QASkills.sh](https://qaskills.sh) - Directory of 20+ curated QA testing skills for AI agents. E2E, API, unit, performance, security, accessibility testing patterns.
 - [reddit-fetch](https://github.com/ykdojo/claude-code-tips/tree/main/skills/reddit-fetch) - Fetches Reddit content via Gemini CLI when WebFetch is blocked or returns 403 errors.
 - [Skill Creator](./skill-creator/) - Provides guidance for creating effective Claude Skills that extend capabilities with specialized knowledge, workflows, and tool integrations.
 - [Skill Seekers](https://github.com/yusufkaraaslan/Skill_Seekers) - Automatically converts any documentation website into a Claude AI skill in minutes. *By [@yusufkaraaslan](https://github.com/yusufkaraaslan)*


### PR DESCRIPTION
## Summary

Adding QASkills.sh - a comprehensive directory of QA testing skills for Claude Code and AI agents.

## About QASkills.sh

- **Expert QA testing patterns** designed specifically for Claude and AI agents
- **20+ curated skills** covering all testing types:
  - E2E testing (Playwright, Cypress, Selenium)
  - API testing (REST Assured, Postman, Playwright API)
  - Unit testing (Jest, Pytest, Vitest)
  - Performance testing (k6, JMeter, Locust)
  - Security testing (OWASP, penetration testing)
  - Accessibility testing (WCAG, axe-core)
  - Visual regression testing
  - Contract testing (Pact)
  - BDD testing (Cucumber)
- **Easy CLI installation** via `npx @qaskills/cli add <skill-name>`
- **27+ AI agents supported** including Claude Code, Cursor, Cline, Windsurf, Copilot, and more
- **Open source, MIT licensed**
- **Built by The Testing Academy** (189K+ YouTube subscribers)

## Why This Belongs Here

QASkills.sh fits perfectly in the Development & Code Tools section alongside other testing skills. It provides battle-tested QA patterns that make AI agents more effective at test automation tasks.

## Changes Made

- Added QASkills.sh to the Development & Code Tools section
- Positioned alphabetically between pypict-claude-skill and reddit-fetch

## Links

- Website: https://qaskills.sh
- GitHub: https://github.com/PramodDutta/qaskills
- npm: https://npmjs.com/package/@qaskills/cli

Thank you for maintaining this excellent resource!