### PR TITLE
Add commune skill to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
+- [commune](https://github.com/shanjairaj7/commune-skill) - Agent-native email inbox that gives any AI agent a permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks. By @shanjairaj7
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.


### PR DESCRIPTION
## Add commune — agent-native email inbox

**commune** gives AI agents their own permanent email address at `@commune.ai`, with a skill designed for Claude Code and the Claude API.

### What it does
- Gives any agent a persistent inbox at `orgname@commune.ai`
- Full send/receive via REST API with Ed25519 agent authentication (no human login required)
- Semantic search across emails, smart triage/labeling, and webhook support
- Agentless registration — agents self-register with a public key, no human approval needed

### Links
- Skill repo: https://github.com/shanjairaj7/commune-skill
- Homepage: https://commune.email

### Category
Added to **Communication & Writing** section, alphabetically after `brainstorming`.