### PR TITLE
Add Presentation Chef to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Presentation Chef](https://github.com/sacredvoid/presentation-chef) - Converts any content into cinematic Apple Keynote-style HTML presentations with 5 themes, 13 slide types, speaker notes, and PDF export — all as a single self-contained `.html` file. *By [@sacredvoid](https://github.com/sacredvoid)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
Adds [Presentation Chef](https://github.com/sacredvoid/presentation-chef) to the **Creative & Media** section.

Presentation Chef converts any content into cinematic Apple Keynote-style HTML presentations as a single self-contained `.html` file with zero dependencies. Features 5 theme presets, 13 slide types, speaker notes sidebar, and PDF export.

Placed alphabetically between Image Enhancer and Slack GIF Creator.