### PR TITLE
Add polaris-datainsight-doc-extract skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [docx](https://github.com/anthropics/skills/tree/main/skills/docx) - Create, edit, analyze Word docs with tracked changes, comments, formatting.
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
+- [polaris-datainsight-doc-extract](https://github.com/jacob-g-park/polaris-datainsight-doc-extract) - Extract structured data from Office documents (DOCX, PPTX, XLSX, HWP, HWPX) using the Polaris AI DataInsight Doc Extract API.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
-- [polaris-datainsight-doc-extract](https://github.com/jacob-g-park/polaris-datainsight-doc-extract) - Extract structured data from Office documents (DOCX, PPTX, XLSX, HWP, HWPX) using the Polaris AI DataInsight Doc Extract API.
 
 ### Development & Code Tools
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
+- [polaris-datainsight-doc-extract](https://github.com/jacob-g-park/polaris-datainsight-doc-extract) - Extract structured data from Office documents (DOCX, PPTX, XLSX, HWP, HWPX) using the Polaris AI DataInsight Doc Extract API.
 
 ### Development & Code Tools
 


### PR DESCRIPTION
# Description

  The Polaris AI DataInsight Doc Extract workflow converts Office documents (DOCX, PPTX, XLSX, HWP, HWPX) into a structured unifiedSchema JSON with a single API call.
  It extracts text, tables, charts, images, shapes, equations, headers, and footers.
  Before using this workflow, you must issue an API key from Polaris DataInsight and register it as the environment variable POLARIS_DATAINSIGHT_API_KEY.

  ## What problem it solves

  Manually parsing each document format is brittle and expensive to maintain.
  This workflow provides one consistent extraction format across multiple file types, making downstream analytics, automation, and RAG pipelines much easier.

  ## Who uses this workflow

  - Data/AI engineers building document intelligence or RAG pipelines
  - Analysts extracting table/chart data from reports
  - Developers automating batch document processing
  - Teams digitizing legacy HWP/HWPX and Office documents into machine-readable data

  ## Attribution/inspiration source

  Polaris Office DataInsight API official documentation and the documented Doc Extract workflow in the skill.

  ## Example of how it’s used

  1. Issue an API key from the Polaris DataInsight site
  2. Set export POLARIS_DATAINSIGHT_API_KEY="your-api-key"
  3. Upload report.docx to the Doc Extract API
  4. Unzip the response and load unifiedSchema JSON
  5. Collect fields like table.content.csv for BI, database loading, or RAG indexing