### PR TITLE
Add Tycana Task Manager skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
+- [Tycana Task Manager](./tycana-task-manager/) - Persistent task management and productivity intelligence via MCP. Captures tasks from conversation, plans your day, and gives personalized recommendations that improve over time.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 

--- a/tycana-task-manager/SKILL.md
+++ b/tycana-task-manager/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: tycana-task-manager
+description: Persistent task management and productivity intelligence via MCP. Captures tasks from conversation, plans your day, tracks patterns, and gives personalized recommendations that improve over time.
+---
+
+# Tycana Task Manager
+
+Tycana gives Claude persistent memory about your work across conversations. Connect once via MCP, and every session includes your tasks, projects, deadlines, blockers, and computed intelligence from your patterns. No app to open — the conversation is the interface.
+
+## When to Use This Skill
+
+- You want to capture tasks, ideas, and follow-ups without leaving your conversation
+- You need your morning planned based on what's actually due and overdue
+- You want honest progress reviews that surface slipping work and blocked items
+- You need a recommendation for what to work on next, factoring in energy and deadlines
+- You want your AI to remember your work context between conversations
+
+## What This Skill Does
+
+1. **Persistent memory** — Tasks, projects, deadlines, notes, and blockers persist across every conversation. Nothing is forgotten between sessions.
+2. **Day planning** — Pulls your tasks, factors in what's overdue, considers deadlines, and suggests a prioritized plan calibrated to your actual completion patterns.
+3. **Capture in context** — Mention something you need to do mid-conversation and it's captured instantly with effort, energy, and project inferred from context.
+4. **Computed intelligence** — Tracks your velocity, detects stalled work, calibrates effort estimates to your actual pace, and surfaces what needs attention. Gets smarter over time.
+5. **Progress reviews** — Summarizes what got done, what carried over, what slipped, and patterns worth noting.
+
+## How to Use
+
+### Basic Usage
+
+Tycana connects via MCP. After connecting your account at https://www.tycana.com/getting-started/, the skill activates automatically whenever you discuss tasks, planning, or productivity.
+
+```
+"Plan my day"
+"Remind me to update the deployment docs before Friday"
+"How's the infrastructure project going?"
+"What should I work on next? I have about an hour and low energy"
+"Review my week"
+```
+
+### Advanced Usage
+
+```
+"Brain dump — I've got a bunch of things rattling around in my head"
+"What's blocking the most work right now?"
+"Compare my velocity this week to last week"
+"Clean up the completed items in Project X"
+```
+
+## Example
+
+**User:** Plan my day — I've got about 6 hours of focus time
+
+**Output:** You've got 5 things due today. The API migration is the big one — that's been sitting for 3 days and it's blocking the staging deploy. I'd start there while you're fresh, then knock out the two quick doc updates after lunch. The design review can probably push to tomorrow if you run out of time — it's not due until Thursday.
+
+## Tips
+
+- Just talk naturally about your work. Tycana captures from conversation context — no special syntax needed.
+- Say "what should I work on next?" when you're unsure. It factors in deadlines, energy, and your patterns.
+- Mention energy level for better recommendations: "I'm low energy" gets you routine tasks, not deep work.
+- Use "review my week" on Fridays to catch slipping work before it becomes a problem.
+
+## Common Use Cases
+
+- Morning planning sessions that account for overdue items and realistic capacity
+- Capturing follow-ups during code reviews, meetings, or brainstorming without context switching
+- Weekly reviews that surface patterns and stalled projects
+- Energy-aware task recommendations throughout the day
+- Tracking project progress with awareness of blocking chains and dependencies


### PR DESCRIPTION
## What problem does it solve?

Every AI conversation starts from zero — no memory of what you captured yesterday, no awareness of what's overdue, no sense of your work patterns. Tycana gives Claude persistent memory about your work so every conversation picks up where the last one left off.

## Who uses this workflow?

Individual developers and knowledge workers who use Claude Code daily and want task management integrated into their AI workflow rather than a separate app.

## What's included

A SKILL.md for the Tycana productivity backend, which connects via MCP to provide:

- **Task capture from conversation** — mention something you need to do and it's captured with effort, energy, and project inferred from context
- **Day planning** — prioritized plans based on what's due, overdue, and your actual completion patterns
- **Progress reviews** — weekly summaries with slip detection and pattern awareness
- **Energy-aware recommendations** — "what should I work on next?" factors in deadlines, priorities, and your current energy level
- **Computed intelligence** — velocity tracking, effort calibration, and stale work detection that improve over time

## Example

```
User: "Plan my day — I've got about 6 hours"
Claude: pulls tasks from Tycana, factors in overdue items, suggests prioritized plan

User: "Remind me to update the deployment docs before Friday"  
Claude: captured instantly with context, no app switching

User: "Review my week"
Claude: summarizes completions, carry-overs, and patterns worth noting
```

## Links

- MCP endpoint: https://app.tycana.com/mcp (OAuth 2.1)
- Getting started: https://www.tycana.com/getting-started/
- Plugin repo: https://github.com/tycana/tycana-claude-plugin