### PR TITLE
Add roadmap-pilot skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Collaboration & Project Management
 
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
+- [roadmap-pilot](https://github.com/antconsales/roadmap-pilot) - Roadmap-driven autopilot for incremental codebase cleanup. Two skills: /init-roadmap (scans project, generates phased roadmap in CLAUDE.md) and /roadmap (executes ONE task per session, commits, hands off). Includes autopilot mode, progress dashboard, rollback, 7 templates, and 30 tests. *By [@antconsales](https://github.com/antconsales)*
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.


### PR DESCRIPTION
## New Skill: roadmap-pilot

**Category:** Collaboration & Project Management
**Link:** https://github.com/antconsales/roadmap-pilot
**License:** MIT

### Description

Roadmap-driven autopilot for incremental codebase cleanup. Two complementary skills:

- **`/init-roadmap`** — Conversational planner: scans project, asks targeted questions, generates a phased CLAUDE.md roadmap
- **`/roadmap`** — Deterministic executor: reads CLAUDE.md, executes ONE task per session, marks done, commits, hands off

### Key Features

- One task per session prevents context overflow and hallucinations
- Auto-pilot mode (`claude -p` loop for unattended execution)
- Visual progress dashboard (`status.sh`)
- Safe rollback (`rollback.sh`)
- 7 ready-to-use templates (TypeScript, React, Python, monorepo, large refactor, bug fixing, general)
- 30 regression tests + GitHub Actions CI/CD
- Works with any cleanup: typing, refactoring, renaming, migrations

### How it works

```
/init-roadmap  →  CLAUDE.md  →  /roadmap
 (planning)       (contract)     (execution)
```

The CLAUDE.md acts as a contract between the two skills. One writes it, the other reads and executes from it.