### PR TITLE
Add chrome-store-publish - Chrome Web Store publishing automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [chrome-store-publish](https://github.com/ofelipelourenco/chrome-store-publish) - Automates Chrome extension preparation for Chrome Web Store publishing with 7-phase workflow (audit, cleanup, build, legal, listing, assets, validation).
 
 ### Data & Analysis
 


### PR DESCRIPTION
## chrome-store-publish

**Description:** Claude Code skill that automates Chrome extension preparation for Chrome Web Store publishing. 7-phase workflow from permission audit to submission-ready package.

**Repository:** https://github.com/ofelipelourenco/chrome-store-publish

**Key Features:**
- Automatic permission audit (flags unused APIs)
- MV3 compliance enforcement
- Clean production ZIP builder
- Privacy policy generator (GDPR-aware)
- Store listing copy writer
- Screenshot/asset generator (HTML → PNG via Playwright)
- 17-point pre-submission validation

**Use Case:** Chrome extension developers preparing for Chrome Web Store submission.

**Status:** Stable, fully documented, Apache 2.0 licensed.