### PR TITLE
Add Apple HIG Skills to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
+- [Apple HIG Skills](https://github.com/raintree-technology/apple-hig-skills) - Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS. *By [@raintree-technology](https://github.com/raintree-technology)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*


### PR DESCRIPTION
Adds [Apple HIG Skills](https://github.com/raintree-technology/apple-hig-skills) — 14 agent skills providing Apple Human Interface Guidelines for iOS, macOS, visionOS, watchOS, and tvOS design decisions. Covers platforms, foundations, components, patterns, inputs, and technologies.