### PR TITLE
Add comic-transcriber skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Creative & Media
 
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [Comic Transcriber](https://github.com/nearestnabors/comic-transcriber) - Converts comic pages into markdown scripts with descriptions, captions, scenes. *By [@nearestnabors](https://github.com/nearestnabors)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
  Adds a skill for transcribing comic book pages into structured markdown.

  - Extracts dialogue, action, narration, and sound effects
  - Outputs play-script format with panel-by-panel breakdown
  - Useful for accessibility, archiving, and searchability

  Repo: https://github.com/nearestnabors/comic-transcriber