### PR TITLE
feat: add github-trending-analyzer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [GitHub Trending Analyzer](https://github.com/jackjin1997/ClawForge/tree/main/skills/github-trending-analyzer) - Automated fetching and categorization of daily/weekly/monthly GitHub Trending projects. Perfect for staying updated on the Agentic Revolution.
+
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
Added a new skill for automated GitHub Trending analysis and categorization. This is specifically useful for Claude Code users to discover new tools and ecosystem shifts. Source: https://github.com/jackjin1997/ClawForge/tree/main/skills/github-trending-analyzer