### PR TITLE
Add 3 skills: mac-ai-optimizer, social-copy-generator, skill-multi-publisher

### DIFF
--- a/mac-ai-optimizer/SKILL.md
+++ b/mac-ai-optimizer/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: mac-ai-optimizer
+description: Optimize macOS for AI workloads (OpenClaw, Docker, Ollama). Reduce idle memory from 6GB to 2.5GB by disabling background services, reducing UI overhead, configuring Docker limits, and enabling SSH. Turn an 8GB Mac into a lean AI server node.
+---
+
+# Mac AI Optimizer
+
+Optimize macOS for AI workloads. Turn an 8GB Mac into a lean AI server node with near-16GB performance for Agent tasks.
+
+## When to Use This Skill
+
+- Running OpenClaw, Ollama, or Docker on a low-memory Mac
+- Building a Mac mini AI compute cluster
+- Need maximum available RAM for AI Agent workloads
+- Docker keeps running out of memory (OOM)
+
+## What This Skill Does
+
+1. **Optimize Memory**: Disable Spotlight, Siri, photo analysis, iCloud sync, analytics — saves ~1.5GB
+2. **Reduce UI**: Disable animations, transparency, Dock effects — saves ~400MB
+3. **Docker Tuning**: Auto-set CPU/RAM/swap limits based on actual system RAM
+4. **SSH Setup**: Enable remote login, output connection info and SSH config snippet
+5. **System Report**: Show current memory, CPU, swap, disk, and background service count
+6. **Full Optimize**: Run all above in sequence — one command to server-ify a Mac
+7. **Revert All**: One command to restore all macOS defaults
+
+## Expected Results (8GB Mac)
+
+| State | Memory Used | Available |
+|-------|-------------|-----------|
+| Default macOS | ~6GB | ~2GB |
+| After optimization | ~2.5GB | ~5.5GB |
+| Headless mode | ~1.8GB | ~6.2GB |
+
+## How to Use
+
+```
+Optimize this Mac for AI workloads
+```
+
+Or run individual tools:
+```
+Show system resource report
+Optimize memory for AI
+Reduce UI overhead
+Optimize Docker for this Mac
+Enable SSH remote access
+```
+
+## Install
+
+```
+npx skills add dongsheng123132/mac-ai-optimizer
+clawhub install mac-ai-optimizer
+```
+
+## Examples
+
+- "My Mac only has 8GB RAM, make it run AI better"
+- "Turn this Mac mini into an AI server"
+- "Reduce memory usage so Docker runs better"

--- a/skill-multi-publisher/SKILL.md
+++ b/skill-multi-publisher/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: skill-multi-publisher
+description: One-command publish a Claude Code skill to ALL major marketplaces — GitHub (npx skills), ClawHub, and community directories (composiohq/awesome-claude-skills, anthropics/skills, daymade/claude-code-skills). Validates, auto-generates files, publishes, and submits PRs.
+---
+
+# Skill Multi-Publisher
+
+Publish a skill to ALL major marketplaces with one command. Direct publish to GitHub + ClawHub, then auto-submit PRs to community directories.
+
+## When to Use This Skill
+
+- Publishing a new skill and want maximum reach
+- Submitting to multiple community marketplaces at once
+- Need to update a skill across all platforms
+- Want automated PR submission to awesome-claude-skills, anthropics/skills, etc.
+
+## What This Skill Does
+
+1. **Validate**: Check SKILL.md frontmatter (name, version, description)
+2. **Auto-Generate**: Create LICENSE and README.md if missing
+3. **GitHub**: Create public repo and push (npx skills discoverable)
+4. **ClawHub**: Publish via clawhub CLI
+5. **Community PRs**: Fork and submit PRs to major directories:
+   - composiohq/awesome-claude-skills (41K+ stars)
+   - anthropics/skills (86K+ stars)
+   - daymade/claude-code-skills (623 stars)
+   - obra/superpowers-marketplace (595 stars)
+6. **Report**: Show all published URLs and PR links
+
+## Supported Platforms
+
+| Platform | Stars | Method |
+|----------|-------|--------|
+| GitHub (npx skills) | - | Direct push |
+| ClawHub | - | Direct publish |
+| composiohq/awesome-claude-skills | 41K+ | PR |
+| anthropics/skills | 86K+ | PR |
+| daymade/claude-code-skills | 623 | PR |
+| obra/superpowers-marketplace | 595 | PR |
+| anthropics/claude-plugins-official | 9.3K | Form |
+
+## How to Use
+
+```
+Publish this skill to all platforms
+发布skill到所有市场
+Submit to awesome-claude-skills
+```
+
+## Install
+
+```
+npx skills add dongsheng123132/skill-multi-publisher
+clawhub install skill-multi-publisher
+```

