### PR TITLE
Add Design Auditor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Creative & Media
 
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [Design Auditor](https://github.com/Ashutos1997/claude-design-auditor-skill) - Audits designs against 17 professional rules including typography, WCAG contrast, spacing, accessibility, iconography, navigation, and design tokens. Scores out of 100. Supports English and Korean.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.

--- a/design-auditor/SKILL.md
+++ b/design-auditor/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: design-auditor
+description: Audit and check designs against 17 professional design rules. Use when reviewing Figma files, HTML/CSS/React/Vue code, screenshots, or design descriptions for issues with typography, contrast, spacing, accessibility, iconography, navigation, tokens, and more.
+---
+
+# Design Auditor
+
+A skill for auditing designs against 17 professional design rules. Gives scored, actionable feedback with plain-language explanations — built for developers who don't have a design background and designers who want a fast second opinion.
+
+## When to Use This Skill
+
+- Reviewing a Figma file, screenshot, or UI code for design issues
+- Checking accessibility and WCAG contrast compliance
+- Auditing a design system for token health
+- Getting feedback before shipping a UI to production
+- Learning why a design feels "off" without knowing the specific rule
+
+## What This Skill Does
+
+1. **Scores the design out of 100**: Deterministic formula — Critical issues (-8pts), Warnings (-4pts), Tips (-1pt)
+2. **Audits across 17 categories**: Typography, color, spacing, hierarchy, consistency, accessibility, forms, motion, dark mode, responsive, states, microcopy, i18n, corner radius, elevation, iconography, navigation, design tokens
+3. **Explains every issue**: Plain-language reasoning for why each rule matters, not just what is wrong
+4. **Declares audit confidence**: High (Figma MCP or code), Medium (screenshot), Low (description only)
+5. **Offers to fix directly**: Applies fixes in code or Figma after the audit
+
+## How to Use
+
+### Basic Usage
+
+Share a Figma link, paste HTML/CSS/React/Vue code, or upload a screenshot:
+
+```
+"Check my design"
+"Review my UI for accessibility issues"
+"Audit this component for spacing and contrast"
+"Does this follow WCAG?"
+```
+
+### Korean Usage
+
+The skill detects Korean input and responds entirely in Korean:
+
+```
+"디자인 검토해줘"
+"접근성 확인해줘"
+"UI 검토해줘"
+```
+
+### Figma MCP
+
+When Figma is connected via MCP, share a Figma URL directly. The skill pulls full layer data, typography, colors, and spacing — then runs the audit and offers to apply fixes in Figma.
+
+## Tips
+
+- Share code or a Figma link for the highest confidence audit — screenshots limit what can be verified
+- Ask for a focused audit (e.g. "just check accessibility") to get faster, targeted feedback
+- After the audit, ask Claude to fix specific issues directly in the code
+- Use the token health score to assess design system maturity in larger codebases
+
+## Common Use Cases
+
+- Developer building a UI who wants to catch issues before design review
+- Designer running a quick WCAG check before handoff
+- Team auditing a new component library for consistency
+- Learning what design rules apply to a specific UI pattern


### PR DESCRIPTION
Adds Design Auditor — a Claude skill that audits designs against 17 
professional rules with a scored, actionable report.

**What it does:**
- Scores designs out of 100 (deterministic: 🔴 −8pts, 🟡 −4pts, 🟢 −1pt)
- Audits 17 categories: typography, WCAG contrast, spacing, accessibility, 
  iconography, navigation, design tokens + more
- Works with Figma MCP, HTML/CSS/React/Vue, and screenshots
- Supports English and Korean
- Offers to fix issues directly in code or Figma after the audit

**Changes:**
- Added `design-auditor/SKILL.md`
- Added entry to README under Creative Content

GitHub: https://github.com/Ashutos1997/claude-design-auditor-skill