### PR TITLE
Add NoizAI Skills to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [NoizAI Skills](https://github.com/NoizAI/skills) - Human-like TTS workflow skills with local/cloud backends, style presets, and app-delivery-oriented voice scripts.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
## Summary
- add `NoizAI Skills` entry to the **Creative & Media** section
- include concise and neutral description focused on TTS workflow capabilities

## Why
- relevant for users looking for practical voice generation and delivery-oriented skill workflows

Closes #343

Made with [Cursor](https://cursor.com)