### PR TITLE
Add dna-claude-analysis to Data & Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) - Personal genome analysis toolkit with Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, and more) and generating a terminal-style single-page HTML visualization. *By [@shmlkv](https://github.com/shmlkv)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 


### PR DESCRIPTION
## What

Adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the **Data & Analysis** section.

## Description

Personal genome analysis toolkit with Python scripts that analyze raw DNA data across 17 categories:

- Health risks, ancestry, pharmacogenomics
- Nutrition, psychology, cognitive traits
- Longevity, sleep, immunity, pain sensitivity
- Detoxification, skin, vision/hearing, physical traits
- Carrier status, sports/fitness

Outputs a terminal-style single-page HTML visualization (inline CSS/JS, no external dependencies beyond Google Fonts).

## Checklist

- [x] Based on a real use case
- [x] No duplicate in existing skills
- [x] Entry placed alphabetically within section
- [x] Link points to public GitHub repository