### PR TITLE
Add claude-skill-notepad to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Productivity & Organization
 
+- [claude-skill-notepad](https://github.com/crfgxr/claude-skill-notepad) - Opens a notepad.md file in a vertical iTerm2 split for your current project. Supports nano and vim. Auto-creates a structured template on first run.
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
## Summary

Adds [claude-skill-notepad](https://github.com/crfgxr/claude-skill-notepad) to the Productivity & Organization section.

This skill opens a `notepad.md` file in a vertical iTerm2 split for the current project. It supports nano (default) and vim editors, and auto-creates a structured template on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)