### PR TITLE
Add BGPT MCP to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Data & Analysis
 
+- [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Search scientific papers via remote MCP server. Returns structured experimental data from full-text studies: methods, results, sample sizes, quality scores, and 25+ fields per paper. Free tier (50 searches), no API key needed. *By [@connerlambden](https://github.com/connerlambden)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) to the Data & Analysis section.

BGPT is a remote MCP server for searching scientific papers that returns structured experimental data from full-text studies — methods, results, sample sizes, quality scores, and 25+ metadata fields per paper. Free tier with 50 searches, no API key needed.

Setup is one line in your MCP config:
```json
{
  "mcpServers": {
    "bgpt": {
      "command": "npx",
      "args": ["mcp-remote", "https://bgpt.pro/mcp/sse"]
    }
  }
}
```

Listed in the [Official MCP Registry](https://registry.modelcontextprotocol.io).