### PR TITLE
Add agentskill.sh to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 ### Community Resources
 
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
+- [agentskill.sh](https://agentskill.sh) - Community skills directory with 44,000+ skills, security scanning, and cross-platform support
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
 


### PR DESCRIPTION
## Summary

Adds [agentskill.sh](https://agentskill.sh) to the Community Resources section.

**What it is:** A community skills directory with 44,000+ indexed skills, built-in security scanning (prompt injection, RCE, credential exfiltration detection), and cross-platform support (Claude Code, Codex, Cursor, Copilot, Windsurf, Cline, and more).

**Why add it:** Helps Claude users discover skills beyond this list and the official marketplace — with security checks before install.