### PR TITLE
Add tutor-skills skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [tutor-skills](https://github.com/RoundTable02/tutor-skills) - Turns PDFs, docs, and codebases into Obsidian study vaults with structured notes, practice questions, and an interactive quiz tutor tracking concept-level progress. *By [@RoundTable02](https://github.com/RoundTable02)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
## Summary

- Adds [tutor-skills](https://github.com/RoundTable02/tutor-skills) to the **Productivity & Organization** section
- Two Claude Code skills (`/tutor-setup` and `/tutor`) that turn any knowledge source (PDFs, docs, codebases) into an Obsidian StudyVault with structured notes, practice questions, and an interactive quiz tutor tracking concept-level progress
- **Document Mode**: Extracts content from PDFs/MD/HTML/EPUB, builds concept notes with comparison tables, ASCII diagrams, and 8+ practice questions per topic
- **Codebase Mode**: Auto-detects project type and generates new-developer onboarding vaults with module notes and exercises
- **Interactive Tutor**: Diagnostic assessments, drill weak areas, 4-question rounds with concept-level proficiency tracking

## Real-World Use Case

Students and developers use this to convert learning materials or unfamiliar codebases into structured, quiz-ready study systems inside Obsidian — enabling active recall and spaced repetition without manual note creation.

## Checklist

- [x] Entry added in alphabetical order within Productivity & Organization
- [x] Follows existing format: `[name](url) - description. *By [@user](profile)*`
- [x] Skill solves a real problem (active learning from any knowledge source)
- [x] No emojis in README entry