### PR TITLE
Add web-search-skills to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [web-search-skills](https://github.com/kevmyung/web-search-skill) - Collection of zero-config search skills (DuckDuckGo web search, Wikipedia, ArXiv) with auto-setup venv and no API keys required. *By [@kevmyung](https://github.com/kevmyung)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
## What's being added

[web-search-skills](https://github.com/kevmyung/web-search-skill) — a collection of three zero-config search skills for Claude Code:

| Skill | Source | Description |
|-------|--------|-------------|
| **web-search** | DuckDuckGo | Web search + URL content fetching |
| **wikipedia-search** | Wikipedia API | Article search and retrieval |
| **arxiv-search** | ArXiv API | Scientific paper search and retrieval |

**Key features:**
- No API keys required — all three skills use free, public APIs
- Auto-setup venv and dependency installation on first run
- Works on macOS and Linux out of the box

**Installation:**
```bash
git clone https://github.com/kevmyung/web-search-skill.git /tmp/web-search-skill
cp -r /tmp/web-search-skill/skills/* ~/.claude/skills/
rm -rf /tmp/web-search-skill
```

## Category

Added to **Data & Analysis** section.