### PR TITLE
Add AI.MD — AI-native CLAUDE.md format converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [AI.MD](https://github.com/sstklen/ai-md) - Convert human-written CLAUDE.md into AI-native structured-label format for higher rule compliance and fewer tokens. Battle-tested across 4 models. *By [@sstklen](https://github.com/sstklen)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## What is AI.MD?

[AI.MD](https://github.com/sstklen/ai-md) converts human-written `CLAUDE.md` files into an AI-native structured-label format. Same rules, fewer tokens, higher compliance.

## Why it belongs here

- **Battle-tested**: 5 rounds of A/B testing across 4 models (Claude, GPT, Gemini, Codex) — structured-label format consistently outperforms prose in rule compliance
- **Practical**: Solves a real problem — as `CLAUDE.md` files grow complex, AI models skip or misinterpret prose-based rules. Structured labels fix that
- **Complements existing skills**: Works alongside `prompt-engineering` and `Skill Creator` already in this list

## Category

Added to **Development & Code Tools** (alphabetical order), alongside similar context-engineering tools like `prompt-engineering`.

## Link

https://github.com/sstklen/ai-md