### PR TITLE
Add research-orchestrator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [research-orchestrator](https://github.com/altmbr/claude-research-skill) - Multi-agent research skill that decomposes questions into parallel workstreams, monitors agent progress, and synthesizes results with inline citations. *By [@altmbr](https://github.com/altmbr)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 
 ### Business & Marketing


### PR DESCRIPTION
## Add research-orchestrator skill

### What problem it solves

Research tasks in Claude Code today are single-threaded: one agent works through a question linearly, which is slow for complex, multi-faceted queries. research-orchestrator solves this by decomposing a research question into independent workstreams, dispatching parallel sub-agents, monitoring their progress, and synthesizing their findings into a single report with inline citations.

### Who uses this workflow

Anyone doing deep research with Claude Code -- competitive analysis, technical due diligence, literature reviews, market landscaping -- where the question naturally breaks into multiple independent lines of inquiry that can run simultaneously.

### What the skill does

- Decomposes complex research questions into parallel, independent workstreams
- Dispatches and monitors sub-agent progress across workstreams
- Synthesizes results into a unified report with inline citations
- Handles failures gracefully (kills stuck agents, relaunches with pre-loaded data)

### Category

Data & Analysis -- alongside existing research-oriented skills like deep-research and root-cause-tracing.

### Links

- Repository: https://github.com/altmbr/claude-research-skill