### PR TITLE
docs: add Developer Marketing Skills to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Developer Marketing Skills](https://github.com/jonathimer/devmarketing-skills) - 33 skills for marketing to developers — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, newsletters, and SEO for devtools. *By [@jonathimer](https://github.com/jonathimer)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Summary

Adding [jonathimer/devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) to the Business & Marketing section.

**What it is:** 33 AI agent skills specifically for marketing to developers — who skip landing pages, go straight to docs, and read HN comments before signing up.

**Skills include:**
- Hacker News strategy (what works vs what gets flagged)
- Technical tutorials
- Docs-as-marketing
- Reddit engagement
- Developer onboarding
- Developer newsletters
- SEO for devtools
- Community building
- Competitor tracking
- And more

**License:** MIT

**Install:** `npx add-skill jonathimer/devmarketing-skills`

Works with Claude Code, Cursor, Windsurf.