### PR TITLE
Add management-consulting to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Management Consulting](https://github.com/anotb/management-consulting-plugin) - 28 commands and 9 skills for the full consulting engagement lifecycle: strategic analysis, business development, implementation planning, and executive deliverables.
 
 ### Communication & Writing
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
-- [Management Consulting](https://github.com/anotb/management-consulting-plugin) - 28 commands and 9 skills for the full consulting engagement lifecycle: strategic analysis, business development, implementation planning, and executive deliverables.
+- [Management Consulting](https://github.com/anotb/management-consulting-plugin) - Skills for the full consulting engagement lifecycle: strategic analysis, financial modeling, due diligence, implementation planning, change management, and client deliverables.
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds a management consulting entry to the Business & Marketing section, linking to a standalone plugin with 28 commands and 9 skills for the full consulting engagement lifecycle.

Covers business development, strategic analysis, implementation planning, change management, and executive deliverables.

Plugin repo: https://github.com/anotb/management-consulting-plugin