### PR TITLE
Add Agent Almanac - 299 skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [Agent Almanac](https://github.com/pjt222/agent-almanac) - A composable library of 299 skills, 62 agents, and 12 teams following the [Agent Skills open standard](https://agentskills.io) across 50+ domains including R packages, containerization, security, and CI/CD. *By [@pjt222](https://github.com/pjt222)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## Summary

- Adds [Agent Almanac](https://github.com/pjt222/agent-almanac) to the Development & Code Tools category
- Agent Almanac is a composable library of **299 skills**, **62 agents**, and **12 teams** following the [Agent Skills open standard](https://agentskills.io)
- Covers 50+ domains including R package development, containerization, security auditing, CI/CD, MCP server integration, and more

## What is Agent Almanac?

Agent Almanac provides a structured system where:
- **Skills** define *how* to do something (step-by-step procedures with validation and error handling)
- **Agents** define *who* does it (persona definitions with tool access and skill assignments)
- **Teams** define *who works together* (multi-agent compositions with coordination patterns)

All skills follow the Agent Skills open standard with YAML frontmatter, numbered procedures, expected/on-failure blocks, and validation steps. Skills are discoverable as Claude Code slash commands when symlinked into `.claude/skills/`.

## Key domains covered

- Software development (R packages, web dev, architecture, testing)
- DevOps & infrastructure (containerization, CI/CD, monitoring)
- Security (auditing, compliance, GxP validation)
- Data science & ML (model review, pipeline setup)
- Documentation (roxygen, pkgdown, API docs)
- And 45+ more domains

## Checklist

- [x] Based on a real use case (actively maintained open-source project)
- [x] No duplicate in existing skills list
- [x] Follows existing README format (alphabetical within category, external link with attribution)
- [x] Entry includes description and author attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)