### PR TITLE
Add defi-mcp — DeFi data skill for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [defi-mcp](https://github.com/OzorOwn/defi-mcp) - DeFi MCP server for Claude Code with 12 tools: real-time crypto prices, multi-chain wallet balances (9 chains), DEX quotes via Jupiter and Li.Fi, and token search across 275+ assets. *By [@OzorOwn](https://github.com/OzorOwn)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 


### PR DESCRIPTION
Adds [defi-mcp](https://github.com/OzorOwn/defi-mcp) to the Data & Analysis section.

**What it does:**
- MCP server providing Claude Code with real-time DeFi data
- 12 tools: crypto prices, multi-chain wallet balances (ETH, SOL, Base, Polygon, Arbitrum, Optimism, Avalanche, BSC, Fantom), DEX quotes via Jupiter and Li.Fi, token search across 275+ assets
- Works with Claude Desktop, Cursor, and Claude Code via standard MCP config
- Also available as a hosted REST API (no local setup required)

**Section:** Data & Analysis (alphabetical order between deep-research and postgres)