### PR TITLE
Add Washin Claude Skills — 112 production-tested skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [Washin Claude Skills](https://github.com/sstklen/washin-claude-skills) — 112 battle-tested Claude Code skills from 200+ production bugs. Covers Docker/DevOps, API architecture, billing patterns, security audits, and Hono/Bun gotchas. One-command installer.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
## What

Adding [Washin Claude Skills](https://github.com/sstklen/washin-claude-skills) to the Development & Code Tools section.

## Highlights

- 112 skills extracted from 200+ real production bugs
- One-command installer: `curl -sL https://raw.githubusercontent.com/sstklen/washin-claude-skills/main/install.sh | bash`
- Categories: Docker/DevOps, API architecture, billing, security, Hono/Bun
- Built at an animal sanctuary in Japan running a production API platform
- MIT licensed