### PR TITLE
Add wondelai/skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [wondelai/skills](https://github.com/wondelai/skills) - 25 agent skills for UX design, marketing, sales, product strategy, and business growth based on bestselling business books. *By [@wondelai](https://github.com/wondelai)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## What's being added
[wondelai/skills](https://github.com/wondelai/skills) — a collection of 25 agent skills for Claude Code covering UX design, marketing/CRO, sales psychology, product innovation, and business strategy.

## Why it's valuable
Each skill provides structured frameworks derived from established methodologies and bestselling books (Refactoring UI, Jobs to Be Done, StoryBrand, $100M Offers, Blue Ocean Strategy, etc.) with scoring rubrics, reference files, and actionable product application tables.

## Category
Business & Marketing — this is where the majority of the 25 skills naturally fit.

## Installation
```bash
npx skills add wondelai/skills
```

## License
MIT