### PR TITLE
Add enzyme — semantic search for Obsidian vaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
+- [enzyme](https://github.com/jshph/enzyme-skill) - Semantic search for Obsidian vaults — surfaces connections between notes by concept, not keyword, using AI-generated catalyst questions anchored to tags, wikilinks, and folders. *By [@jshph](https://github.com/jshph)*
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.


### PR DESCRIPTION
Adds [enzyme](https://github.com/jshph/enzyme-skill) to the Productivity & Organization section.

Enzyme indexes an Obsidian vault's tags, wikilinks, and folders, generates AI-driven "catalyst" questions anchored to each entity, then uses those questions to drive semantic retrieval — surfacing connections between notes by concept rather than keyword.

- [enzyme.garden](https://enzyme.garden)
- [Self-contained skill repo](https://github.com/jshph/enzyme-skill) (bundled binary + embedding model)
- [CLI repo](https://github.com/jshph/enzyme)