### PR TITLE
Add Temporal Cortex skills (datetime + scheduling + router + calendar-scheduling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ Pre-built workflow skills for 78 SaaS apps via [Rube MCP (Composio)](https://com
 - [Calendly Automation](./calendly-automation/) - Automate Calendly: events, invitees, event types, scheduling links, and availability.
 - [Google Calendar Automation](./google-calendar-automation/) - Automate Google Calendar: events, attendees, free/busy, and recurring schedules.
 - [Outlook Calendar Automation](./outlook-calendar-automation/) - Automate Outlook Calendar: events, attendees, reminders, and recurring schedules.
+- [Temporal Cortex](https://github.com/temporal-cortex/skills/tree/main/skills/temporal-cortex) - Route to datetime or scheduling sub-skills for calendar management across Google, Outlook, and CalDAV. 12 tools, 5 layers. *By [@temporal-cortex](https://github.com/temporal-cortex)*
+- [Temporal Cortex Datetime](https://github.com/temporal-cortex/skills/tree/main/skills/temporal-cortex-datetime) - Convert timezones, resolve natural language times, compute durations, and adjust timestamps with DST awareness. Zero-setup, no credentials needed. *By [@temporal-cortex](https://github.com/temporal-cortex)*
+- [Temporal Cortex Scheduling](https://github.com/temporal-cortex/skills/tree/main/skills/temporal-cortex-scheduling) - List events, find free slots, and book meetings across Google Calendar, Outlook, and CalDAV with Two-Phase Commit conflict prevention. *By [@temporal-cortex](https://github.com/temporal-cortex)*
 
 **Social Media**
 - [Instagram Automation](./instagram-automation/) - Automate Instagram: posts, stories, comments, media, and business insights.

--- a/README.md
+++ b/README.md
@@ -257,10 +257,11 @@ Pre-built workflow skills for 78 SaaS apps via [Rube MCP (Composio)](https://com
 
 **Calendar & Scheduling**
 - [Cal.com Automation](./cal-com-automation/) - Automate Cal.com: event types, bookings, availability, and scheduling.
+- [Calendar Scheduling](https://github.com/temporal-cortex/skills/tree/main/skills/calendar-scheduling) - Schedule meetings, check availability, and manage calendars across Google, Outlook, and CalDAV. Alias for Temporal Cortex router — same 15 tools, kept for discoverability. *By [@temporal-cortex](https://github.com/temporal-cortex)*
 - [Calendly Automation](./calendly-automation/) - Automate Calendly: events, invitees, event types, scheduling links, and availability.
 - [Google Calendar Automation](./google-calendar-automation/) - Automate Google Calendar: events, attendees, free/busy, and recurring schedules.
 - [Outlook Calendar Automation](./outlook-calendar-automation/) - Automate Outlook Calendar: events, attendees, reminders, and recurring schedules.
-- [Temporal Cortex](https://github.com/temporal-cortex/skills/tree/main/skills/temporal-cortex) - Route to datetime or scheduling sub-skills for calendar management across Google, Outlook, and CalDAV. 12 tools, 5 layers. *By [@temporal-cortex](https://github.com/temporal-cortex)*
+- [Temporal Cortex](https://github.com/temporal-cortex/skills/tree/main/skills/temporal-cortex) - Route to datetime or scheduling sub-skills for calendar management across Google, Outlook, and CalDAV. 15 tools, 5 layers. *By [@temporal-cortex](https://github.com/temporal-cortex)*
 - [Temporal Cortex Datetime](https://github.com/temporal-cortex/skills/tree/main/skills/temporal-cortex-datetime) - Convert timezones, resolve natural language times, compute durations, and adjust timestamps with DST awareness. Zero-setup, no credentials needed. *By [@temporal-cortex](https://github.com/temporal-cortex)*
 - [Temporal Cortex Scheduling](https://github.com/temporal-cortex/skills/tree/main/skills/temporal-cortex-scheduling) - List events, find free slots, and book meetings across Google Calendar, Outlook, and CalDAV with Two-Phase Commit conflict prevention. *By [@temporal-cortex](https://github.com/temporal-cortex)*
 


### PR DESCRIPTION
## New Skills: Temporal Cortex (Calendar Scheduling) — v0.7.5

**Repository:** https://github.com/temporal-cortex/skills
**Category:** Calendar & Scheduling
**License:** MIT

### What it does

4 skills that teach AI agents how to work with calendars through the Temporal Cortex MCP server:

| Skill | Tools | Setup | Description |
|-------|-------|-------|-------------|
| **Temporal Cortex** | 15 (all) | — | Router: routes to the right sub-skill based on user intent |
| **Temporal Cortex Datetime** | 5 | Zero-setup | Timezone conversion, natural language time resolution, duration math |
| **Temporal Cortex Scheduling** | 11 | OAuth | Calendar discovery, events, free slots, availability, open scheduling, booking |
| **Calendar Scheduling** | 15 (all) | — | Legacy alias for the router — kept for discoverability |

Split at the **credential boundary**: datetime tools are pure computation (zero-setup), scheduling tools need OAuth (Google/Outlook/CalDAV).

### Key capabilities

- **15 tools across 5 layers:** discovery → temporal context → calendar ops → availability → booking
- **Multi-provider:** Google Calendar, Outlook, and CalDAV simultaneously
- **Temporal intelligence:** Resolves 60+ natural language time expressions, DST-aware
- **Cross-calendar availability:** Merge busy/free across providers with privacy modes
- **Safe booking:** Atomic event creation with Two-Phase Commit conflict prevention
- **Open Scheduling (v0.7.5):** Agent-to-agent scheduling via public availability and booking requests

Works across Claude Code, Claude Desktop, Cursor, Windsurf, and 20+ other MCP-compatible platforms.

**MCP Server:** [@temporal-cortex/cortex-mcp](https://www.npmjs.com/package/@temporal-cortex/cortex-mcp)

### Checklist

- [x] Based on real use case (calendar scheduling for AI agents)
- [x] Well-documented (SKILL.md + reference docs + README)
- [x] Tested with Claude Code
- [x] Safe (conflict-checked booking with confirmation)
- [x] Portable across 26+ platforms
- [x] Entries follow existing Calendar & Scheduling format
- [x] Alphabetical order maintained

> Replaces #242 (closed — project restructured from single skill to multi-skill layout, migrated to `temporal-cortex` org)