### PR TITLE
Add Product Manager Skills to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Product Manager Skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains (discovery, strategy, delivery, finance, career, AI product craft), 30+ frameworks, 10 templates, and 32 SaaS metrics with formulas. Pure Markdown, zero scripts.
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Added Skill

**[Product Manager Skills](https://github.com/Digidai/product-manager-skills)** — Senior PM agent skill for Claude Code.

### Category
Business & Marketing

### What it does
A single-install skill that gives Claude 6 PM knowledge domains, 30+ frameworks, 10 templates, and 32 SaaS metrics with exact formulas:

- **Discovery & Research**: JTBD, Mom Test, Opportunity Solution Tree, PoL Probes
- **Strategy & Positioning**: Geoffrey Moore, PESTEL, TAM/SAM/SOM, RICE/Kano
- **Artifacts & Delivery**: PRD, user stories (Cohn + Gherkin), epics, PRFAQ
- **Finance & Metrics**: 32 SaaS metrics with formulas and stage-specific benchmarks
- **Career & Leadership**: PM to Director to VP to CPO transition frameworks
- **AI Product Craft**: Context engineering, agent orchestration

### Security
Pure Markdown, zero scripts, zero dependencies, no network calls. Fully auditable.

### License
CC BY-NC-SA 4.0