### PR TITLE
Add deapi-ai/claude-code-skills to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
+- [deapi-ai/claude-code-skills](https://github.com/deapi-ai/claude-code-skills) - AI media generation via natural language — image creation (Flux), text-to-speech, transcription, video generation, OCR, upscaling & background removal. Powered by [deAPI.ai](https://deapi.ai/) with $5 free credit, no credit card or subscription required. Also works with Cursor, Windsurf & Continue.dev.
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Hi! 👋

Adding [deapi-ai/claude-code-skills](https://github.com/deapi-ai/claude-code-skills) to the Creative & Media section.

**What it does:** A Claude Code skill that brings AI media generation into your coding workflow — image generation (Flux), text-to-speech, audio/video transcription, OCR, video generation, upscaling, and background removal. All via natural language.

**Why it fits:** Open-source skill (MIT license) that extends Claude Code with creative media capabilities. Also compatible with Cursor, Windsurf & Continue.dev.

**Easy to try:** $5 free credit on signup — no credit card required, no subscription. Just install and start generating.

Thanks for curating this list! 🙏