### PR TITLE
Add AgentWard to Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [AgentWard](https://github.com/agentward-ai/agentward) - Open-source permission control plane for AI agents — scans, enforces, and audits every tool call in code, not prompts.
 
 ### App Automation via Composio
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
-- [AgentWard](https://github.com/agentward-ai/agentward) - Open-source permission control plane for AI agents — scans, enforces, and audits every tool call in code, not prompts.
+- [AgentWard](https://github.com/agentward-ai/agentward) - Open-source runtime & compile-time enforcement layer for AI agents — scans, enforces, and audits every tool call in code, not prompts.
 
 ### App Automation via Composio
 


### PR DESCRIPTION
Adds [AgentWard](https://github.com/agentward-ai/agentward) — open-source permission control plane for AI agents.

Scans MCP servers, OpenClaw skills, and Python SDK tools, then enforces least-privilege policies at runtime in code (not prompts). Apache 2.0.

- `pip install agentward`
- [GitHub repo](https://github.com/agentward-ai/agentward)