### PR TITLE
Add skill: Product Manager Agent by Digidai

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Product Manager Agent](https://github.com/Digidai/product-manager-skills) - AI-native PM agent with 6 knowledge modules and 10 templates covering PRD, user stories, roadmaps, SaaS metrics, positioning, discovery interviews, career coaching, and AI product strategy. *By [@Digidai](https://github.com/Digidai)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Add PM Agent Skill

- **Skill:** [Product Manager Agent](https://github.com/Digidai/product-manager-skills) by [Gene Dai](https://genedai.me/)
- **Category:** Business & Marketing
- **Description:** AI-native PM agent with 6 knowledge modules and 10 templates covering PRD, user stories, roadmaps, SaaS metrics, positioning, discovery interviews, career coaching, and AI product strategy
- **Install:** `clawhub install pm-agent` or `npx skills add Digidai/product-manager-skills`