### PR TITLE
Add OpenPaw to Productivity & Organization skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
+- [OpenPaw](https://github.com/daxaur/openpaw) - Turns Claude Code into a personal assistant with 38 skills for email, calendar, Spotify, smart home, Slack, GitHub, and more. CLI install via `npx pawmode`. *By [@daxaur](https://github.com/daxaur)*
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.


### PR DESCRIPTION
Adds [OpenPaw](https://github.com/daxaur/openpaw) to the Productivity & Organization section.

OpenPaw turns Claude Code into a personal assistant with 38 skills covering email, calendar, Spotify, smart home, Slack, GitHub, and more. Install via `npx pawmode` — no daemon, no cloud, MIT licensed.