--- a/social-copy-generator/SKILL.md
+++ b/social-copy-generator/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: social-copy-generator
+description: Generate platform-optimized social media copy for product launches. One input, six platform outputs (Twitter/X, Jike, Xiaohongshu, WeChat Moments, Video Account, LinkedIn). Auto-generates an HTML page with one-click copy buttons.
+---
+
+# Social Copy Generator
+
+Generate social media copy for multiple platforms from a single product description. Output as an HTML page with one-click copy buttons.
+
+## When to Use This Skill
+
+- Launching an open source project and need social media posts
+- Promoting a product across multiple platforms at once
+- Need platform-specific marketing copy (Twitter vs Xiaohongshu vs WeChat)
+- Want copy-paste-ready text without terminal whitespace issues
+
+## What This Skill Does
+
+1. **Multi-Platform Copy**: Generate optimized copy for 6 platforms in one go
+2. **Platform Rules**: Respect each platform's character limits, style, and conventions
+3. **HTML Output**: Create a styled webpage with copy buttons — no whitespace issues
+4. **Bilingual**: Support Chinese and English content
+5. **One-Click Copy**: Each platform card has a copy button using clipboard API
+
+## Supported Platforms
+
+| Platform | Style | Limits |
+|----------|-------|--------|
+| Twitter/X | Concise, technical, hashtags | 280 chars |
+| Jike | Developer community, dry content | No limit |
+| Xiaohongshu | Casual, emoji-rich, comparison data | No limit |
+| WeChat Moments | Personal, conversational | No limit |
+| Video Account | Title + description | Title < 30 chars |
+| LinkedIn | Professional, achievement-focused | No limit |
+
+## How to Use
+
+```
+Generate social media posts for my new project
+Write copy to promote this tool on all platforms
+帮我写社交媒体推广文案
+```
+
+## Install
+
+```
+npx skills add dongsheng123132/social-copy-generator
+clawhub install social-copy-generator
+```


### PR DESCRIPTION
## 3 New Skills

### 1. mac-ai-optimizer
Optimize macOS for AI workloads. Reduce idle memory from ~6GB to ~2.5GB by disabling background services (Spotlight, Siri, iCloud), reducing UI overhead, configuring Docker limits, and enabling SSH remote management. Turn an 8GB Mac into a lean AI server node.

- Install: `npx skills add dongsheng123132/mac-ai-optimizer`
- Also on ClawHub: `clawhub install mac-ai-optimizer`

### 2. social-copy-generator
Generate platform-optimized social media copy for product launches. One input, six platform outputs (Twitter/X, Jike, Xiaohongshu, WeChat Moments, Video Account, LinkedIn). Outputs an HTML page with one-click copy buttons.

- Install: `npx skills add dongsheng123132/social-copy-generator`
- Also on ClawHub: `clawhub install social-copy-generator`

### 3. skill-multi-publisher
One-command publish a skill to ALL major marketplaces: GitHub, ClawHub, and community directories. Auto-validates, generates missing files, publishes, and submits PRs.

- Install: `npx skills add dongsheng123132/skill-multi-publisher`
- Also on ClawHub: `clawhub install skill-multi-publisher`

## Testing
All 3 skills tested in Claude Code CLI and published to GitHub + ClawHub.