### PR TITLE
Add EUrouter Integration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [EUrouter Integration](https://github.com/EUrouter/eurouter-skill) - Integrate EUrouter, an OpenAI-compatible AI gateway for EU/GDPR compliance with drop-in migration from OpenAI/OpenRouter, EU data residency controls, streaming, tool calling, and multi-model fallback. *By [@EUrouter](https://github.com/EUrouter)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds [EUrouter Integration](https://github.com/EUrouter/eurouter-skill) to the Development & Code Tools section.

EUrouter is an OpenAI-compatible AI gateway for EU/GDPR compliance. This skill covers drop-in migration from OpenAI/OpenRouter, EU data residency controls, streaming, tool calling, and multi-model fallback.

**Install:** `npx skills add eurouter/eurouter-skill`