### PR TITLE
Add Seek and Analyze Video skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Seek and Analyze Video](https://github.com/kennyzheng-builds/seek-and-analyze-video) - Search, import, and analyze video content from TikTok, YouTube, and Instagram with persistent AI memory using Memories.ai's Large Visual Memory Model. *By [@kennyzheng-builds](https://github.com/kennyzheng-builds)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
This PR adds the Seek and Analyze Video skill to the Creative & Media category.

## About the Skill

Seek and Analyze Video is a video intelligence skill that enables Claude to:
- Search and import video content from TikTok, YouTube, and Instagram
- Analyze video content using AI
- Maintain persistent memory across sessions using Memories.ai's Large Visual Memory Model

The skill has been added in alphabetical order within the Creative & Media section of the README.

Repository: https://github.com/kennyzheng-builds/seek-and-analyze-video