### PR TITLE
Add Subtitle Pipeline skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
+- [Subtitle Pipeline](https://github.com/mxggle/subtitle-pipeline) - End-to-end subtitle processing for local media: list, extract, transcribe, translate, and merge multilingual subtitle tracks. *By [@mxggle](https://github.com/mxggle)*
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.


### PR DESCRIPTION
## Summary
Adds **Subtitle Pipeline** to the Creative & Media section of the README.

## Real-world use case
This skill helps process multilingual subtitles for local videos end-to-end:
- list subtitle tracks
- extract to SRT
- transcribe with Whisper
- translate via OpenAI-compatible APIs
- merge bilingual/multilingual tracks

## Who uses this workflow
Developers and language learners working with multilingual video content and subtitle tooling.

## Attribution
Created by @mxggle: https://github.com/mxggle/subtitle-pipeline

## Example usage
Install with:

```bash
npx skills add https://github.com/mxggle/subtitle-pipeline --skill subtitle-pipeline --yes
```
