### PR TITLE
Add design-to-code skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
+- [Design to code](https://github.com/MigoXLab/coderio/tree/main/skills/design-to-code) - High-fidelity UI restoration from Figma designs to production-ready React + TypeScript components.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*
 - [FFUF Web Fuzzing](https://github.com/jthack/ffuf_claude_skill) - Integrates the ffuf web fuzzer so Claude can run fuzzing tasks and analyze results for vulnerabilities. *By [@jthack](https://github.com/jthack)*
 - [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.

--- a/design-to-code/LICENSE.txt
+++ b/design-to-code/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/design-to-code/SKILL.md
+++ b/design-to-code/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: design-to-code
+description: Convert Figma designs to pixel-perfect, production-ready React + TypeScript components using coderio. Features robust error handling, checkpoint recovery, and a streamlined helper script workflow.
+---
+
+# Design to Code
+
+High-fidelity UI restoration from Figma designs to production-ready React + TypeScript components.
+This skill uses a **robust helper script** to minimize manual errors and ensure pixel-perfect results with TailwindCSS V4.
+
+## When to Use This Skill
+
+- You have a Figma design URL and want to generate a working React component
+- You need pixel-perfect conversion of UI designs to production code
+- You want a guided, step-by-step process for extracting design structure and props before generating code
+
+## What This Skill Does
+
+1. **Setup**: Initializes the coderio helper script and project environment
+2. **Protocol Extraction**: Analyzes the Figma design to generate component structure and extract props with visual accuracy
+3. **Code Generation**: Produces production-ready React + TypeScript components that match the design exactly
+
+## How to Use
+
+### Prerequisites
+
+1. **Figma API Token**: Get from Figma → Settings → Personal Access Tokens
+2. **Node.js**: Version 18+
+3. **coderio**: Installed in `scripts/` folder (handled by Setup phase)
+
+
+### Basic Usage
+
+```
+Use design-to-code skill to convert this design: [Your Figma URL]
+The Agent will guide you step-by-step through protocol extraction and code generation.
+```
+
+---
+
+## Workflow Overview
+
+```
+Phase 0: SETUP    → Create helper script and script environment
+Phase 1: PROTOCOL → Generate design protocol (Structure & Props)
+Phase 2: CODE     → Generate components and assets
+```
+
+---
+
+# Phase 0: Setup
+
+## Step 0.1: Initialize Helper Script
+
+**User Action**: Run these commands to create the execution helper and isolate its dependencies.
+
+```bash
+mkdir -p scripts
+
+# 1. Copy script files
+# Note: Ensure you have the 'skills/design-to-code/scripts' directory available
+cp skills/design-to-code/scripts/package.json scripts/package.json
+cp skills/design-to-code/scripts/coderio-skill.mjs scripts/coderio-skill.mjs
+
+# 2. Install coderio in scripts directory (adjust version if needed)
+cd scripts && pnpm install && cd ..
+```
+
+## Step 0.2: Scaffold Project (Optional)
+
+If starting a new project:
+
+1. Run: `node scripts/coderio-skill.mjs scaffold-prompt "MyApp"`
+2. **AI Task**: Follow the instructions output by the command to create files.
+
+---
+
+# Phase 1: Protocol Generation
+
+## Step 1.1: Fetch Data
+
+```bash
+# Replace with your URL and Token
+node scripts/coderio-skill.mjs fetch-figma "https://figma.com/file/..." "figd_..."
+```
+
+**Verify**: `process/thumbnail.png` should exist.
+
+## Step 1.2: Generate Structure
+
+1. **Generate Prompt**:
+
+    ```bash
+    node scripts/coderio-skill.mjs structure-prompt > scripts/structure-prompt.md
+    ```
+
+2. **AI Task (Structure)**:
+    - **ATTACH**: `process/thumbnail.png` (MANDATORY)
+    - **READ**: `scripts/structure-prompt.md`
+    - **INSTRUCTION**: "Generate the component structure JSON based on the prompt and the attached thumbnail. Focus on visual grouping. **Use text content to name components accurately (e.g. 'SafeProducts', not 'FAQ').**"
+    - **SAVE**: Paste the JSON result into `scripts/structure-output.json`.
+
+3. **Process Result**:
+    ```bash
+    node scripts/coderio-skill.mjs save-structure
+    ```
+
+## Step 1.3: Extract Props (Iterative)
+
+1. **List Components**:
+
+    ```bash
+    node scripts/coderio-skill.mjs list-components
+    ```
+
+2. **For EACH component in the list**:
+
+    a. **Generate Prompt**:
+
+    ```bash
+    node scripts/coderio-skill.mjs props-prompt "ComponentName" > scripts/current-props-prompt.md
+    ```
+
+    b. **AI Task (Props)**:
+    - **ATTACH**: `process/thumbnail.png` (MANDATORY)
+    - **READ**: `scripts/current-props-prompt.md`
+    - **INSTRUCTION**: "Extract props and state data. Be pixel-perfect with text and image paths."
+    - **SAVE**: Paste the JSON result into `scripts/ComponentName-props.json`.
+
+    c. **Save & Validate**:
+
+    ```bash
+    node scripts/coderio-skill.mjs save-props "ComponentName"
+    # If this fails, re-do step 'b' with better attention to the thumbnail
+    ```
+
+---
+
+# Phase 2: Code Generation
+
+## Step 2.1: Plan Tasks
+
+```bash
+node scripts/coderio-skill.mjs list-gen-tasks
+```
+
+This outputs a list of tasks with indices (0, 1, 2...).
+
+## Step 2.2: Generate Components (Iterative)
+
+**For EACH task index (starting from 0)**:
+
+1. **Generate Prompt**:
+
+    ```bash
+    node scripts/coderio-skill.mjs code-prompt 0 > scripts/code-prompt.md
+    # Replace '0' with current task index
+    ```
+
+2. **AI Task (Code)**:
+    - **ATTACH**: `process/thumbnail.png` (MANDATORY)
+    - **READ**: `scripts/code-prompt.md`
+    - **INSTRUCTION**: "Generate the React component code. Match the thumbnail EXACTLY. **Use STRICT text content from input data, do not hallucinate.**"
+    - **SAVE**: Paste the code block into `scripts/code-output.txt`.
+
+3. **Save Code**:
+    ```bash
+    node scripts/coderio-skill.mjs save-code 0
+    # Replace '0' with current task index
+    ```
+
+## Step 2.3: Final Integration
+
+Inject the root component into `App.tsx`. Use the path found in the last task of Phase 2.1.
+
+---
+
+# Troubleshooting
+
+- **"Props validation failed"**: The AI generated empty props. Check if `process/thumbnail.png` was attached and visible to the AI. Retry the props generation step.
+- **"Module not found"**: Ensure `node scripts/coderio-skill.mjs save-code` was run for the child component before the parent component. Phase 2 must be done in order (0, 1, 2...).
+- **"Visuals don't match"**: Did you attach the thumbnail? The AI relies on it for spacing and layout nuances not present in the raw data.

--- a/design-to-code/scripts/coderio-skill.mjs
+++ b/design-to-code/scripts/coderio-skill.mjs
@@ -1,0 +1,300 @@
+import fs from 'fs';
+import path from 'path';
+import {
+    parseFigmaUrl, executeFigmaAndImagesActions, figmaTool, downloadImage,
+    extractNodePositionsHierarchical, generateStructurePrompt, extractJSON,
+    postProcessStructure, extractComponentGroups, simplifyFigmaNodeForContent,
+    extractDataListPrompt,
+    flattenPostOrder, detectRenderingModes, generateFramePrompt, generateComponentPrompt,
+    DEFAULT_STYLING, saveGeneratedCode, workspaceManager,
+    toKebabCase, toPascalCase, INITIAL_AGENT_SYSTEM_PROMPT, initialAgentInstruction
+} from 'coderio';
+
+const [,, command, ...args] = process.argv;
+const appPath = process.cwd();
+const processDir = path.join(appPath, 'process');
+const scriptsDir = path.join(appPath, 'scripts');
+const assetsDir = path.join(appPath, 'src/assets');
+
+// Ensure directories exist
+[processDir, scriptsDir, assetsDir].forEach(d => {
+    if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
+});
+
+function extractAllComponentGroups(node) {
+    const groups = new Map();
+    function traverse(currentNode) {
+        const localGroups = extractComponentGroups(currentNode);
+        for (const [name, list] of localGroups) {
+            if (!groups.has(name)) groups.set(name, []);
+            groups.get(name).push(...list);
+        }
+        if (currentNode.children) {
+            currentNode.children.forEach(traverse);
+        }
+    }
+    traverse(node);
+    return groups;
+}
+
+function findParentOfGroup(root, componentName) {
+    let result = null;
+    function traverse(node) {
+        if (result) return;
+        if (node.children && node.children.some(c => c.data.componentName === componentName)) {
+            result = node;
+            return;
+        }
+        if (node.children) node.children.forEach(traverse);
+    }
+    traverse(root);
+    return result;
+}
+
+function applyPropsAndStateToProtocol(parsed, node, compName, group, isList) {
+    if (parsed && parsed.state && Array.isArray(parsed.state)) {
+        if (isList) {
+            if (!node.data.states) {
+                node.data.states = [];
+            }
+
+            node.data.states = node.data.states.filter(s => s.componentName !== compName);
+
+            node.data.states.push({
+                state: parsed.state,
+                componentName: compName,
+                componentPath: group[0]?.data.componentPath || '',
+            });
+
+            const originalChildren = node.children || [];
+            const newChildren = [];
+            const processedComponentNames = new Set();
+
+            for (const child of originalChildren) {
+                const childName = child.data.componentName;
+                if (childName === compName) {
+                    if (!processedComponentNames.has(childName)) {
+                        child.data.name = childName;
+                        child.id = childName;
+                        const cleanKebabName = toKebabCase(childName);
+                        child.data.kebabName = cleanKebabName;
+                        delete child.data.path;
+
+                        if (parsed.props && Array.isArray(parsed.props)) {
+                            child.data.props = parsed.props;
+                        }
+
+                        newChildren.push(child);
+                        processedComponentNames.add(childName);
+                    }
+                } else {
+                    newChildren.push(child);
+                }
+            }
+
+            node.children = newChildren;
+        }
+    }
+}
+
+async function main() {
+    try {
+        switch (command) {
+            case 'scaffold-prompt': {
+                console.log(INITIAL_AGENT_SYSTEM_PROMPT);
+                console.log('\n--- INSTRUCTION ---\n');
+                console.log(initialAgentInstruction({ appPath, appName: args[0] || 'MyApp' }));
+                break;
+            }
+
+            case 'fetch-figma': {
+                const [figmaUrl, figmaToken] = args;
+                if (!figmaUrl || !figmaToken) throw new Error('Usage: fetch-figma <url> <token>');
+
+                const urlInfo = parseFigmaUrl(figmaUrl);
+                console.log('Fetching Figma document...');
+                const { document, imageNodesMap } = await executeFigmaAndImagesActions(urlInfo, assetsDir, processDir, figmaToken);
+
+                const simplified = figmaTool.simplifyImageNodes(document, imageNodesMap);
+                const processed = figmaTool.processedStyle(simplified);
+                fs.writeFileSync(path.join(processDir, 'processed.json'), JSON.stringify(processed, null, 2));
+
+                if (processed.thumbnailUrl) {
+                    console.log('Downloading thumbnail...');
+                    const base64 = await downloadImage(processed.thumbnailUrl, undefined, undefined, true);
+                    fs.writeFileSync(path.join(processDir, 'thumbnail.png'), Buffer.from(base64, 'base64'));
+                    console.log('Thumbnail saved to process/thumbnail.png');
+                }
+                console.log('Figma data processed.');
+                break;
+            }
+
+            case 'structure-prompt': {
+                const procDoc = JSON.parse(fs.readFileSync(path.join(processDir, 'processed.json'), 'utf-8'));
+                const frames = procDoc.frames || procDoc.children;
+                const positions = extractNodePositionsHierarchical(frames);
+                const prompt = generateStructurePrompt({
+                    positions: JSON.stringify(positions, null, 2),
+                    width: String(procDoc.absoluteBoundingBox?.width || 1440)
+                });
+                console.log(prompt);
+                break;
+            }
+
+            case 'save-structure': {
+                const structureJson = fs.readFileSync(path.join(scriptsDir, 'structure-output.json'), 'utf-8');
+                const pDoc = JSON.parse(fs.readFileSync(path.join(processDir, 'processed.json'), 'utf-8'));
+
+                const parsed = JSON.parse(extractJSON(structureJson));
+                const structFrames = pDoc.frames || pDoc.children;
+                postProcessStructure(parsed, structFrames);
+
+                const protocol = Array.isArray(parsed) ? parsed[0] : parsed;
+                fs.writeFileSync(path.join(processDir, 'protocol.json'), JSON.stringify(protocol, null, 2));
+                console.log('Structure saved to process/protocol.json');
+                break;
+            }
+
+            case 'list-components': {
+                const prot = JSON.parse(fs.readFileSync(path.join(processDir, 'protocol.json'), 'utf-8'));
+                const groups = extractAllComponentGroups(prot);
+                const list = Array.from(groups.keys()).map(name => {
+                    return { name, count: groups.get(name).length };
+                });
+                fs.writeFileSync(path.join(scriptsDir, 'component-list.json'), JSON.stringify(list, null, 2));
+                console.log(JSON.stringify(list, null, 2));
+                break;
+            }
+
+            case 'props-prompt': {
+                const compName = args[0];
+                const prot2 = JSON.parse(fs.readFileSync(path.join(processDir, 'protocol.json'), 'utf-8'));
+                const groups2 = extractAllComponentGroups(prot2);
+                const group = groups2.get(compName);
+                if (!group) throw new Error(`Component ${compName} not found`);
+
+                const instances = group.flatMap(g => g.data.elements || []);
+                const simpleNodes = instances
+                    .filter(n => typeof n === 'object' && n !== null)
+                    .map(n => simplifyFigmaNodeForContent(n));
+
+                console.log(extractDataListPrompt({
+                    containerName: prot2.data.name || 'Container',
+                    childComponentName: compName,
+                    figmaData: JSON.stringify(simpleNodes, null, 2)
+                }));
+                break;
+            }
+
+            case 'save-props': {
+                const cName = args[0];
+                const propsJsonPath = path.join(scriptsDir, `${cName}-props.json`);
+                const propsJson = fs.readFileSync(propsJsonPath, 'utf-8');
+                const parsedProps = JSON.parse(extractJSON(propsJson));
+
+                if (!parsedProps.props || parsedProps.props.length === 0) {
+                    throw new Error('Validation Failed: Props array is empty.');
+                }
+
+                const prot3 = JSON.parse(fs.readFileSync(path.join(processDir, 'protocol.json'), 'utf-8'));
+                const groups3 = extractAllComponentGroups(prot3);
+                const group3 = groups3.get(cName);
+
+                const parentNode = findParentOfGroup(prot3, cName);
+                if (parentNode) {
+                    applyPropsAndStateToProtocol(parsedProps, parentNode, cName, group3, true);
+                    fs.writeFileSync(path.join(processDir, 'protocol.json'), JSON.stringify(prot3, null, 2));
+                    console.log(`Props applied to ${cName} (Parent: ${parentNode.data.name || parentNode.id})`);
+                } else {
+                    console.error(`Parent not found for ${cName}`);
+                }
+                break;
+            }
+
+            case 'list-gen-tasks': {
+                const prot4 = JSON.parse(fs.readFileSync(path.join(processDir, 'protocol.json'), 'utf-8'));
+                const flat = flattenPostOrder(prot4);
+                const tasks = flat.map((node, i) => ({
+                    index: i,
+                    name: node.data.name || node.data.componentName,
+                    path: node.data.path || node.data.componentPath,
+                    isLeaf: !node.children?.length
+                }));
+                fs.writeFileSync(path.join(scriptsDir, 'gen-tasks.json'), JSON.stringify(tasks, null, 2));
+                console.log(JSON.stringify(tasks, null, 2));
+                break;
+            }
+
+            case 'code-prompt': {
+                const idx = parseInt(args[0]);
+                const prot5 = JSON.parse(fs.readFileSync(path.join(processDir, 'protocol.json'), 'utf-8'));
+                const flat2 = flattenPostOrder(prot5);
+                const node = flat2[idx];
+                const assets = fs.readdirSync(assetsDir).join(', ');
+
+                let prompt = '';
+                if (!node.children?.length) {
+                    prompt = generateComponentPrompt({
+                        componentName: node.data.name || node.data.componentName,
+                        componentDetails: JSON.stringify(node.data, null, 2),
+                        styling: JSON.stringify(DEFAULT_STYLING),
+                        assetFiles: assets
+                    });
+                } else {
+                    const imports = node.children.map(c => ({
+                        name: c.data.name,
+                        path: c.data.path || c.data.componentPath
+                    }));
+                    const modes = detectRenderingModes(node);
+                    prompt = generateFramePrompt({
+                        frameDetails: JSON.stringify(node.data, null, 2),
+                        childrenImports: JSON.stringify(imports, null, 2),
+                        styling: JSON.stringify(DEFAULT_STYLING),
+                        assetFiles: assets,
+                        renderingModes: modes
+                    });
+                }
+
+                // Add instruction for Asset Imports in State
+                if (node.data.states && node.data.states.length > 0) {
+                    prompt += `\n\n<asset_imports_instruction>
+The 'states' data contains references to assets (e.g. "@/assets/foo.png").
+You MUST:
+1. Import these assets at the top of the file: \`import image_foo from '@/assets/foo.png';\`
+2. In the \`states\` array in your code, use the variable \`image_foo\` instead of the string.
+   Example: \`imageSrc: image_foo\` (NOT \`imageSrc: "@/assets/foo.png"\`)
+</asset_imports_instruction>`;
+                }
+
+                console.log(prompt);
+                break;
+            }
+
+            case 'save-code': {
+                const idx2 = parseInt(args[0]);
+                const codePath = path.join(scriptsDir, 'code-output.txt');
+                const code = fs.readFileSync(codePath, 'utf-8');
+
+                const prot6 = JSON.parse(fs.readFileSync(path.join(processDir, 'protocol.json'), 'utf-8'));
+                const flat3 = flattenPostOrder(prot6);
+                const node2 = flat3[idx2];
+
+                const componentPath = node2.data.path || node2.data.componentPath;
+                if (!componentPath) throw new Error(`Node ${node2.data.name} has no path`);
+
+                const compDir = path.join(appPath, 'src', workspaceManager.resolveComponentPath(componentPath));
+                saveGeneratedCode(code, compDir);
+                console.log(`Code saved to ${compDir}`);
+                break;
+            }
+
+            default:
+                console.log('Unknown command');
+        }
+    } catch (e) {
+        console.error('Error:', e.message);
+        process.exit(1);
+    }
+}
+
+main();

--- a/design-to-code/scripts/package.json
+++ b/design-to-code/scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "coderio-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "coderio": "latest"
+  }
+}


### PR DESCRIPTION
# What problem it solves
Translating a Figma design into production code is one of the most tedious and error-prone steps in frontend development. Developers typically spend hours manually inspecting layouts, copying text, measuring spacing, and writing boilerplate component code — often producing results that drift visually from the original design.
This skill solves that by giving a structured, multi-phase protocol to convert any Figma design into pixel-perfect, production-ready React + TypeScript components. It uses a helper script (coderio-skill.mjs) to orchestrate data extraction, structure analysis, props generation, and code output — minimizing hallucination and maximizing visual fidelity.
# Who uses this workflow
Frontend developers and design engineers who work with Figma designs and need to ship React UIs quickly. It's especially useful for teams that want a repeatable, AI-assisted handoff process from design to code without relying on fragile one-shot prompts.
# Attribution / Inspiration
This skill is built on top of [coderio](https://github.com/MigoXLab/coderio), an open-source design-to-code engine. The workflow and helper script (coderio-skill.mjs) are adapted from the skills/design-to-code directory of the coderio repository.
# Example of how it's used
Get [Figma Personal Access Token](https://www.figma.com/developers/api#access-tokens).
Use design-to-code skill to convert this design: https://figma.com/your-figma-design-url. The Agent will guide you step-by-step through protocol extraction and code generation.
- Run fetch-figma to pull the design and generate a thumbnail
- Analyze the layout structure and extract component hierarchy
- Iteratively extract props for each component using the thumbnail as visual ground truth
- Generate React + TypeScript components (TailwindCSS V4) in dependency order
- Inject the root component into App.tsx