### PR TITLE
Add translate skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [translate](https://github.com/FuHehe12/Nitro-Engine) - Natural, fluent Markdown translation using "translation as writing" philosophy. Multi-agent parallel processing for large documents, customizable glossary, locale-aware. *By [@FuHehe12](https://github.com/FuHehe12)*
 
 ### Creative & Media
 


### PR DESCRIPTION
## What problem it solves

  Machine translation often produces output that's "accurate but painful to read" — grammatically correct, yet stiff and
   unnatural. This skill treats translation as writing, not word conversion, producing text that feels native to the
  target language.

  ## Who uses this workflow

  - People translating long technical documents who care about readability
  - People frustrated by "technically correct but unnatural" translations
  - Developers reading English documentation in their native language

  ## Attribution/inspiration

  Inspired by translation theory: good translation isn't about word-for-word accuracy, but re-expressing meaning
  naturally in the target language.

  ## Example usage

  将 path/to/document.md 翻译为中文。

  Or batch translate:

  将 path/to/folder/ 下所有 Markdown 文件翻译为中文。

  ---

  Repository: https://github.com/FuHehe12/Nitro-Engine

  ---