### PR TITLE
Add PM AI Partner: 12 PM-specific agent skills + 6 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
+- [PM AI Partner](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework) - 12 PM-specific agent skills, 6 workflow commands, 3 hooks for Product Managers. Install: `npx pm-ai-partner@latest` *By [@ahmedkhaledmohamed](https://github.com/ahmedkhaledmohamed)*
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.


### PR DESCRIPTION
## Summary

- Adds **[PM AI Partner](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework)** to the Productivity & Organization section
- A Claude Code plugin with 12 PM-specific agent skills, 6 workflow commands, and 3 automation hooks designed for Product Managers
- One-line install: `npx pm-ai-partner@latest`

## Links

- **GitHub**: https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework
- **npm**: https://www.npmjs.com/package/pm-ai-partner

## Skills included

Agent modes: Thought Partner, Technical Analyst, Writer, Devil's Advocate, Builder, Data Analyst  
Workflow commands: product-brief, meeting-prep, stakeholder-update, strategic-clarity, and more  
Hooks: 3 automation hooks for common PM workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)