### PR TITLE
Add founder-toolkit: startup skills for founders

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Founder Toolkit](https://github.com/mooster/founder-toolkit) - 4 production skills for startup founders: investor update writer (YC/a16z format), pitch deck reviewer (10-dimension scoring), SaaS metrics dashboard (ARR/NRR/LTV with benchmarks), and outreach lead scorer. Built from real ops running a $120B+ AUM fintech. *By [@mooster](https://github.com/mooster)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds **[founder-toolkit](https://github.com/mooster/founder-toolkit)** to the Business & Marketing section.

4 production skills for startup founders:
- **investor-update** — Generate professional investor updates (YC/a16z format, EN/中文)
- **pitch-reviewer** — Review pitch decks with 10-dimension VC scoring rubric (1-5 each)
- **startup-metrics** — Full SaaS metrics suite (ARR, NRR, LTV, CAC, burn multiple, runway) with OpenView/Bessemer/SaaStr benchmarks
- **lead-scorer** — Score outreach leads with ICP methodology + 3-layer email verification

Built from real operational experience running a $120B+ AUM fintech (60+ institutional clients).

**License:** MIT