### PR TITLE
Add Claude Recall - auto-generate skills from usage patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ If you receive the email, Claude is now connected to 500+ apps.
 - [Resources](#resources)
 - [License](#license)
 
+- [Claude Recall](https://github.com/zchdu/claude-recall) - Automatically discovers repeated workflows from Claude Code usage logs and generates reusable skills via PostToolUse hook logging and cross-session pattern analysis.
 ## What Are Claude Skills?
 
 Claude Skills are customizable workflows that teach Claude how to perform specific tasks according to your unique requirements. Skills enable Claude to execute tasks in a repeatable, standardized manner across all Claude platforms.


### PR DESCRIPTION
Adds [Claude Recall](https://github.com/zchdu/claude-recall) to **Development & Code Tools**.

Watches Claude Code usage via PostToolUse hook, analyzes logs across sessions, discovers repeated multi-step workflows, and generates skill files automatically.