### PR TITLE
Add kimi-code and qwen-code skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [qwen-code](https://github.com/Dominic789654/qwen-code-skills) - Delegate tasks to Qwen Code CLI (Alibaba) as a subagent for file operations, web research, and code analysis with rich built-in tools and 1M context window. *By [@Dominic789654](https://github.com/Dominic789654)*
+- [kimi-code](https://github.com/Dominic789654/kimi-code-skills) - Delegate tasks to Kimi Code CLI (Moonshot AI) as a subagent for file operations, code summarization, and analysis with transparent execution and safe --print mode. *By [@Dominic789654](https://github.com/Dominic789654)*
 
 ### Data & Analysis
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
-- [qwen-code](https://github.com/Dominic789654/qwen-code-skills) - Delegate tasks to Qwen Code CLI (Alibaba) as a subagent for file operations, web research, and code analysis with rich built-in tools and 1M context window. *By [@Dominic789654](https://github.com/Dominic789654)*
-- [kimi-code](https://github.com/Dominic789654/kimi-code-skills) - Delegate tasks to Kimi Code CLI (Moonshot AI) as a subagent for file operations, code summarization, and analysis with transparent execution and safe --print mode. *By [@Dominic789654](https://github.com/Dominic789654)*
+- [qwen-code](./qwen-code/) - Delegate tasks to Qwen Code CLI (Alibaba) as a subagent for file operations, web research, and code analysis with rich built-in tools and 1M context window. *By [@Dominic789654](https://github.com/Dominic789654)*
+- [kimi-code](./kimi-code/) - Delegate tasks to Kimi Code CLI (Moonshot AI) as a subagent for file operations, code summarization, and analysis with transparent execution and safe --print mode. *By [@Dominic789654](https://github.com/Dominic789654)*
 
 ### Data & Analysis
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [claude-code](./claude-code/) - Delegate tasks to Claude Code CLI as a subagent for complex coding, code review, architectural decisions, security analysis, and multi-file refactoring with deep reasoning. *By [@Dominic789654](https://github.com/Dominic789654)*
 - [qwen-code](./qwen-code/) - Delegate tasks to Qwen Code CLI (Alibaba) as a subagent for file operations, web research, and code analysis with rich built-in tools and 1M context window. *By [@Dominic789654](https://github.com/Dominic789654)*
 - [kimi-code](./kimi-code/) - Delegate tasks to Kimi Code CLI (Moonshot AI) as a subagent for file operations, code summarization, and analysis with transparent execution and safe --print mode. *By [@Dominic789654](https://github.com/Dominic789654)*
 

--- a/claude-code/SKILL.md
+++ b/claude-code/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: claude-code
+description: "Delegate tasks to Claude Code CLI as a subagent for complex coding tasks, code review, architectural decisions, security analysis, and multi-file refactoring. Claude provides deep reasoning, extensive tool support, and high-quality code generation."
+---
+
+# Claude Code Delegation Skill
+
+Delegate appropriate tasks to Claude Code CLI for efficient task distribution.
+
+## Overview
+
+Claude Code is Anthropic's command-line AI assistant that provides:
+- Deep reasoning and analysis for complex problems
+- Multi-file code generation and refactoring
+- Comprehensive code review and security analysis
+- Architecture design and system planning
+- Integration with skills, agents, and MCP servers
+- Tool-based execution with safety controls
+
+## Key Characteristics
+
+### Strengths
+- **Deep Reasoning**: Excellent for complex architectural decisions and system design
+- **Tool Extensibility**: Rich tool system with skills, agents, and MCP support
+- **Code Quality**: High-quality code generation following best practices
+- **Security Focus**: Built-in security review and best practice enforcement
+- **Multi-file Context**: Handles complex multi-file refactoring tasks
+- **Session Management**: Persistent sessions with continuation support
+
+### Limitations
+- **Slower for Simple Tasks**: Overhead may be excessive for trivial operations
+- **Requires Setup**: Needs proper configuration for best results
+- **Higher Cost**: More capable but potentially more expensive for simple tasks
+- **Permission System**: May require user approval for sensitive operations
+
+### Performance Profile
+- **Typical Response Time**: 10-30 seconds for complex tasks
+- **Tool Support**: Extensive (Bash, Read, Write, Edit, Grep, Glob, Task, MCP, etc.)
+- **Context Window**: Large context handling for complex multi-file operations
+- **Output Quality**: High-quality, well-reasoned responses with detailed explanations
+
+## When to Delegate to Claude Code
+
+Use Claude Code for tasks that are:
+- **Complex architectural decisions**: System design, API design, database schema
+- **Multi-file refactoring**: Changes spanning multiple files with dependencies
+- **Code review and security analysis**: Deep analysis of code quality and security
+- **Complex debugging**: Issues requiring deep contextual understanding
+- **Documentation generation**: Comprehensive docs from code analysis
+- **Test generation**: Comprehensive test suites with edge cases
+
+### Suitable Task Examples
+- `Review this codebase for security vulnerabilities`
+- `Refactor the authentication system to use JWT tokens`
+- `Design an API for a new microservice`
+- `Analyze this code for performance bottlenecks`
+- `Generate comprehensive tests for this module`
+- `Document the architecture of this system`
+
+### Keep with Direct Execution
+- Simple file operations (use Bash directly)
+- Quick grep searches (use Grep tool)
+- Single-line edits (use Edit tool)
+- Very simple questions (answer directly)
+
+## Basic Claude Code Commands
+
+### Check Installation
+```bash
+claude --version
+claude --help
+```
+
+### Execute Task
+```bash
+# Non-interactive mode (for automation)
+claude -p "Your task description here" --output-format json
+
+# Continue previous session
+claude -c -p "Continue from last task" --output-format json
+
+# With specific permission mode
+claude -p "Task description" --permission-mode plan --output-format json
+```
+
+## Delegation Workflow
+
+### 1. Task Assessment
+- Is task complex enough to benefit from Claude's capabilities?
+- Does `claude` command exist? (`which claude`)
+- What working directory is needed?
+- Should this be handled directly instead?
+
+### 2. Command Construction
+```bash
+# Basic pattern
+claude -p "Clear task description with necessary context" --output-format json
+
+# Example: Code review
+claude -p "Review the src/auth/ directory for security vulnerabilities and code quality issues" --output-format json
+
+# Example: Architecture design
+claude -p "Design a caching layer for this API that handles 10k RPS" --output-format json
+```
+
+### 3. Execute and Parse
+```bash
+# Execute via Bash tool
+result=$(claude -p "Task description" --output-format json 2>&1)
+
+# Check exit code (0 = success)
+echo $?
+```
+
+### 4. Extract Results
+Parse JSON output to extract Claude's response. The JSON structure contains:
+- `content`: The main response text
+- `tool_calls`: Any tool calls made
+- `usage`: Token usage statistics
+
+## Output Parsing
+
+### JSON Output Structure
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "The main response..."
+    }
+  ],
+  "tool_calls": [...],
+  "usage": {
+    "input_tokens": 1234,
+    "output_tokens": 567
+  }
+}
+```
+
+### Key Sections to Extract
+1. **Content array**: Claude's text responses
+2. **Tool calls**: What tools were invoked
+3. **Usage**: Token consumption statistics
+
+## Examples
+
+### Example 1: Code Review
+```bash
+claude -p "Review the authentication module in src/auth/ for security vulnerabilities, code quality issues, and best practice violations. Provide specific recommendations." --output-format json
+```
+
+### Example 2: Architecture Design
+```bash
+claude -p "Design a caching layer for a REST API that needs to handle 10,000 requests per second with sub-10ms latency. Consider Redis, in-memory, and CDN options." --output-format json
+```
+
+### Example 3: Multi-file Refactoring
+```bash
+claude -p "Refactor the user management system to use dependency injection instead of global state. This spans src/users/, src/auth/, and src/database/ directories." --output-format json
+```
+
+### Example 4: Test Generation
+```bash
+claude -p "Generate comprehensive unit tests for the PaymentProcessor class in src/payments/processor.py, including edge cases, error conditions, and mock dependencies." --output-format json
+```
+
+### Example 5: Documentation Generation
+```bash
+claude -p "Generate comprehensive API documentation for the REST endpoints in src/api/, including request/response schemas, authentication requirements, and example usage." --output-format json
+```
+
+## Best Practices
+
+### Clear Task Definitions
+- Be specific: "Review src/auth/ for security vulnerabilities"
+- Include paths: "In directory /path/to/project, analyze X"
+- Specify scope: "Focus on performance bottlenecks in database queries"
+
+### Error Handling
+- Check exit code: `if [ $? -eq 0 ]; then ...`
+- Parse JSON errors from output
+- Have fallback: handle task directly if Claude fails
+
+### Cost Awareness
+- Monitor token usage in `usage` field
+- Use for tasks where Claude's capabilities justify the cost
+- Consider caching strategies for similar queries
+
+## Security Considerations
+
+### Claude Code Safety Features
+- **Permission Modes**: `--permission-mode` flag controls approval requirements:
+  - `default`: Standard permission prompts
+  - `plan`: Approve the overall plan, then individual tool uses
+  - `acceptEdits`: Automatically accept file edits
+  - `dontAsk`: Minimal prompting (use with caution)
+  - `bypassPermissions`: Skip all permissions (dangerous)
+
+- **Tool Control**: `--allowed-tools` and `--disallowed-tools` restrict available tools
+- **Output Format**: `--output-format json` for programmatic processing
+- **Working Directory**: Uses current directory; use `cd` to change scope
+
+### Risk Mitigation Strategies
+
+1. **Permission Mode Selection**
+   ```bash
+   # For read-only analysis (safer)
+   claude -p "Analyze code structure" --permission-mode default --output-format json
+
+   # For planned operations
+   claude -p "Refactor module" --permission-mode plan --output-format json
+
+   # Avoid for sensitive operations
+   # ❌ DON'T: claude -p "Task" --permission-mode bypassPermissions
+   ```
+
+2. **Tool Restriction**
+   ```bash
+   # Limit available tools for safer execution
+   claude -p "Read-only analysis" --disallowed-tools "Write,Edit" --output-format json
+
+   # Or explicitly allow only read tools
+   claude -p "Analysis task" --allowed-tools "Read,Bash(ls:*)" --output-format json
+   ```
+
+3. **Working Directory Isolation**
+   ```bash
+   # Change to specific directory before execution
+   cd /safe/workspace && claude -p "Task" --output-format json
+
+   # Use with timeout for safety
+   timeout 60 claude -p "Task" --output-format json
+   ```
+
+4. **Content Safety**
+   - Review prompts for sensitive data exposure
+   - Check output for accidental credential leaks
+   - Use dedicated workspace directories
+   - Implement audit logging for compliance
+
+### Risk-Based Task Categorization
+
+| Risk Level | Task Type | Safety Measures |
+|------------|-----------|-----------------|
+| **Low** | Read-only analysis, documentation review | `--permission-mode default` |
+| **Medium** | Code suggestions, test generation | `--permission-mode plan` |
+| **High** | File modifications, refactoring | `--disallowed-tools Write,Edit` or manual review |
+| **Critical** | System changes, deployments | Handle directly with oversight |
+
+### Emergency Response
+If Claude starts executing dangerous operations:
+1. **Immediate Interrupt**: `Ctrl+C` to stop execution
+2. **Check Git Status**: `git status` to see file changes
+3. **Restore Files**: `git checkout -- .` to revert modifications
+4. **Review Logs**: Check session history for executed operations
+5. **Adjust Settings**: Strengthen permission modes or tool restrictions
+
+### Recommended Safety Configuration
+```bash
+# For routine analysis tasks (low risk)
+claude -p "Analyze code structure" --permission-mode default --output-format json
+
+# For development tasks (medium risk)
+claude -p "Refactor function" --permission-mode plan --output-format json
+
+# For high-risk operations
+claude -p "Modify critical files" --permission-mode default --disallowed-tools "Write,Edit,Bash(rm:*)" --output-format json
+```
+
+## Integration Pattern
+
+```bash
+# Pseudo-implementation for delegation
+delegate_to_claude() {
+    local task="$1"
+    local workdir="${2:-.}"
+
+    if ! command -v claude &> /dev/null; then
+        echo "Claude Code not found, handling task directly"
+        return 1
+    fi
+
+    echo "Delegating to Claude Code: $task"
+    output=$(cd "$workdir" && claude -p "$task" --output-format json 2>&1)
+
+    if [ $? -eq 0 ]; then
+        # Extract content from JSON
+        echo "$output" | jq -r '.content[0].text // empty'
+        return 0
+    else
+        echo "Claude Code failed, fallback to direct handling"
+        return 1
+    fi
+}
+```
+
+## Troubleshooting
+
+### Claude Not Found
+```bash
+# Check installation
+which claude
+
+# Expected: /usr/local/bin/claude or similar
+# If missing, install via official installer
+```
+
+### Permission Issues
+```bash
+# Check permission mode settings
+claude -p "Test" --permission-mode default --output-format json
+
+# Review available permission modes
+claude --help | grep permission
+```
+
+### Output Parsing Issues
+```bash
+# Test JSON output
+claude -p "Say hello" --output-format json | jq .
+
+# Install jq if needed
+sudo apt-get install jq  # Ubuntu/Debian
+brew install jq          # macOS
+```
+
+## References
+
+- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code/overview)
+- [Claude Code Skills Guide](https://docs.anthropic.com/en/docs/claude-code/skills)
+- [Anthropic API Documentation](https://docs.anthropic.com/en/api/overview)
+
+---
+
+**Usage**: When you encounter a task that matches the "Suitable Task Examples", delegate it to Claude Code using the patterns above. This creates an efficient subagent workflow where complex tasks are handled by Claude, freeing you for other work.

--- a/kimi-code/LICENSE.txt
+++ b/kimi-code/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2025 The skill author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific details governing permissions and
+limitations under the License.

--- a/kimi-code/SKILL.md
+++ b/kimi-code/SKILL.md
@@ -1,49 +1,104 @@
 ---
 name: kimi-code
-description: Delegate tasks to Kimi Code CLI as a subagent for file operations, code summarization, and analysis. Use when you need to delegate simple to moderate coding tasks. Kimi provides transparent execution with ThinkPart/ToolCall visibility, safe --print mode, and working directory isolation.
+description: Delegate simple to moderate coding tasks to Kimi Code CLI as a subagent for file operations, code summarization, and analysis. Use when you need transparent execution with ThinkPart/ToolCall visibility, safe --print mode, and working directory isolation.
 license: Complete terms in LICENSE.txt
 ---
 
 # Kimi Code Delegation
 
-This skill enables delegation of appropriate tasks to Kimi Code CLI (Moonshot AI's command-line programming assistant) for efficient task distribution.
+This skill teaches Claude how to delegate appropriate tasks to Kimi Code CLI (Moonshot AI's command-line programming assistant) for efficient task distribution.
 
-## When to Use
+Kimi Code provides transparent execution with detailed ThinkPart reasoning, ToolCall visibility, and StatusUpdate with token usage statistics. It's ideal for tasks where you want to see exactly what the AI is doing.
 
-Delegate to Kimi Code for tasks that are:
-- **Simple to moderate complexity**: File listing, code reading, basic analysis
-- **Well-defined**: Clear requirements and expected outputs
-- **Independent**: Can be executed without extensive context sharing
-- **Resource-efficient**: Benefit from Kimi's caching system
+## When to Use This Skill
 
-### Suitable Tasks
-- List files in directory and subdirectories
-- Find all Python files and show their sizes
-- Read README.md and summarize key points
-- Explain the purpose of a function
-- Check if specific tools are installed
-- Run simple tests and report results
-- Rename variables in a file
-- Extract functions from code
+- **File operations**: List files, find specific file types, check file sizes
+- **Code reading**: Read and summarize code files, explain functions
+- **Basic analysis**: Count lines, check imports, analyze simple code patterns
+- **Environment checks**: Verify tool installations, check system status
+- **Simple testing**: Run basic tests and report results
 
-### Keep with Claude Code
-- Complex architectural decisions
-- Multi-step feature implementation
-- Security-critical operations
-- Tasks requiring deep contextual understanding
-- Team coordination and integration
+## What This Skill Does
+
+1. **Task delegation**: Teaches Claude when to delegate tasks to Kimi Code vs handling them directly
+2. **Command construction**: Shows how to build proper kimi commands with --print flag for safety
+3. **Output parsing**: Guides parsing of Kimi's ThinkPart/ToolCall/StatusUpdate output format
+4. **Safety enforcement**: Ensures safe use with --print mode and working directory isolation
+5. **Error handling**: Provides fallback strategies when Kimi Code fails
+
+## How to Use
+
+### Basic Usage
+
+When Claude identifies a task suitable for Kimi Code, it will construct a command like:
+
+```bash
+kimi -p "List all Python files in current directory with sizes" --print
+```
+
+### Advanced Usage
+
+For more complex tasks, use working directory isolation and session continuation:
+
+```bash
+# With specific working directory
+kimi -w /path/to/project -p "Analyze project structure" --print
+
+# Continue from previous session
+kimi -C -p "Continue analysis from last task" --print
+
+# With timeout for safety
+timeout 30 kimi -p "Task description" --print
+```
+
+## Example
+
+**User**: "List all Python files in the current directory and show their line counts"
+
+**Claude (using this skill)**: Delegates to Kimi Code with:
+
+```bash
+kimi -p "Find all .py files in current directory, show their names, sizes, and line counts" --print
+```
+
+**Output from Kimi**:
+```
+ThinkPart(type='think', text='I need to list Python files...')
+ToolCall(type='shell', command='find . -name "*.py" -exec wc -l {} \;')
+ToolResult(type='result', result='./main.py: 45\n./utils.py: 120\n./test.py: 67')
+TextPart(type='text', text='Found 3 Python files:\n- main.py: 45 lines\n- utils.py: 120 lines\n- test.py: 67 lines\nTotal: 232 lines')
+StatusUpdate(type='status', token_usage=TokenUsage(input_other=150, output=37, input_cache_read=320))
+```
+
+**Inspired by**: Real-world usage of Kimi Code CLI for development workflow automation
+
+## Tips
+
+- **Always use --print**: This prevents accidental approval of destructive actions
+- **Use -w for isolation**: Restrict file operations to specific directories
+- **Monitor token usage**: Check StatusUpdate for cache efficiency (input_cache_read)
+- **Extract TextPart**: The final answer is in the TextPart section of output
+- **Have fallbacks**: If Kimi fails, be prepared to handle the task directly
+
+## Common Use Cases
+
+1. **Project onboarding**: Quickly analyze a new codebase structure
+2. **Code review prep**: Gather statistics about files to be reviewed
+3. **Documentation**: Generate summaries of code files for documentation
+4. **Environment setup**: Verify required tools and dependencies are installed
+5. **Test automation**: Run simple tests and summarize results
 
 ## Key Characteristics
 
 ### Strengths
 - **Transparent Execution**: Shows detailed ThinkPart reasoning, ToolCall details, and StatusUpdate with token usage
-- **Cache Efficiency**: Built-in caching with input_cache_read statistics
-- **Safe by Default**: --print mode is non-interactive and doesn't auto-approve destructive actions
-- **Context Management**: -w flag for working directory isolation, -C for session continuation
+- **Cache Efficiency**: Built-in caching system with `input_cache_read` statistics showing cost savings
+- **Safe by Default**: `--print` mode is non-interactive and doesn't auto-approve destructive actions
+- **Context Management**: `-w` flag for working directory isolation, `-C` for session continuation
 - **Multi-step Reasoning**: Can plan and execute complex multi-step tasks autonomously
 
 ### Limitations
-- **Slower Output**: Detailed transparency comes at parsing complexity cost
+- **Slower Output**: Detailed transparency comes at the cost of parsing complexity
 - **Tool Dependency**: Relies on external tool calls via Shell for many operations
 - **Less Built-in Tools**: Fewer native tools compared to Qwen Code
 - **Python Dependency**: Requires Python/uv installation environment
@@ -72,7 +127,7 @@ kimi -C -p "Continue from last task" --print
 
 ### 1. Task Assessment
 - Is task well-defined and suitable for Kimi?
-- Does kimi command exist? (which kimi)
+- Does `kimi` command exist? (`which kimi`)
 - What working directory is needed?
 
 ### 2. Command Construction
@@ -97,58 +152,18 @@ echo $?
 ```
 
 ### 4. Extract Results
-Look for TextPart sections in Kimi's output:
+Look for `TextPart` sections in Kimi's output:
 ```
 TextPart(type='text', text='The answer here...')
-```
-
-## Output Parsing
-
-### Key Output Components
-1. **TextPart**: Final answer (extract this)
-2. **ThinkPart**: Reasoning process (debugging)
-3. **ToolCall/ToolResult**: Tool execution details
-4. **StatusUpdate**: Token usage statistics
-
-### Token Usage Monitoring
-```
-TokenUsage(
-    input_other=2650,    # Prompt tokens
-    output=37,           # Response tokens
-    input_cache_read=5376,  # Cache hits (saves cost)
-    input_cache_creation=0  # Cache writes
-)
-```
-
-## Examples
-
-### Example 1: File System Analysis
-```bash
-kimi -p "Find all .py files in the project, show line counts and last modified dates" --print
-```
-
-### Example 2: Code Documentation
-```bash
-kimi -p "Read src/utils.py and create a table of functions with their parameters and return types" --print
-```
-
-### Example 3: Environment Check
-```bash
-kimi -p "Check Python version, pip availability, and list installed packages" --print
-```
-
-### Example 4: Test Summary
-```bash
-kimi -p "Run pytest on tests/ and summarize which tests passed/failed" --print
 ```
 
 ## Security Considerations
 
 ### Kimi Code Safety Features
-- **Non-interactive by Default**: --print mode prevents accidental approval of destructive actions
-- **Transparent Tool Execution**: All ToolCall and ToolResult details are visible in output
-- **No Auto-approval**: Unlike Qwen's --yolo, Kimi requires explicit approval for risky operations
-- **Working Directory Isolation**: -w flag limits file operations to specified directory
+- **Non-interactive by Default**: `--print` mode prevents accidental approval of destructive actions
+- **Transparent Tool Execution**: All `ToolCall` and `ToolResult` details are visible in output
+- **No Auto-approval**: Unlike Qwen's `--yolo`, Kimi requires explicit approval for risky operations
+- **Working Directory Isolation**: `-w` flag limits file operations to specified directory
 
 ### Recommended Safety Configuration
 ```bash
@@ -161,40 +176,6 @@ kimi -w /workspace -C -p "Continue analysis" --print
 # Avoid dangerous patterns
 # DON'T: kimi -p "Delete temporary files" --print
 # DO: kimi -p "List temporary files that could be deleted" --print
-```
-
-### Emergency Stop
-If Kimi starts executing dangerous operations:
-1. **Send SIGINT**: Ctrl+C to interrupt the process
-2. **Check output**: Review ToolCall sections for executed commands
-3. **Verify files**: Check if any files were modified or deleted
-4. **Use git**: If working in git repository, git status and git checkout -- . to restore
-
-## Integration Pattern
-
-```bash
-# Pseudo-implementation for delegation
-delegate_to_kimi() {
-    local task="$1"
-    local workdir="${2:-.}"
-    
-    if ! command -v kimi &> /dev/null; then
-        echo "Kimi Code not found, handling task directly"
-        return 1
-    fi
-    
-    echo "Delegating to Kimi Code: $task"
-    output=$(kimi -w "$workdir" -p "$task" --print 2>&1)
-    
-    if [ $? -eq 0 ]; then
-        # Extract TextPart content
-        echo "$output" | grep -A1 "TextPart.*text=" | tail -1 | sed "s/.*text='\(.*\)'.*/\1/"
-        return 0
-    else
-        echo "Kimi Code failed, fallback to direct handling"
-        return 1
-    fi
-}
 ```
 
 ## Troubleshooting

--- a/kimi-code/SKILL.md
+++ b/kimi-code/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: kimi-code
+description: Delegate tasks to Kimi Code CLI as a subagent for file operations, code summarization, and analysis. Use when you need to delegate simple to moderate coding tasks. Kimi provides transparent execution with ThinkPart/ToolCall visibility, safe --print mode, and working directory isolation.
+license: Complete terms in LICENSE.txt
+---
+
+# Kimi Code Delegation
+
+This skill enables delegation of appropriate tasks to Kimi Code CLI (Moonshot AI's command-line programming assistant) for efficient task distribution.
+
+## When to Use
+
+Delegate to Kimi Code for tasks that are:
+- **Simple to moderate complexity**: File listing, code reading, basic analysis
+- **Well-defined**: Clear requirements and expected outputs
+- **Independent**: Can be executed without extensive context sharing
+- **Resource-efficient**: Benefit from Kimi's caching system
+
+### Suitable Tasks
+- List files in directory and subdirectories
+- Find all Python files and show their sizes
+- Read README.md and summarize key points
+- Explain the purpose of a function
+- Check if specific tools are installed
+- Run simple tests and report results
+- Rename variables in a file
+- Extract functions from code
+
+### Keep with Claude Code
+- Complex architectural decisions
+- Multi-step feature implementation
+- Security-critical operations
+- Tasks requiring deep contextual understanding
+- Team coordination and integration
+
+## Key Characteristics
+
+### Strengths
+- **Transparent Execution**: Shows detailed ThinkPart reasoning, ToolCall details, and StatusUpdate with token usage
+- **Cache Efficiency**: Built-in caching with input_cache_read statistics
+- **Safe by Default**: --print mode is non-interactive and doesn't auto-approve destructive actions
+- **Context Management**: -w flag for working directory isolation, -C for session continuation
+- **Multi-step Reasoning**: Can plan and execute complex multi-step tasks autonomously
+
+### Limitations
+- **Slower Output**: Detailed transparency comes at parsing complexity cost
+- **Tool Dependency**: Relies on external tool calls via Shell for many operations
+- **Less Built-in Tools**: Fewer native tools compared to Qwen Code
+- **Python Dependency**: Requires Python/uv installation environment
+
+## Basic Commands
+
+### Check Installation
+```bash
+kimi --version
+kimi info
+```
+
+### Execute Task
+```bash
+# Non-interactive mode (for automation)
+kimi -p "Your task description here" --print
+
+# With specific working directory
+kimi -w /path/to/directory -p "List files" --print
+
+# Continue previous session
+kimi -C -p "Continue from last task" --print
+```
+
+## Delegation Workflow
+
+### 1. Task Assessment
+- Is task well-defined and suitable for Kimi?
+- Does kimi command exist? (which kimi)
+- What working directory is needed?
+
+### 2. Command Construction
+```bash
+# Basic pattern
+kimi -p "Clear task description" --print
+
+# Example: File analysis
+kimi -p "List all .py files in current directory with their sizes" --print
+
+# Example: Code reading
+kimi -p "Read main.py and summarize what it does" --print
+```
+
+### 3. Execute and Parse
+```bash
+# Execute via Bash tool
+result=$(kimi -p "Task description" --print 2>&1)
+
+# Check exit code (0 = success)
+echo $?
+```
+
+### 4. Extract Results
+Look for TextPart sections in Kimi's output:
+```
+TextPart(type='text', text='The answer here...')
+```
+
+## Output Parsing
+
+### Key Output Components
+1. **TextPart**: Final answer (extract this)
+2. **ThinkPart**: Reasoning process (debugging)
+3. **ToolCall/ToolResult**: Tool execution details
+4. **StatusUpdate**: Token usage statistics
+
+### Token Usage Monitoring
+```
+TokenUsage(
+    input_other=2650,    # Prompt tokens
+    output=37,           # Response tokens
+    input_cache_read=5376,  # Cache hits (saves cost)
+    input_cache_creation=0  # Cache writes
+)
+```
+
+## Examples
+
+### Example 1: File System Analysis
+```bash
+kimi -p "Find all .py files in the project, show line counts and last modified dates" --print
+```
+
+### Example 2: Code Documentation
+```bash
+kimi -p "Read src/utils.py and create a table of functions with their parameters and return types" --print
+```
+
+### Example 3: Environment Check
+```bash
+kimi -p "Check Python version, pip availability, and list installed packages" --print
+```
+
+### Example 4: Test Summary
+```bash
+kimi -p "Run pytest on tests/ and summarize which tests passed/failed" --print
+```
+
+## Security Considerations
+
+### Kimi Code Safety Features
+- **Non-interactive by Default**: --print mode prevents accidental approval of destructive actions
+- **Transparent Tool Execution**: All ToolCall and ToolResult details are visible in output
+- **No Auto-approval**: Unlike Qwen's --yolo, Kimi requires explicit approval for risky operations
+- **Working Directory Isolation**: -w flag limits file operations to specified directory
+
+### Recommended Safety Configuration
+```bash
+# Safe execution pattern
+timeout 30 kimi -w /workspace -p "Read-only task description" --print
+
+# With session continuation for efficiency
+kimi -w /workspace -C -p "Continue analysis" --print
+
+# Avoid dangerous patterns
+# DON'T: kimi -p "Delete temporary files" --print
+# DO: kimi -p "List temporary files that could be deleted" --print
+```
+
+### Emergency Stop
+If Kimi starts executing dangerous operations:
+1. **Send SIGINT**: Ctrl+C to interrupt the process
+2. **Check output**: Review ToolCall sections for executed commands
+3. **Verify files**: Check if any files were modified or deleted
+4. **Use git**: If working in git repository, git status and git checkout -- . to restore
+
+## Integration Pattern
+
+```bash
+# Pseudo-implementation for delegation
+delegate_to_kimi() {
+    local task="$1"
+    local workdir="${2:-.}"
+    
+    if ! command -v kimi &> /dev/null; then
+        echo "Kimi Code not found, handling task directly"
+        return 1
+    fi
+    
+    echo "Delegating to Kimi Code: $task"
+    output=$(kimi -w "$workdir" -p "$task" --print 2>&1)
+    
+    if [ $? -eq 0 ]; then
+        # Extract TextPart content
+        echo "$output" | grep -A1 "TextPart.*text=" | tail -1 | sed "s/.*text='\(.*\)'.*/\1/"
+        return 0
+    else
+        echo "Kimi Code failed, fallback to direct handling"
+        return 1
+    fi
+}
+```
+
+## Troubleshooting
+
+### Kimi Not Found
+```bash
+# Check installation
+which kimi
+
+# Expected: ~/.local/bin/kimi or similar
+# If missing, install via uv:
+uv tool install kimi-cli
+```
+
+### Authentication Issues
+```bash
+# Run login if needed
+kimi login
+```
+
+### Command Failures
+```bash
+# Test basic functionality
+kimi -p "Say hello" --print
+
+# Check verbose output
+kimi -p "Task" --print --verbose
+```
+
+## References
+
+- [Kimi Code Documentation](https://moonshotai.github.io/kimi-cli/)
+- [Kimi Code GitHub](https://github.com/moonshotai/kimi-cli)

--- a/kimi-code/SKILL.md.bak
+++ b/kimi-code/SKILL.md.bak
@@ -1,0 +1,230 @@
+---
+name: kimi-code
+description: Delegate tasks to Kimi Code CLI as a subagent for file operations, code summarization, and analysis. Use when you need to delegate simple to moderate coding tasks. Kimi provides transparent execution with ThinkPart/ToolCall visibility, safe --print mode, and working directory isolation.
+license: Complete terms in LICENSE.txt
+---
+
+# Kimi Code Delegation
+
+This skill enables delegation of appropriate tasks to Kimi Code CLI (Moonshot AI's command-line programming assistant) for efficient task distribution.
+
+## When to Use
+
+Delegate to Kimi Code for tasks that are:
+- **Simple to moderate complexity**: File listing, code reading, basic analysis
+- **Well-defined**: Clear requirements and expected outputs
+- **Independent**: Can be executed without extensive context sharing
+- **Resource-efficient**: Benefit from Kimi's caching system
+
+### Suitable Tasks
+- List files in directory and subdirectories
+- Find all Python files and show their sizes
+- Read README.md and summarize key points
+- Explain the purpose of a function
+- Check if specific tools are installed
+- Run simple tests and report results
+- Rename variables in a file
+- Extract functions from code
+
+### Keep with Claude Code
+- Complex architectural decisions
+- Multi-step feature implementation
+- Security-critical operations
+- Tasks requiring deep contextual understanding
+- Team coordination and integration
+
+## Key Characteristics
+
+### Strengths
+- **Transparent Execution**: Shows detailed ThinkPart reasoning, ToolCall details, and StatusUpdate with token usage
+- **Cache Efficiency**: Built-in caching with input_cache_read statistics
+- **Safe by Default**: --print mode is non-interactive and doesn't auto-approve destructive actions
+- **Context Management**: -w flag for working directory isolation, -C for session continuation
+- **Multi-step Reasoning**: Can plan and execute complex multi-step tasks autonomously
+
+### Limitations
+- **Slower Output**: Detailed transparency comes at parsing complexity cost
+- **Tool Dependency**: Relies on external tool calls via Shell for many operations
+- **Less Built-in Tools**: Fewer native tools compared to Qwen Code
+- **Python Dependency**: Requires Python/uv installation environment
+
+## Basic Commands
+
+### Check Installation
+```bash
+kimi --version
+kimi info
+```
+
+### Execute Task
+```bash
+# Non-interactive mode (for automation)
+kimi -p "Your task description here" --print
+
+# With specific working directory
+kimi -w /path/to/directory -p "List files" --print
+
+# Continue previous session
+kimi -C -p "Continue from last task" --print
+```
+
+## Delegation Workflow
+
+### 1. Task Assessment
+- Is task well-defined and suitable for Kimi?
+- Does kimi command exist? (which kimi)
+- What working directory is needed?
+
+### 2. Command Construction
+```bash
+# Basic pattern
+kimi -p "Clear task description" --print
+
+# Example: File analysis
+kimi -p "List all .py files in current directory with their sizes" --print
+
+# Example: Code reading
+kimi -p "Read main.py and summarize what it does" --print
+```
+
+### 3. Execute and Parse
+```bash
+# Execute via Bash tool
+result=$(kimi -p "Task description" --print 2>&1)
+
+# Check exit code (0 = success)
+echo $?
+```
+
+### 4. Extract Results
+Look for TextPart sections in Kimi's output:
+```
+TextPart(type='text', text='The answer here...')
+```
+
+## Output Parsing
+
+### Key Output Components
+1. **TextPart**: Final answer (extract this)
+2. **ThinkPart**: Reasoning process (debugging)
+3. **ToolCall/ToolResult**: Tool execution details
+4. **StatusUpdate**: Token usage statistics
+
+### Token Usage Monitoring
+```
+TokenUsage(
+    input_other=2650,    # Prompt tokens
+    output=37,           # Response tokens
+    input_cache_read=5376,  # Cache hits (saves cost)
+    input_cache_creation=0  # Cache writes
+)
+```
+
+## Examples
+
+### Example 1: File System Analysis
+```bash
+kimi -p "Find all .py files in the project, show line counts and last modified dates" --print
+```
+
+### Example 2: Code Documentation
+```bash
+kimi -p "Read src/utils.py and create a table of functions with their parameters and return types" --print
+```
+
+### Example 3: Environment Check
+```bash
+kimi -p "Check Python version, pip availability, and list installed packages" --print
+```
+
+### Example 4: Test Summary
+```bash
+kimi -p "Run pytest on tests/ and summarize which tests passed/failed" --print
+```
+
+## Security Considerations
+
+### Kimi Code Safety Features
+- **Non-interactive by Default**: --print mode prevents accidental approval of destructive actions
+- **Transparent Tool Execution**: All ToolCall and ToolResult details are visible in output
+- **No Auto-approval**: Unlike Qwen's --yolo, Kimi requires explicit approval for risky operations
+- **Working Directory Isolation**: -w flag limits file operations to specified directory
+
+### Recommended Safety Configuration
+```bash
+# Safe execution pattern
+timeout 30 kimi -w /workspace -p "Read-only task description" --print
+
+# With session continuation for efficiency
+kimi -w /workspace -C -p "Continue analysis" --print
+
+# Avoid dangerous patterns
+# DON'T: kimi -p "Delete temporary files" --print
+# DO: kimi -p "List temporary files that could be deleted" --print
+```
+
+### Emergency Stop
+If Kimi starts executing dangerous operations:
+1. **Send SIGINT**: Ctrl+C to interrupt the process
+2. **Check output**: Review ToolCall sections for executed commands
+3. **Verify files**: Check if any files were modified or deleted
+4. **Use git**: If working in git repository, git status and git checkout -- . to restore
+
+## Integration Pattern
+
+```bash
+# Pseudo-implementation for delegation
+delegate_to_kimi() {
+    local task="$1"
+    local workdir="${2:-.}"
+    
+    if ! command -v kimi &> /dev/null; then
+        echo "Kimi Code not found, handling task directly"
+        return 1
+    fi
+    
+    echo "Delegating to Kimi Code: $task"
+    output=$(kimi -w "$workdir" -p "$task" --print 2>&1)
+    
+    if [ $? -eq 0 ]; then
+        # Extract TextPart content
+        echo "$output" | grep -A1 "TextPart.*text=" | tail -1 | sed "s/.*text='\(.*\)'.*/\1/"
+        return 0
+    else
+        echo "Kimi Code failed, fallback to direct handling"
+        return 1
+    fi
+}
+```
+
+## Troubleshooting
+
+### Kimi Not Found
+```bash
+# Check installation
+which kimi
+
+# Expected: ~/.local/bin/kimi or similar
+# If missing, install via uv:
+uv tool install kimi-cli
+```
+
+### Authentication Issues
+```bash
+# Run login if needed
+kimi login
+```
+
+### Command Failures
+```bash
+# Test basic functionality
+kimi -p "Say hello" --print
+
+# Check verbose output
+kimi -p "Task" --print --verbose
+```
+
+## References
+
+- [Kimi Code Documentation](https://moonshotai.github.io/kimi-cli/)
+- [Kimi Code GitHub](https://github.com/moonshotai/kimi-cli)

--- a/qwen-code/LICENSE.txt
+++ b/qwen-code/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2025 The skill author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific details governing permissions and
+limitations under the License.

--- a/qwen-code/SKILL.md
+++ b/qwen-code/SKILL.md
@@ -1,54 +1,118 @@
 ---
 name: qwen-code
-description: Delegate tasks to Qwen Code CLI as a subagent for file operations, web research, and code analysis. Use when you need to delegate tasks requiring rich built-in tools, high cache efficiency (>95%), and structured JSON output. WARNING: --yolo auto-approves ALL actions - use with caution.
+description: Delegate tasks to Qwen Code CLI as a subagent for file operations, web research, and code analysis. Use when you need rich built-in tools, high cache efficiency (>95%), 1M context window, and structured JSON output. WARNING: --yolo auto-approves ALL actions - use with caution.
 license: Complete terms in LICENSE.txt
 ---
 
 # Qwen Code Delegation
 
-This skill enables delegation of appropriate tasks to Qwen Code CLI (Alibaba's command-line AI assistant) for efficient task distribution.
+This skill teaches Claude how to delegate appropriate tasks to Qwen Code CLI (Alibaba's command-line AI assistant) for efficient task distribution.
 
-## When to Use
+Qwen Code provides rich built-in tools, high cache efficiency, and structured JSON output. It's ideal for tasks requiring file operations, web research, or data extraction with 1M context window for long documents.
 
-Delegate to Qwen Code for tasks that are:
-- **File and code operations**: Reading, writing, editing, searching files
+## When to Use This Skill
+
+- **File operations**: Read, write, edit, search files with built-in tools
 - **Web research**: Search and fetch web content for information gathering
-- **Basic to moderate complexity**: Well-defined tasks with clear outputs
-- **Data extraction**: Structured information gathering from various sources
-- **Routine checks**: Environment verification, dependency checks, system status
+- **Data extraction**: Gather structured information from various sources
+- **Code analysis**: Analyze code patterns, imports, and structure
+- **Environment verification**: Check system status, dependencies, and tools
+- **Long document processing**: Handle files up to 1M tokens in length
 
-### Suitable Tasks
-- List files in directory and subdirectories with details
-- Find all Python files and analyze their imports
-- Read documentation and extract key points
-- Search the web for specific technical information
-- Check system environment and installed tools
-- Run simple tests and summarize results
-- Extract data from files into structured formats
-- Search codebase for specific patterns or functions
+## What This Skill Does
 
-### Keep with Claude Code
-- Complex architectural decisions and system design
-- Multi-step system integration and deployment
-- Security-critical operations and sensitive data handling
-- Tasks requiring deep contextual understanding of the codebase
-- Team coordination, task management, and workflow orchestration
+1. **Task delegation**: Teaches Claude when to delegate tasks to Qwen Code vs handling them directly
+2. **Command construction**: Shows how to build proper qwen commands with appropriate safety flags
+3. **Output parsing**: Guides parsing of Qwen's text or JSON output formats
+4. **Safety enforcement**: Implements critical safety measures for the dangerous --yolo flag
+5. **Tool selection**: Helps choose between text output for reading vs JSON for programmatic use
+
+## How to Use
+
+### Basic Usage (Text Output)
+
+When Claude identifies a task suitable for Qwen Code, it will construct a command like:
+
+```bash
+qwen -p "List all Python files in current directory with sizes and line counts" --yolo -o text
+```
+
+### Advanced Usage (JSON Output)
+
+For programmatic processing and data extraction:
+
+```bash
+# JSON output for parsing
+qwen -p "Read config.json and output as structured data" --yolo -o json
+
+# With safety exclusions for file operations
+qwen -p "Analyze project structure" --exclude-tools write_file,edit --yolo -o text
+
+# Using approval modes for safer file operations
+qwen -p "Edit configuration file" --approval-mode plan -o text
+```
+
+## Example
+
+**User**: "Search for recent best practices about Python type hints"
+
+**Claude (using this skill)**: Delegates to Qwen Code with:
+
+```bash
+qwen -p "Search the web for recent best practices about Python type hints and async programming, summarize key points in bullet format" --yolo -o text
+```
+
+**Output from Qwen**:
+```
+Here are recent best practices for Python type hints and async programming:
+
+Type Hints:
+• Use typing module for complex types (List[str], Dict[str, Any])
+• Add return type annotations for all functions
+• Use TypeVar for generic functions
+• Consider mypy or pyright for type checking
+
+Async Programming:
+• Use asyncio.create_task() instead of ensure_future()
+• Always await coroutines properly
+• Use async context managers (async with)
+• Handle cancellation with asyncio.CancelledError
+```
+
+**Inspired by**: Real-world usage of Qwen Code CLI for development and research workflows
+
+## Tips
+
+- **Avoid --yolo for file writes**: Use `--approval-mode default` or `--approval-mode plan` for file operations
+- **Use -o json for parsing**: JSON output is structured and easier to process programmatically
+- **Monitor cache efficiency**: Check `cache_read_input_tokens` in usage stats (typically >95%)
+- **Add timeouts**: Use `timeout 30` to prevent hanging on long tasks
+- **Exclude dangerous tools**: Use `--exclude-tools write_file,edit` for read-only tasks
+
+## Common Use Cases
+
+1. **Research automation**: Gather and summarize technical information from the web
+2. **Codebase analysis**: Analyze imports, dependencies, and code patterns
+3. **Documentation generation**: Extract key information from code for documentation
+4. **Environment auditing**: Verify system configurations and installed tools
+5. **Data extraction**: Convert unstructured information into structured formats
+6. **Long document processing**: Handle large code files or documentation (1M context)
 
 ## Key Characteristics
 
 ### Strengths
-- **Rich Built-in Tools**: Native support for read_file, write_file, edit, web_search, grep_search, etc.
-- **High Cache Efficiency**: Typically >95% cache hit rate (cache_read_input_tokens in usage stats)
+- **Rich Built-in Tools**: Native support for `read_file`, `write_file`, `edit`, `web_search`, `grep_search`, etc.
+- **High Cache Efficiency**: Typically >95% cache hit rate (`cache_read_input_tokens` in usage stats)
 - **Large Context Window**: 1M context length, suitable for processing long documents and code files
 - **Structured Output**: JSON format with detailed metadata (token usage, tool list, execution stats)
 - **Fast Execution**: Quick response times due to efficient caching and built-in tool integration
 - **Web Capabilities**: Built-in web search and content fetching without external dependencies
 
 ### Limitations
-- **Auto-approval Risk**: --yolo flag automatically approves all actions (potentially dangerous)
+- **Auto-approval Risk**: `--yolo` flag automatically approves all actions (potentially dangerous)
 - **Less Transparent**: JSON output requires parsing, less human-readable than Kimi's ThinkPart
-- **No Directory Isolation**: No -w flag for working directory restriction
-- **Node.js Dependency**: Requires Node.js/npm environment
+- **No Directory Isolation**: No `-w` flag for working directory restriction
+- **Node.js Dependency**: Requires Node.js/npm installation environment
 
 ## Basic Commands
 
@@ -70,104 +134,13 @@ qwen -p "Your task description here" --yolo -o json
 qwen "Your prompt here"
 ```
 
-## Delegation Workflow
-
-### 1. Task Assessment
-- Verify task fits "Suitable Tasks" criteria
-- Check that qwen command is available: which qwen
-- Determine if task requires text or JSON output format
-
-### 2. Command Construction
-```bash
-# Basic pattern for human-readable output
-qwen -p "Clear task description with necessary context" --yolo -o text
-
-# For programmatic processing and data extraction
-qwen -p "Structured task expecting JSON output" --yolo -o json
-
-# Example: File system analysis
-qwen -p "List all .py files in current directory with their sizes and line counts" --yolo -o text
-
-# Example: Code analysis with structured output
-qwen -p "Read main.py and output function signatures as JSON array" --yolo -o json
-```
-
-### 3. Execute and Parse
-```bash
-# Execute via Bash tool
-result=$(qwen -p "Task description" --yolo -o text 2>&1)
-
-# Check exit code (0 = success)
-echo $?
-
-# For JSON output, parse with jq
-json_result=$(qwen -p "Task" --yolo -o json 2>&1)
-parsed=$(echo "$json_result" | jq -r '.[-1].result')
-```
-
-## Output Parsing
-
-### Text Output Format
-Qwen Code provides clean, formatted text output suitable for direct human consumption.
-
-### JSON Output Structure
-```json
-[
-  {
-    "type": "system",
-    "subtype": "init",
-    "tools": ["list_directory", "read_file", "web_search", ...],
-    "model": "coder-model"
-  },
-  {
-    "type": "result",
-    "subtype": "success",
-    "result": "Final answer text",
-    "usage": {
-      "input_tokens": 13324,
-      "output_tokens": 284,
-      "cache_read_input_tokens": 13002,
-      "total_tokens": 13608
-    }
-  }
-]
-```
-
-### Key Fields to Extract
-1. **.result**: Complete answer text
-2. **.message.content[0].text**: Assistant's text response
-3. **.usage**: Token usage statistics for cost monitoring
-4. **.tools**: List of available tools (for debugging)
-
-## Examples
-
-### Example 1: Comprehensive File System Analysis
-```bash
-qwen -p "Find all Python files in the project directory and subdirectories, show their sizes, line counts, last modification dates, and count total lines of Python code" --yolo -o text
-```
-
-### Example 2: Code Documentation Extraction
-```bash
-qwen -p "Read the file src/utils.py and create a structured JSON output containing: function names, parameters, return types, docstrings, and line numbers" --yolo -o json
-```
-
-### Example 3: Web Research Task
-```bash
-qwen -p "Search for recent best practices about Python type hints and async programming, summarize key points in bullet format" --yolo -o text
-```
-
-### Example 4: Environment and Dependency Check
-```bash
-qwen -p "Check Python version, Node.js version, Docker status, list installed Python packages, and verify if git is configured" --yolo -o text
-```
-
-## Security Considerations
+## Security Considerations ⚠️
 
 ### Qwen Code Security Risks
-- **Auto-approval Danger**: --yolo flag automatically approves ALL actions including file writes, edits, and deletions
-- **Built-in File Operations**: Native write_file, edit tools can modify or delete files without confirmation
-- **No Directory Isolation**: Missing -w flag makes it harder to restrict file access scope
-- **Web Access**: Built-in web_search and web_fetch can access external content (potential data leakage)
+- **Auto-approval Danger**: `--yolo` flag automatically approves ALL actions including file writes, edits, and deletions
+- **Built-in File Operations**: Native `write_file`, `edit` tools can modify or delete files without confirmation
+- **No Directory Isolation**: Missing `-w` flag makes it harder to restrict file access scope
+- **Web Access**: Built-in `web_search` and `web_fetch` can access external content (potential data leakage)
 
 ### Critical Safety Measures
 
@@ -206,18 +179,10 @@ git add -A && git commit -m "Pre-Qwen-backup" && qwen -p "Task" --yolo -o text
 
 | Risk Level | Task Type | Safety Measures |
 |------------|-----------|-----------------|
-| **Low** | Read-only analysis, web search | --yolo acceptable, add timeout |
-| **Medium** | File reading, code analysis | Use --approval-mode default, exclude write tools |
-| **High** | File editing, refactoring | Use --approval-mode plan, manual review required |
+| **Low** | Read-only analysis, web search | `--yolo` acceptable, add timeout |
+| **Medium** | File reading, code analysis | Use `--approval-mode default`, exclude write tools |
+| **High** | File editing, refactoring | Use `--approval-mode plan`, manual review required |
 | **Critical** | System changes, deletions | Avoid delegation, handle directly with Claude Code |
-
-### Emergency Response
-If Qwen starts executing dangerous operations:
-1. **Immediate Interrupt**: Ctrl+C to stop execution
-2. **Check Git Status**: git status to see file changes
-3. **Restore Files**: git checkout -- . to revert modifications
-4. **Review Logs**: Check ~/.qwen/debug/ for execution details
-5. **Adjust Safety**: Strengthen tool exclusions or switch to approval modes
 
 ## Troubleshooting
 

--- a/qwen-code/SKILL.md
+++ b/qwen-code/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: qwen-code
+description: Delegate tasks to Qwen Code CLI as a subagent for file operations, web research, and code analysis. Use when you need to delegate tasks requiring rich built-in tools, high cache efficiency (>95%), and structured JSON output. WARNING: --yolo auto-approves ALL actions - use with caution.
+license: Complete terms in LICENSE.txt
+---
+
+# Qwen Code Delegation
+
+This skill enables delegation of appropriate tasks to Qwen Code CLI (Alibaba's command-line AI assistant) for efficient task distribution.
+
+## When to Use
+
+Delegate to Qwen Code for tasks that are:
+- **File and code operations**: Reading, writing, editing, searching files
+- **Web research**: Search and fetch web content for information gathering
+- **Basic to moderate complexity**: Well-defined tasks with clear outputs
+- **Data extraction**: Structured information gathering from various sources
+- **Routine checks**: Environment verification, dependency checks, system status
+
+### Suitable Tasks
+- List files in directory and subdirectories with details
+- Find all Python files and analyze their imports
+- Read documentation and extract key points
+- Search the web for specific technical information
+- Check system environment and installed tools
+- Run simple tests and summarize results
+- Extract data from files into structured formats
+- Search codebase for specific patterns or functions
+
+### Keep with Claude Code
+- Complex architectural decisions and system design
+- Multi-step system integration and deployment
+- Security-critical operations and sensitive data handling
+- Tasks requiring deep contextual understanding of the codebase
+- Team coordination, task management, and workflow orchestration
+
+## Key Characteristics
+
+### Strengths
+- **Rich Built-in Tools**: Native support for read_file, write_file, edit, web_search, grep_search, etc.
+- **High Cache Efficiency**: Typically >95% cache hit rate (cache_read_input_tokens in usage stats)
+- **Large Context Window**: 1M context length, suitable for processing long documents and code files
+- **Structured Output**: JSON format with detailed metadata (token usage, tool list, execution stats)
+- **Fast Execution**: Quick response times due to efficient caching and built-in tool integration
+- **Web Capabilities**: Built-in web search and content fetching without external dependencies
+
+### Limitations
+- **Auto-approval Risk**: --yolo flag automatically approves all actions (potentially dangerous)
+- **Less Transparent**: JSON output requires parsing, less human-readable than Kimi's ThinkPart
+- **No Directory Isolation**: No -w flag for working directory restriction
+- **Node.js Dependency**: Requires Node.js/npm environment
+
+## Basic Commands
+
+### Check Installation
+```bash
+qwen --version
+qwen --help
+```
+
+### Execute Task
+```bash
+# Non-interactive mode with text output (human readable)
+qwen -p "Your task description here" --yolo -o text
+
+# JSON output for programmatic processing
+qwen -p "Your task description here" --yolo -o json
+
+# Interactive mode (opens chat interface)
+qwen "Your prompt here"
+```
+
+## Delegation Workflow
+
+### 1. Task Assessment
+- Verify task fits "Suitable Tasks" criteria
+- Check that qwen command is available: which qwen
+- Determine if task requires text or JSON output format
+
+### 2. Command Construction
+```bash
+# Basic pattern for human-readable output
+qwen -p "Clear task description with necessary context" --yolo -o text
+
+# For programmatic processing and data extraction
+qwen -p "Structured task expecting JSON output" --yolo -o json
+
+# Example: File system analysis
+qwen -p "List all .py files in current directory with their sizes and line counts" --yolo -o text
+
+# Example: Code analysis with structured output
+qwen -p "Read main.py and output function signatures as JSON array" --yolo -o json
+```
+
+### 3. Execute and Parse
+```bash
+# Execute via Bash tool
+result=$(qwen -p "Task description" --yolo -o text 2>&1)
+
+# Check exit code (0 = success)
+echo $?
+
+# For JSON output, parse with jq
+json_result=$(qwen -p "Task" --yolo -o json 2>&1)
+parsed=$(echo "$json_result" | jq -r '.[-1].result')
+```
+
+## Output Parsing
+
+### Text Output Format
+Qwen Code provides clean, formatted text output suitable for direct human consumption.
+
+### JSON Output Structure
+```json
+[
+  {
+    "type": "system",
+    "subtype": "init",
+    "tools": ["list_directory", "read_file", "web_search", ...],
+    "model": "coder-model"
+  },
+  {
+    "type": "result",
+    "subtype": "success",
+    "result": "Final answer text",
+    "usage": {
+      "input_tokens": 13324,
+      "output_tokens": 284,
+      "cache_read_input_tokens": 13002,
+      "total_tokens": 13608
+    }
+  }
+]
+```
+
+### Key Fields to Extract
+1. **.result**: Complete answer text
+2. **.message.content[0].text**: Assistant's text response
+3. **.usage**: Token usage statistics for cost monitoring
+4. **.tools**: List of available tools (for debugging)
+
+## Examples
+
+### Example 1: Comprehensive File System Analysis
+```bash
+qwen -p "Find all Python files in the project directory and subdirectories, show their sizes, line counts, last modification dates, and count total lines of Python code" --yolo -o text
+```
+
+### Example 2: Code Documentation Extraction
+```bash
+qwen -p "Read the file src/utils.py and create a structured JSON output containing: function names, parameters, return types, docstrings, and line numbers" --yolo -o json
+```
+
+### Example 3: Web Research Task
+```bash
+qwen -p "Search for recent best practices about Python type hints and async programming, summarize key points in bullet format" --yolo -o text
+```
+
+### Example 4: Environment and Dependency Check
+```bash
+qwen -p "Check Python version, Node.js version, Docker status, list installed Python packages, and verify if git is configured" --yolo -o text
+```
+
+## Security Considerations
+
+### Qwen Code Security Risks
+- **Auto-approval Danger**: --yolo flag automatically approves ALL actions including file writes, edits, and deletions
+- **Built-in File Operations**: Native write_file, edit tools can modify or delete files without confirmation
+- **No Directory Isolation**: Missing -w flag makes it harder to restrict file access scope
+- **Web Access**: Built-in web_search and web_fetch can access external content (potential data leakage)
+
+### Critical Safety Measures
+
+#### 1. Avoid --yolo for File Operations
+```bash
+# DANGEROUS: Auto-approves file modifications
+qwen -p "Edit config file" --yolo -o text
+
+# SAFER: Use approval modes for file operations
+qwen -p "Edit config file" --approval-mode default -o text
+qwen -p "Edit config file" --approval-mode plan -o text
+```
+
+#### 2. Exclude Dangerous Tools
+```bash
+# Prevent write/delete operations
+qwen -p "Task" --exclude-tools write_file,edit --yolo -o text
+
+# Read-only mode (approximate)
+qwen -p "Analysis task" --exclude-tools write_file,edit,run_shell_command --yolo -o text
+```
+
+#### 3. Implement External Safeguards
+```bash
+# Use timeout to prevent hanging
+timeout 30 qwen -p "Task" --yolo -o text
+
+# Run in restricted directory
+cd /safe/workspace && qwen -p "Task" --yolo -o text
+
+# Git protection layer
+git add -A && git commit -m "Pre-Qwen-backup" && qwen -p "Task" --yolo -o text
+```
+
+### Risk-Based Task Categorization
+
+| Risk Level | Task Type | Safety Measures |
+|------------|-----------|-----------------|
+| **Low** | Read-only analysis, web search | --yolo acceptable, add timeout |
+| **Medium** | File reading, code analysis | Use --approval-mode default, exclude write tools |
+| **High** | File editing, refactoring | Use --approval-mode plan, manual review required |
+| **Critical** | System changes, deletions | Avoid delegation, handle directly with Claude Code |
+
+### Emergency Response
+If Qwen starts executing dangerous operations:
+1. **Immediate Interrupt**: Ctrl+C to stop execution
+2. **Check Git Status**: git status to see file changes
+3. **Restore Files**: git checkout -- . to revert modifications
+4. **Review Logs**: Check ~/.qwen/debug/ for execution details
+5. **Adjust Safety**: Strengthen tool exclusions or switch to approval modes
+
+## Troubleshooting
+
+### Qwen Not Found
+```bash
+# Check installation
+which qwen
+# Expected: ~/.nvm/versions/node/v*/bin/qwen or similar
+# If missing, install via npm:
+npm install -g @qwen-ai/code
+```
+
+### Command Failures
+```bash
+# Test basic functionality
+qwen -p "Say hello" --yolo -o text
+
+# Enable debug mode for detailed logs
+qwen -p "Task" --yolo --debug -o text
+
+# Check debug logs location
+ls -la ~/.qwen/debug/
+```
+
+### JSON Parsing Issues
+```bash
+# Install jq for JSON parsing if not available
+sudo apt-get install jq
+
+# Test JSON parsing
+qwen -p "Test JSON output" --yolo -o json | jq .
+
+# Extract specific field
+qwen -p "Task" --yolo -o json | jq -r '.[-1].result'
+```
+
+## References
+
+- [Qwen Code GitHub Repository](https://github.com/QwenLM/Qwen-Code)
+- [Alibaba Qwen Models Documentation](https://qwenlm.github.io/)
+- [Qwen Code CLI Documentation](https://help.aliyun.com/zh/model-studio/developer-reference/qwen-code-cli)

--- a/qwen-code/SKILL.md.bak
+++ b/qwen-code/SKILL.md.bak
@@ -1,0 +1,261 @@
+---
+name: qwen-code
+description: Delegate tasks to Qwen Code CLI as a subagent for file operations, web research, and code analysis. Use when you need to delegate tasks requiring rich built-in tools, high cache efficiency (>95%), and structured JSON output. WARNING: --yolo auto-approves ALL actions - use with caution.
+license: Complete terms in LICENSE.txt
+---
+
+# Qwen Code Delegation
+
+This skill enables delegation of appropriate tasks to Qwen Code CLI (Alibaba's command-line AI assistant) for efficient task distribution.
+
+## When to Use
+
+Delegate to Qwen Code for tasks that are:
+- **File and code operations**: Reading, writing, editing, searching files
+- **Web research**: Search and fetch web content for information gathering
+- **Basic to moderate complexity**: Well-defined tasks with clear outputs
+- **Data extraction**: Structured information gathering from various sources
+- **Routine checks**: Environment verification, dependency checks, system status
+
+### Suitable Tasks
+- List files in directory and subdirectories with details
+- Find all Python files and analyze their imports
+- Read documentation and extract key points
+- Search the web for specific technical information
+- Check system environment and installed tools
+- Run simple tests and summarize results
+- Extract data from files into structured formats
+- Search codebase for specific patterns or functions
+
+### Keep with Claude Code
+- Complex architectural decisions and system design
+- Multi-step system integration and deployment
+- Security-critical operations and sensitive data handling
+- Tasks requiring deep contextual understanding of the codebase
+- Team coordination, task management, and workflow orchestration
+
+## Key Characteristics
+
+### Strengths
+- **Rich Built-in Tools**: Native support for read_file, write_file, edit, web_search, grep_search, etc.
+- **High Cache Efficiency**: Typically >95% cache hit rate (cache_read_input_tokens in usage stats)
+- **Large Context Window**: 1M context length, suitable for processing long documents and code files
+- **Structured Output**: JSON format with detailed metadata (token usage, tool list, execution stats)
+- **Fast Execution**: Quick response times due to efficient caching and built-in tool integration
+- **Web Capabilities**: Built-in web search and content fetching without external dependencies
+
+### Limitations
+- **Auto-approval Risk**: --yolo flag automatically approves all actions (potentially dangerous)
+- **Less Transparent**: JSON output requires parsing, less human-readable than Kimi's ThinkPart
+- **No Directory Isolation**: No -w flag for working directory restriction
+- **Node.js Dependency**: Requires Node.js/npm environment
+
+## Basic Commands
+
+### Check Installation
+```bash
+qwen --version
+qwen --help
+```
+
+### Execute Task
+```bash
+# Non-interactive mode with text output (human readable)
+qwen -p "Your task description here" --yolo -o text
+
+# JSON output for programmatic processing
+qwen -p "Your task description here" --yolo -o json
+
+# Interactive mode (opens chat interface)
+qwen "Your prompt here"
+```
+
+## Delegation Workflow
+
+### 1. Task Assessment
+- Verify task fits "Suitable Tasks" criteria
+- Check that qwen command is available: which qwen
+- Determine if task requires text or JSON output format
+
+### 2. Command Construction
+```bash
+# Basic pattern for human-readable output
+qwen -p "Clear task description with necessary context" --yolo -o text
+
+# For programmatic processing and data extraction
+qwen -p "Structured task expecting JSON output" --yolo -o json
+
+# Example: File system analysis
+qwen -p "List all .py files in current directory with their sizes and line counts" --yolo -o text
+
+# Example: Code analysis with structured output
+qwen -p "Read main.py and output function signatures as JSON array" --yolo -o json
+```
+
+### 3. Execute and Parse
+```bash
+# Execute via Bash tool
+result=$(qwen -p "Task description" --yolo -o text 2>&1)
+
+# Check exit code (0 = success)
+echo $?
+
+# For JSON output, parse with jq
+json_result=$(qwen -p "Task" --yolo -o json 2>&1)
+parsed=$(echo "$json_result" | jq -r '.[-1].result')
+```
+
+## Output Parsing
+
+### Text Output Format
+Qwen Code provides clean, formatted text output suitable for direct human consumption.
+
+### JSON Output Structure
+```json
+[
+  {
+    "type": "system",
+    "subtype": "init",
+    "tools": ["list_directory", "read_file", "web_search", ...],
+    "model": "coder-model"
+  },
+  {
+    "type": "result",
+    "subtype": "success",
+    "result": "Final answer text",
+    "usage": {
+      "input_tokens": 13324,
+      "output_tokens": 284,
+      "cache_read_input_tokens": 13002,
+      "total_tokens": 13608
+    }
+  }
+]
+```
+
+### Key Fields to Extract
+1. **.result**: Complete answer text
+2. **.message.content[0].text**: Assistant's text response
+3. **.usage**: Token usage statistics for cost monitoring
+4. **.tools**: List of available tools (for debugging)
+
+## Examples
+
+### Example 1: Comprehensive File System Analysis
+```bash
+qwen -p "Find all Python files in the project directory and subdirectories, show their sizes, line counts, last modification dates, and count total lines of Python code" --yolo -o text
+```
+
+### Example 2: Code Documentation Extraction
+```bash
+qwen -p "Read the file src/utils.py and create a structured JSON output containing: function names, parameters, return types, docstrings, and line numbers" --yolo -o json
+```
+
+### Example 3: Web Research Task
+```bash
+qwen -p "Search for recent best practices about Python type hints and async programming, summarize key points in bullet format" --yolo -o text
+```
+
+### Example 4: Environment and Dependency Check
+```bash
+qwen -p "Check Python version, Node.js version, Docker status, list installed Python packages, and verify if git is configured" --yolo -o text
+```
+
+## Security Considerations
+
+### Qwen Code Security Risks
+- **Auto-approval Danger**: --yolo flag automatically approves ALL actions including file writes, edits, and deletions
+- **Built-in File Operations**: Native write_file, edit tools can modify or delete files without confirmation
+- **No Directory Isolation**: Missing -w flag makes it harder to restrict file access scope
+- **Web Access**: Built-in web_search and web_fetch can access external content (potential data leakage)
+
+### Critical Safety Measures
+
+#### 1. Avoid --yolo for File Operations
+```bash
+# DANGEROUS: Auto-approves file modifications
+qwen -p "Edit config file" --yolo -o text
+
+# SAFER: Use approval modes for file operations
+qwen -p "Edit config file" --approval-mode default -o text
+qwen -p "Edit config file" --approval-mode plan -o text
+```
+
+#### 2. Exclude Dangerous Tools
+```bash
+# Prevent write/delete operations
+qwen -p "Task" --exclude-tools write_file,edit --yolo -o text
+
+# Read-only mode (approximate)
+qwen -p "Analysis task" --exclude-tools write_file,edit,run_shell_command --yolo -o text
+```
+
+#### 3. Implement External Safeguards
+```bash
+# Use timeout to prevent hanging
+timeout 30 qwen -p "Task" --yolo -o text
+
+# Run in restricted directory
+cd /safe/workspace && qwen -p "Task" --yolo -o text
+
+# Git protection layer
+git add -A && git commit -m "Pre-Qwen-backup" && qwen -p "Task" --yolo -o text
+```
+
+### Risk-Based Task Categorization
+
+| Risk Level | Task Type | Safety Measures |
+|------------|-----------|-----------------|
+| **Low** | Read-only analysis, web search | --yolo acceptable, add timeout |
+| **Medium** | File reading, code analysis | Use --approval-mode default, exclude write tools |
+| **High** | File editing, refactoring | Use --approval-mode plan, manual review required |
+| **Critical** | System changes, deletions | Avoid delegation, handle directly with Claude Code |
+
+### Emergency Response
+If Qwen starts executing dangerous operations:
+1. **Immediate Interrupt**: Ctrl+C to stop execution
+2. **Check Git Status**: git status to see file changes
+3. **Restore Files**: git checkout -- . to revert modifications
+4. **Review Logs**: Check ~/.qwen/debug/ for execution details
+5. **Adjust Safety**: Strengthen tool exclusions or switch to approval modes
+
+## Troubleshooting
+
+### Qwen Not Found
+```bash
+# Check installation
+which qwen
+# Expected: ~/.nvm/versions/node/v*/bin/qwen or similar
+# If missing, install via npm:
+npm install -g @qwen-ai/code
+```
+
+### Command Failures
+```bash
+# Test basic functionality
+qwen -p "Say hello" --yolo -o text
+
+# Enable debug mode for detailed logs
+qwen -p "Task" --yolo --debug -o text
+
+# Check debug logs location
+ls -la ~/.qwen/debug/
+```
+
+### JSON Parsing Issues
+```bash
+# Install jq for JSON parsing if not available
+sudo apt-get install jq
+
+# Test JSON parsing
+qwen -p "Test JSON output" --yolo -o json | jq .
+
+# Extract specific field
+qwen -p "Task" --yolo -o json | jq -r '.[-1].result'
+```
+
+## References
+
+- [Qwen Code GitHub Repository](https://github.com/QwenLM/Qwen-Code)
+- [Alibaba Qwen Models Documentation](https://qwenlm.github.io/)
+- [Qwen Code CLI Documentation](https://help.aliyun.com/zh/model-studio/developer-reference/qwen-code-cli)


### PR DESCRIPTION
This PR adds two new skills for delegating tasks to Kimi Code CLI and Qwen Code CLI as subagents.

### Problem Solved
Claude Code users often need to delegate simple to moderate tasks to other AI coding assistants for efficiency. These skills teach Claude when and how to delegate tasks appropriately.

### Real-World Use Case
- **Developers**: Delegate file operations, code reading, and analysis tasks while maintaining focus on complex work
- **Researchers**: Delegate web research and data extraction tasks to specialized tools
- **Technical Writers**: Delegate documentation summarization and code explanation tasks

### Skill Details

#### Kimi Code Skill ()
- **What it does**: Teaches Claude to delegate tasks to Kimi Code CLI (Moonshot AI) for file operations, code summarization, and analysis
- **Key features**: Transparent execution with ThinkPart/ToolCall visibility, safe --print mode, working directory isolation
- **Use cases**: File listing, code reading, environment checks, simple test runs

#### Qwen Code Skill ()
- **What it does**: Teaches Claude to delegate tasks to Qwen Code CLI (Alibaba) for file operations, web research, and code analysis
- **Key features**: Rich built-in tools, >95% cache efficiency, 1M context window, structured JSON output
- **Use cases**: Web research, data extraction, file operations, environment verification

### Attribution
Skills developed by @Dominic789654 based on real usage of Kimi Code and Qwen Code CLI tools.

### Example Usage
**User**: "List all Python files in the current directory and count their lines"
**Claude (using kimi-code skill)**: Delegates to Kimi Code: `kimi -p "List all .py files with line counts" --print`

**User**: "Search for recent best practices about Python async programming"
**Claude (using qwen-code skill)**: Delegates to Qwen Code: `qwen -p "Search for Python async programming best practices" --yolo -o text`

Both skills include comprehensive safety guidelines and follow official Anthropic skill format.