### PR TITLE
Add x-twitter-scraper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X (Twitter) real-time data platform skill: tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, monitoring, webhooks, and 19 extraction tools via MCP server. *By [@Xquik-dev](https://github.com/Xquik-dev)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) to the Data & Analysis section.

It's an MCP server skill for pulling data from X/Twitter — tweet search, user profiles, follower lists, engagement stats, giveaway draws, account monitoring, webhooks, and 19 different extraction tools. Built on the Xquik platform.

Placed alphabetically after root-cause-tracing in Data & Analysis.