### PR TITLE
feat: Add nanhu-pdf skill for nanhu-print-java PDF generation

### DIFF
--- a/nanhu-pdf/SKILL.md
+++ b/nanhu-pdf/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: nanhu-pdf
+description: Generate PDF files using the nanhu-print-java framework. Use this skill when the user wants to create PDF documents with nanhu-print-java, including writing XML templates, preparing JSON business data, calling the Java API (NanhuprintInterpreter), or integrating nanhu-print-java into a Spring Boot service. Triggers on requests like "generate a PDF with nanhu-print-java", "write an XML template for nanhu-print-java", "how do I call NanhuprintInterpreter", or "create a PDF invoice/report using nanhu-print-java".
+---
+
+# nanhu-pdf Skill
+
+nanhu-print-java is an XML-to-PDF generation framework for Java. Users write an XML template + prepare JSON business data, then call `NanhuprintInterpreter` to produce a PDF.
+
+Maven dependency:
+```xml
+<dependency>
+    <groupId>io.github.hongjinqiu</groupId>
+    <artifactId>nanhu-print-java</artifactId>
+    <version>1.0.6</version>
+</dependency>
+```
+
+## Workflow
+
+1. Write an XML template (see `references/xml-template.md`)
+2. Prepare JSON business data
+3. Call the Java API (see `references/java-api.md`)
+
+## Quick Example
+
+**hello_world.xml**
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<html xmlns="https://github.com/hongjinqiu/nanhu-print-java"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <body>
+    <div>
+      <span value="js:businessData" />
+    </div>
+  </body>
+</html>
+```
+
+**hello_world.json**
+```json
+{ "businessData": "Hello, nanhu-print-java!" }
+```
+
+**Java call**
+```java
+NanhuprintInterpreter interpreter = new NanhuprintInterpreter();
+String xml = /* read hello_world.xml as String */;
+Map<String, Object> env = JSONObject.fromObject(/* read hello_world.json */);
+// Save to file:
+interpreter.interpreterString("output.pdf", xml, env);
+// Or get bytes:
+byte[] pdfBytes = interpreter.interpreterString(xml, env);
+```
+
+## Reference Files
+
+- **XML template syntax, tags, CSS, dynamic tags**: See `references/xml-template.md`
+- **Java API methods and integration patterns**: See `references/java-api.md`
+
+## XSD Constraint
+
+All XML templates must conform to the official XSD schema:
+
+- Skill local copy: `references/nanhuprint.xsd`
+- GitHub: https://github.com/hongjinqiu/nanhu-print-java/blob/main/src/main/resources/xsd/nanhuprint.xsd
+
+**Before writing or reviewing any XML template, read the XSD to verify allowed elements, attributes, and nesting rules.** The XSD is the authoritative source of truth — it overrides any assumptions based on examples alone.

--- a/nanhu-pdf/references/examples.md
+++ b/nanhu-pdf/references/examples.md
@@ -1,0 +1,666 @@
+# nanhu-print-java XML Template Examples
+
+Real working examples from the project test suite. Each example is verified to produce a valid PDF.
+
+---
+
+## Example 1 — Basic multi-page document (twoPage1)
+
+Demonstrates: `thead` firstPage + everyPage, `tbody` forEach, `tloop`, `tbottom` lastPage + everyPage with page numbers.
+
+**XML**
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<html xmlns="https://github.com/hongjinqiu/nanhu-print-java"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <style></style>
+  <macros></macros>
+  <body pageSizePdf="A4" rotate="false" paddingLeft="50px"
+        paddingRight="50px" paddingTop="30px" paddingBottom="30px"
+        width="685px" height="840px">
+    <params>
+      <param name="extendToFillBody" value="default" />
+    </params>
+    <table cellspacing="0" cellpadding="0" width="100%" tableLayout="fixed">
+      <thead>
+        <tr>
+          <td width="100%">
+            <span value="show only on first page, name is:" />
+            <span value="js:data.firstPage" />
+          </td>
+        </tr>
+      </thead>
+      <thead showPosition="everyPage">
+        <tr>
+          <td width="100%">
+            <span value="show on every page, name is:" />
+            <span value="js:data.everyPage" />
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td width="100%">
+            <div fontSize="20" textAlign="center">
+              <span value="I am tbody"/>
+            </div>
+          </td>
+        </tr>
+        <forEach var="item" itemsJs="data.contentList" varStatus="index">
+          <tr>
+            <td width="100%">
+              <div paddingTop="20">
+                <span value="js:item"/>
+              </div>
+            </td>
+          </tr>
+        </forEach>
+      </tbody>
+      <tloop>
+        <tr>
+          <td width="100%">
+            <span value="1" visibility="hidden"/>
+            <span value=" "/>
+          </td>
+        </tr>
+      </tloop>
+      <tbottom>
+        <tr>
+          <td textAlign="center">
+            <span value="I am lastPage, value is:"/>
+            <span value="js:data.lastPageTbottom"/>
+          </td>
+        </tr>
+      </tbottom>
+      <tbottom showPosition="everyPage">
+        <tr>
+          <td textAlign="center">
+            <div>
+              <params>
+                <param name="customContent" value="com.hongjinqiu.nanhuprint.eval.custom.CustomPageNumber" />
+                <param name="customContentFormat" value="{currentPageNumber} /of/ {totalPageNumber}" />
+              </params>
+            </div>
+          </td>
+        </tr>
+      </tbottom>
+    </table>
+  </body>
+</html>
+```
+
+**JSON**
+```json
+{
+  "data": {
+    "firstPage": "this is firstPage",
+    "everyPage": "this is everyPage",
+    "lastPageTbottom": "this is lastPage tbottom",
+    "contentList": ["content1", "content2", "content3"]
+  }
+}
+```
+
+---
+
+## Example 2 — Watermark (text + image)
+
+Demonstrates: body-level text watermark, tbottom-level image watermark, `waterMarkLayer`, `waterMarkOpacity`, `waterMarkRotation`.
+
+**XML**
+```xml
+<body pageSizePdf="A4" rotate="false" paddingLeft="50px"
+      paddingRight="50px" paddingTop="30px" paddingBottom="30px"
+      width="685px" height="840px">
+  <params>
+    <param name="waterMark" value="default" />
+    <param name="waterMarkText" value="I am water mark text" />
+    <param name="waterMarkOpacity" value="1" />
+    <param name="waterMarkTextFontSize" value="14" />
+    <param name="waterMarkOffsetX" value="0" />
+    <param name="waterMarkOffsetY" value="0" />
+    <param name="waterMarkRotation" value="45" />
+    <param name="waterMarkLayer" value="under" />
+  </params>
+  <table cellspacing="0" cellpadding="0" width="100%" tableLayout="fixed">
+    <!-- ... thead / tbody / tloop ... -->
+    <tbottom>
+      <tr>
+        <td>
+          <params>
+            <param name="waterMark" value="default" />
+            <param name="waterMarkOpacity" value="0.9" />
+            <param name="waterMarkImage" value="https://example.com/logo.png" />
+            <param name="waterMarkImageWidth" value="200" />
+            <param name="waterMarkImageHeight" value="200" />
+            <param name="waterMarkRotation" value="45" />
+            <param name="waterMarkLayer" value="under" />
+          </params>
+          <span value="js:data.lastPageTbottom" />
+        </td>
+      </tr>
+    </tbottom>
+  </table>
+</body>
+```
+
+---
+
+## Example 3 — Alternating row colors with tloop mode="two"
+
+Demonstrates: `<set>` + `<if>` for conditional background, `<tloop mode="two">` for two alternating filler rows.
+
+**XML**
+```xml
+<body pageSizePdf="A4" rotate="false" paddingLeft="50px"
+      paddingRight="50px" paddingTop="30px" paddingBottom="30px"
+      width="685px" height="840px">
+  <params>
+    <param name="extendToFillBody" value="default" />
+  </params>
+  <table cellspacing="0" cellpadding="0" width="100%" tableLayout="fixed">
+    <thead>
+      <tr>
+        <td width="100%">
+          <span value="js:data.firstPage" />
+        </td>
+      </tr>
+    </thead>
+    <tbody>
+      <forEach var="item" itemsJs="data.contentList" varStatus="index">
+        <set valueJs="'white'" var="loopBgColor" />
+        <if testJs="index % 2 == 0">
+          <set valueJs="'orange'" var="loopBgColor" />
+        </if>
+        <tr backgroundColor="js:loopBgColor">
+          <td width="100%">
+            <div paddingTop="20">
+              <span value="js:item"/>
+            </div>
+          </td>
+        </tr>
+      </forEach>
+    </tbody>
+    <tloop mode="two">
+      <tr>
+        <td width="100%" backgroundColor="black">
+          <span value="1" visibility="hidden"/>
+          <span value=" "/>
+        </td>
+      </tr>
+      <tr>
+        <td width="100%">
+          <span value="1" visibility="hidden"/>
+          <span value=" "/>
+        </td>
+      </tr>
+    </tloop>
+  </table>
+</body>
+```
+
+---
+
+## Example 4 — Dynamic border on page breaks (stackoverflow_2)
+
+Demonstrates: `firstLineOfTbodyCss`, `lastLineofTbodyCss`, `firstLineOfPageCss`, `lastLineOfPageCss` params on `<td>` for smart border rendering across page breaks.
+
+**XML**
+```xml
+<style>
+  <css name="borderTopSolid">
+    <borderTopStyle js="solid"/>
+    <borderTopWidth js="1px" pdf="0.1"/>
+    <borderTopColor js="black"/>
+  </css>
+  <css name="borderBottomSolid">
+    <borderBottomStyle js="solid"/>
+    <borderBottomWidth js="1px" pdf="0.1"/>
+    <borderBottomColor js="black"/>
+  </css>
+  <css name="borderLeftSolid">
+    <borderLeftStyle js="solid"/>
+    <borderLeftWidth js="1px" pdf="0.1"/>
+    <borderLeftColor js="black"/>
+  </css>
+  <css name="borderRightSolid">
+    <borderRightStyle js="solid"/>
+    <borderRightWidth js="1px" pdf="0.1"/>
+    <borderRightColor js="black"/>
+  </css>
+  <css name="paddingAll">
+    <paddingTop pdf="8" />
+    <paddingBottom pdf="8" />
+  </css>
+</style>
+
+<!-- In tbody forEach: -->
+<forEach var="item" itemsJs="order.itemLi" varStatus="index">
+  <tr>
+    <td cls="borderLeftSolid textAlignCenter paddingAll">
+      <params>
+        <param name="firstLineOfTbodyCss" value="borderLeftSolid borderTopSolid textAlignCenter paddingAll" />
+        <param name="lastLineofTbodyCss"  value="borderLeftSolid borderBottomSolid textAlignCenter paddingAll" />
+        <param name="firstLineOfPageCss"  value="borderLeftSolid borderTopSolid textAlignCenter paddingAll" />
+        <param name="lastLineOfPageCss"   value="borderLeftSolid borderBottomSolid textAlignCenter paddingAll" />
+      </params>
+      <span value="js:item.item" />
+    </td>
+    <!-- repeat params pattern for each td -->
+    <td cls="borderRightSolid textAlignCenter paddingAll">
+      <params>
+        <param name="firstLineOfTbodyCss" value="borderRightSolid borderTopSolid textAlignCenter paddingAll" />
+        <param name="lastLineofTbodyCss"  value="borderRightSolid borderBottomSolid textAlignCenter paddingAll" />
+        <param name="firstLineOfPageCss"  value="borderRightSolid borderTopSolid textAlignCenter paddingAll" />
+        <param name="lastLineOfPageCss"   value="borderRightSolid borderBottomSolid textAlignCenter paddingAll" />
+      </params>
+      <span value="js:item.summa" />
+    </td>
+  </tr>
+</forEach>
+```
+
+**JSON**
+```json
+{
+  "order": {
+    "itemLi": [
+      { "item": "Apple",  "quantity": 2, "price": "1.00", "summa": "2.00" },
+      { "item": "Banana", "quantity": 5, "price": "0.50", "summa": "2.50" }
+    ]
+  }
+}
+```
+
+---
+
+## Example 5 — Multi-column invoice with everyPage header (stackoverflow_1)
+
+Demonstrates: 7-column table, `showPosition="everyPage"` thead with company name + Bill To / Ship To + invoice metadata, nested tables inside `<td>`, `tloop` with partial borders, `tbottom` lastPage + everyPage page numbers.
+
+**Key pattern — width-definition row + spanning header rows:**
+```xml
+<thead showPosition="everyPage">
+  <!-- Row 1: invisible width-definition row -->
+  <tr>
+    <td width="14%" height="1px"></td>
+    <td width="14%" height="1px"></td>
+    <td width=""    height="1px"></td>
+    <td width="14%" height="1px"></td>
+    <td width="14%" height="1px"></td>
+    <td width="14%" height="1px"></td>
+    <td width="14%" height="1px"></td>
+  </tr>
+  <!-- Row 2: company name spanning all 7 columns -->
+  <tr>
+    <td colspan="7">
+      <div cls="lineHeightAll">
+        <span value="Acme Paper Co LLC" cls="title0" />
+      </div>
+    </td>
+  </tr>
+  <!-- Row 3: Bill To (left) + Invoice metadata (right) -->
+  <tr>
+    <td colspan="3">
+      <!-- nested table for Bill To / Ship To -->
+    </td>
+    <td colspan="4">
+      <!-- nested table for Invoice Number, Date, Due Date, Tax Id -->
+    </td>
+  </tr>
+  <!-- Row 4: column headers -->
+  <tr>
+    <td cls="borderAll fontWeightBold textAlignCenter paddingAll"><span value="Quantity" /></td>
+    <td cls="borderAll fontWeightBold textAlignCenter paddingAll"><span value="Code" /></td>
+    <td cls="borderAll fontWeightBold textAlignCenter paddingAll"><span value="Description" /></td>
+    <td cls="borderAll fontWeightBold textAlignCenter paddingAll"><span value="Unit Price" /></td>
+    <td cls="borderAll fontWeightBold textAlignCenter paddingAll"><span value="Tax1" /></td>
+    <td cls="borderAll fontWeightBold textAlignCenter paddingAll"><span value="Tax2" /></td>
+    <td cls="borderAll fontWeightBold textAlignCenter paddingAll"><span value="Line Total" /></td>
+  </tr>
+</thead>
+```
+
+**tloop with partial left/right borders only (no top/bottom):**
+```xml
+<tloop>
+  <tr>
+    <td cls="borderLeftSolid"><span value=" " /></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td cls="borderRightSolid"></td>
+  </tr>
+</tloop>
+```
+
+---
+
+## Example 6 — Dynamic row count with JavaScript array expression
+
+Demonstrates: generating rows from a JS inline array (no JSON data needed), `Array.apply` pattern.
+
+```xml
+<tbody>
+  <forEach var="i"
+           itemsJs="Array.apply(null, {length: 50}).map(function(_, i) { return i + 1; })"
+           varStatus="index">
+    <tr>
+      <td width="50%" cls="border1px tdPadding">
+        <span value="js:'Row ' + i + ' - Data 1'" />
+      </td>
+      <td width="50%" cls="border1px tdPadding">
+        <span value="js:'Row ' + i + ' - Data 2'" />
+      </td>
+    </tr>
+  </forEach>
+</tbody>
+```
+
+---
+
+## Example 7 — Background image on body + `<div>` + `scaleToFitContentByPdf`
+
+Demonstrates: body-level background image with opacity, element-level background image, `scaleToFitContentByPdf` to shrink overflowing content.
+
+```xml
+<!-- Body-level background image -->
+<body ...>
+  <css>
+    <backgroundImage pdf="url('http://example.com/bg.jpg')" />
+    <backgroundSize js="50%" />
+    <backgroundPositionX js="center" />
+    <backgroundPositionY js="center" />
+    <backgroundImageOpacityByPdf js="0.3" />
+  </css>
+  ...
+</body>
+
+<!-- Element-level background image on a div -->
+<div width="100px" height="100px">
+  <css>
+    <backgroundImage pdf="url('http://example.com/logo.jpg')" />
+    <backgroundSize js="50%" />
+    <backgroundPositionX js="left" />
+    <backgroundPositionY js="25%" />
+  </css>
+</div>
+
+<!-- Scale content to fit cell width -->
+<div cls="f13" scaleToFitContentByPdf="true">
+  <span value="RMB" />
+  <span value="js:bodyVo.originAmtWithouDiscount" />
+</div>
+```
+
+---
+
+## Example 8 — Macro with parameter
+
+Demonstrates: `<macro name="..." paramJs="obj">` definition and `<macroRef name="..." paramJs="macroObj" />` usage.
+
+```xml
+<macros>
+  <macro name="personTable" paramJs="obj">
+    <table width="100%" cellspacing="0" cellpadding="">
+      <if testJs="2+3">
+        <tbody>
+          <tr>
+            <td cls="border1px"><span value="Name" /></td>
+            <td cls="border1px"><span value="Age" /></td>
+          </tr>
+          <tr>
+            <td cls="border1px"><span value="js:obj.name" /></td>
+            <td cls="border1px"><span value="js:obj.age" format="num" /></td>
+          </tr>
+          <forEach var="item" itemsJs="obj.loopLi" varStatus="index">
+            <tr>
+              <td cls="border1px"><span value="js:item.name" /></td>
+              <td cls="border1px"><span value="js:item.age" /></td>
+            </tr>
+          </forEach>
+        </tbody>
+      </if>
+    </table>
+  </macro>
+</macros>
+
+<!-- Usage: pass data object via paramJs -->
+<macroRef name="personTable" paramJs="macroObj" />
+```
+
+---
+
+## Example 9 — Dynamic colspan with `<set>` variable
+
+Demonstrates: storing a number in a variable and using it as `colspan`.
+
+```xml
+<set var="colspanCount" valueJs="4" />
+
+<!-- Later in the table: -->
+<td colspan="js:colspanCount">
+  ...
+</td>
+
+<!-- Or arithmetic: -->
+<td colspan="js:colspanCount - 1">
+  ...
+</td>
+```
+
+---
+
+## Example 10 — `calcWidth` for auto-sized label column
+
+Demonstrates: `calcWidth` custom param to make a `<td>` auto-size to its content width (useful for "ISSUED BY:" label + underline signature line).
+
+```xml
+<table cellspacing="0" cellpadding="0" tableLayout="auto">
+  <tbody>
+    <tr>
+      <td textAlign="left">
+        <params>
+          <param name="calcWidth" value="com.hongjinqiu.nanhuprint.eval.custom.CalcWidth" />
+          <param name="calcWidthTagId" value="leftIssueBy" />
+        </params>
+        <div id="leftIssueBy" whiteSpace="nowrap" paddingRight="5px">
+          <span value="ISSUED BY:" />
+        </div>
+      </td>
+      <td>
+        <css>
+          <width pdf="150px" />
+        </css>
+        <div width="150px"
+             borderBottomStyle="solid" borderBottomColor="black" borderBottomWidth="1px">
+          <span value=" " color="white" />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+---
+
+## Example 11 — `tloop countJs` to fill exactly N rows
+
+Demonstrates: `<tloop countJs="20">` to always fill 20 filler rows regardless of data count (useful for fixed-height invoice forms).
+
+```xml
+<tloop countJs="20">
+  <tr>
+    <td cls="borderLeft borderRight tc tdPadding bodyLineHeight">
+      <span value=" " />
+    </td>
+    <td cls="borderRight tdPadding"></td>
+    <td cls="borderRight tc tdPadding"></td>
+    <td cls="borderRight tc tdPadding"></td>
+  </tr>
+</tloop>
+```
+
+---
+
+## Example 12 — `minHeight` / `maxHeight` / `height` on `<td>`
+
+Demonstrates: controlling cell height constraints.
+
+```xml
+<!-- minHeight: cell grows to at least this height -->
+<td minHeight="20px">...</td>
+
+<!-- maxHeight: cell is capped at this height (content may be clipped) -->
+<td maxHeight="180px">...</td>
+
+<!-- height: fixed height (overrides content) -->
+<td height="30px">...</td>
+
+<!-- Combined: min 20px, max 40px -->
+<td minHeight="20px" maxHeight="40px">...</td>
+```
+
+---
+
+## Example 13 — `rowspan` in nested table
+
+Demonstrates: `rowspan` attribute on `<td>` inside a nested table.
+
+```xml
+<table cellspacing="0" cellpadding="0" tableLayout="fixed">
+  <tbody>
+    <tr>
+      <td width="20px">
+        <div width="20px" height="20px" borderLeftWidth="0.1px" borderTopWidth="0.1px"></div>
+      </td>
+      <td width="300px" rowspan="2">
+        <forEach var="item" itemsJs="[1,2,3]" varStatus="index">
+          <div><span value="js:'line_' + index" /></div>
+        </forEach>
+      </td>
+      <td width="20px">
+        <div width="20px" height="20px" borderRightWidth="0.1px" borderTopWidth="0.1px"></div>
+      </td>
+    </tr>
+    <tr>
+      <td verticalAlign="bottom">
+        <div width="20px" height="20px" borderLeftWidth="0.1px" borderBottomWidth="0.1px"></div>
+      </td>
+      <td verticalAlign="bottom">
+        <div width="20px" height="20px" borderRightWidth="0.1px" borderBottomWidth="0.1px"></div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+---
+
+## Example 14 — `floatAlign="right"` for right-aligned nested table
+
+Demonstrates: `floatAlign="right"` on a nested table to push it to the right side of its container.
+
+```xml
+<td textAlign="right">
+  <table cellspacing="0" cellpadding="0" tableLayout="fixed" floatAlign="right">
+    <tbody>
+      <tr>
+        <td width="50px" textAlign="right">
+          <div whiteSpace="nowrap">
+            <span value="ISSUED BY:" />
+          </div>
+        </td>
+        <td width="150px">
+          <div width="150px"
+               borderBottomStyle="solid" borderBottomColor="black" borderBottomWidth="1px">
+            <span value=" " color="white" />
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</td>
+```
+
+---
+
+## Example 15 — `explain="true"` for debug layout
+
+Demonstrates: `explain="true"` on a `<div>` or `<td>` to render a visible debug border around the element (useful during development).
+
+```xml
+<div fontFamily="arial" explain="true">
+  <span value="this text has a debug border" />
+</div>
+
+<td cls="borderLeftSolid" explain="true">
+  <span value="js:item.item" />
+</td>
+```
+
+---
+
+## CSS Quick Reference
+
+All CSS properties used across the test suite:
+
+```xml
+<style>
+  <!-- Font -->
+  <css name="f12"><fontSize js="12px" pdf="js:12/1.3" /></css>
+  <css name="f13"><fontSize js="13px" pdf="js:13/1.3" /></css>
+  <css name="f16"><fontSize js="16px" pdf="js:16/1.3" /></css>
+  <css name="f24"><fontSize js="24px" pdf="js:24/1.3" /></css>
+  <css name="f32"><fontSize js="32px" pdf="js:32/1.3" /></css>
+  <css name="fwb"><fontWeight js="bold" /></css>
+  <css name="fi"><fontStyle js="italic" /></css>
+
+  <!-- Text alignment -->
+  <css name="tc"><textAlign js="center" /></css>
+  <css name="tr"><textAlign js="right" /></css>
+  <css name="tl"><textAlign js="left" /></css>
+
+  <!-- Word wrap -->
+  <css name="breakWord">
+    <whiteSpace js="pre-wrap" />
+    <wordWrap js="break-word" />
+  </css>
+
+  <!-- Borders — full -->
+  <css name="borderAll">
+    <borderLeftStyle js="solid" /><borderLeftWidth js="1px" pdf="0.1" /><borderLeftColor js="black" />
+    <borderTopStyle js="solid" /><borderTopWidth js="1px" pdf="0.1" /><borderTopColor js="black" />
+    <borderRightStyle js="solid" /><borderRightWidth js="1px" pdf="0.1" /><borderRightColor js="black" />
+    <borderBottomStyle js="solid" /><borderBottomWidth js="1px" pdf="0.1" /><borderBottomColor js="black" />
+  </css>
+
+  <!-- Borders — individual sides -->
+  <css name="borderTopSolid">
+    <borderTopStyle js="solid" /><borderTopWidth js="1px" pdf="0.1" /><borderTopColor js="black" />
+  </css>
+  <css name="borderBottomSolid">
+    <borderBottomStyle js="solid" /><borderBottomWidth js="1px" pdf="0.1" /><borderBottomColor js="black" />
+  </css>
+  <css name="borderLeftSolid">
+    <borderLeftStyle js="solid" /><borderLeftWidth js="1px" pdf="0.1" /><borderLeftColor js="black" />
+  </css>
+  <css name="borderRightSolid">
+    <borderRightStyle js="solid" /><borderRightWidth js="1px" pdf="0.1" /><borderRightColor js="black" />
+  </css>
+
+  <!-- Padding -->
+  <css name="tdPadding">
+    <paddingLeft js="8px" /><paddingRight js="8px" />
+    <paddingTop js="2px" /><paddingBottom js="2px" />
+  </css>
+  <css name="paddingAll">
+    <paddingTop pdf="8" /><paddingBottom pdf="8" />
+  </css>
+
+  <!-- Line height -->
+  <css name="lineHeightAll"><lineHeight pdf="30" /></css>
+</style>
+```

--- a/nanhu-pdf/references/java-api.md
+++ b/nanhu-pdf/references/java-api.md
@@ -1,0 +1,123 @@
+# Java API Reference
+
+## Core Class: `NanhuprintInterpreter`
+
+`com.hongjinqiu.nanhuprint.NanhuprintInterpreter`
+
+All PDF generation goes through this class. It is stateless — create one instance and reuse it.
+
+## Main Methods
+
+### `interpreterString(String filePath, String metaString, Map<String, Object> env)`
+
+Parse XML + data, write PDF to file.
+
+```java
+NanhuprintInterpreter interpreter = new NanhuprintInterpreter();
+interpreter.interpreterString("/tmp/output.pdf", xmlString, env);
+```
+
+### `interpreterString(String metaString, Map<String, Object> env) → byte[]`
+
+Parse XML + data, return PDF as byte array (useful for HTTP responses).
+
+```java
+byte[] pdfBytes = interpreter.interpreterString(xmlString, env);
+response.setContentType("application/pdf");
+response.getOutputStream().write(pdfBytes);
+```
+
+## Typical Usage Pattern
+
+```java
+import com.hongjinqiu.nanhuprint.NanhuprintInterpreter;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+
+// 1. Load XML template
+String xmlTemplate = IOUtils.toString(
+    getClass().getResourceAsStream("/templates/invoice.xml"), "UTF-8");
+
+// 2. Build env from JSON business data
+Map<String, Object> env = JSONObject.fromObject(jsonDataString);
+
+// 3. Generate PDF
+NanhuprintInterpreter interpreter = new NanhuprintInterpreter();
+byte[] pdf = interpreter.interpreterString(xmlTemplate, env);
+```
+
+## Optional env Parameters
+
+These keys in `env` control number formatting:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `amountPrecision` | `"2"` | Decimal places for `format="amt"` |
+| `numberPrecision` | `"0"` | Decimal places for `format="num"` |
+| `unitPricePrecision` | `"2"` | Decimal places for `format="unitPrice"` |
+
+Example:
+```java
+env.put("amountPrecision", "2");
+env.put("numberPrecision", "3");
+```
+
+## Spring Boot Integration
+
+```java
+@RestController
+public class PdfController {
+
+    @GetMapping(value = "/invoice/{id}", produces = "application/pdf")
+    public ResponseEntity<byte[]> generateInvoice(@PathVariable String id) throws Exception {
+        // Load template
+        String xml = IOUtils.toString(
+            getClass().getResourceAsStream("/templates/invoice.xml"), "UTF-8");
+
+        // Build business data
+        Map<String, Object> env = new HashMap<>();
+        env.put("order", orderService.findById(id));
+
+        // Generate
+        NanhuprintInterpreter interpreter = new NanhuprintInterpreter();
+        byte[] pdf = interpreter.interpreterString(xml, env);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentDispositionFormData("attachment", "invoice-" + id + ".pdf");
+        return ResponseEntity.ok().headers(headers).body(pdf);
+    }
+}
+```
+
+## Lower-Level Methods
+
+For advanced use cases where you need to separate dynamic-tag evaluation from PDF rendering:
+
+```java
+// Step 1: Evaluate dynamic tags (if/forEach/set) → resolved XML string
+String resolvedXml = interpreter.unmarshallerAndRunDynamicElement(xmlTemplate, env);
+
+// Step 2: Render resolved XML → PDF bytes
+byte[] pdf = interpreter.unmarshallerAndRunToPdf(resolvedXml, env);
+```
+
+## Exception Handling
+
+The framework throws `NanhuprintException` (unchecked) on errors. Wrap calls in try-catch for production:
+
+```java
+try {
+    byte[] pdf = interpreter.interpreterString(xml, env);
+} catch (NanhuprintException e) {
+    log.error("PDF generation failed", e);
+    throw new RuntimeException("PDF generation failed", e);
+}
+```
+
+## Docker Demo (for testing)
+
+```bash
+docker pull hjq20021984/nanhu-print-java-demo:1.0.6
+docker run -d -p 8891:8891 --name nanhu-demo hjq20021984/nanhu-print-java-demo:1.0.6
+# Visit http://localhost:8891
+```

--- a/nanhu-pdf/references/nanhuprint.xsd
+++ b/nanhu-pdf/references/nanhuprint.xsd
@@ -1,0 +1,1341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="https://github.com/hongjinqiu/nanhu-print-java"
+        xmlns:tns="https://github.com/hongjinqiu/nanhu-print-java"
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        jaxb:version="2.1"
+        elementFormDefault="qualified">
+	<annotation>
+		<appinfo>
+			<!-- 生成 java 映射文件命令: xjc nanhuprint.xsd -d D:\git\malay_idea_print_test\malay-service\src\main\java -->
+			<jaxb:schemaBindings>
+				<!--<jaxb:package name="com.hongjinqiu.framework.nanhuprint.model"/>-->
+				<jaxb:package name="com.hongjinqiu.nanhuprint.model"/>
+			</jaxb:schemaBindings>
+		</appinfo>
+		<documentation>nanhuprint框架约束规范</documentation>
+	</annotation>
+
+    <element name="html">
+        <annotation>
+            <documentation>入口根元素,与网页中的 html 相类似</documentation>
+        </annotation>
+        <complexType>
+            <sequence>
+				<element ref="tns:style" minOccurs="0" maxOccurs="1"></element>
+				<element ref="tns:macros" minOccurs="0" maxOccurs="1"></element>
+                <element ref="tns:body" minOccurs="0" maxOccurs="1"></element>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="style">
+        <annotation>
+            <documentation>用于包含 css 用的,一般紧跟着 html</documentation>
+        </annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+                <element ref="tns:css" minOccurs="0" maxOccurs="unbounded"></element>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="css">
+		<annotation>
+			<documentation>与 html 中的 css 概念相近,拥有 width, height 等各种样式子元素</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+                <group ref="tns:css-element2" minOccurs="0" maxOccurs="unbounded" />
+            </sequence>
+            <attribute name="name"></attribute>
+        </complexType>
+    </element>
+
+	<element name="macros">
+		<annotation>
+			<documentation>用于包含 macro</documentation>
+		</annotation>
+		<complexType>
+			<sequence maxOccurs="unbounded">
+				<group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+				<element ref="tns:macro" minOccurs="0" maxOccurs="unbounded"></element>
+			</sequence>
+		</complexType>
+	</element>
+
+	<element name="macro">
+		<annotation>
+			<documentation>宏,宏通常用来包含重复的代码,有些时候也可以当函数来使用</documentation>
+		</annotation>
+		<complexType>
+			<sequence maxOccurs="unbounded">
+				<group ref="tns:all-body-element" minOccurs="0" maxOccurs="unbounded" />
+				<group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+			</sequence>
+			<attribute name="name"></attribute>
+			<attribute name="paramJs"></attribute>
+		</complexType>
+	</element>
+
+	<element name="body">
+		<annotation>
+			<documentation>与网页 html 中的 body 概念相近,页面元素的展示容器</documentation>
+		</annotation>
+		<complexType>
+			<sequence maxOccurs="unbounded">
+				<group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+				<element ref="tns:css" minOccurs="0" maxOccurs="1" />
+				<group ref="tns:nest-element" minOccurs="0" maxOccurs="unbounded" />
+				<element ref="tns:params" minOccurs="0" maxOccurs="1" />
+				<element ref="tns:span" minOccurs="0" maxOccurs="unbounded" />
+				<!--<element ref="tns:img" minOccurs="0" maxOccurs="unbounded" />-->
+			</sequence>
+			<attribute name="id"></attribute>
+			<attribute name="pageSizePdf">
+				<simpleType>
+					<union>
+						<simpleType>
+							<restriction base="string">
+								<enumeration value="A0" />
+								<enumeration value="A1" />
+								<enumeration value="A2" />
+								<enumeration value="A3" />
+								<enumeration value="A4" />
+								<enumeration value="A5" />
+								<enumeration value="A6" />
+								<enumeration value="A7" />
+								<enumeration value="A8" />
+								<enumeration value="A9" />
+								<enumeration value="A10" />
+							</restriction>
+						</simpleType>
+						<simpleType>
+							<restriction base="string">
+								<pattern value="js:.+" />
+							</restriction>
+						</simpleType>
+					</union>
+				</simpleType>
+			</attribute>
+			<attribute name="explain" type="tns:trueOrFalse"></attribute>
+			<attribute name="rotate" type="tns:trueOrFalse"></attribute>
+			<attributeGroup ref="tns:css-attribute" />
+		</complexType>
+	</element>
+
+	<element name="table">
+		<annotation>
+			<documentation>与网页 html 中的 table 概念相近,不同的地方在于添加了 tloop, tbottom 元素, tloop 用于页面空白行填充, tbottom 用于表尾显示</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+                <element ref="tns:css" minOccurs="0" maxOccurs="1" />
+                <element ref="tns:params" minOccurs="0" maxOccurs="1" />
+                <element ref="tns:thead" minOccurs="0" />
+                <element ref="tns:tbody" minOccurs="0" />
+                <element ref="tns:tloop" minOccurs="0" />
+                <element ref="tns:tbottom" minOccurs="0" />
+            </sequence>
+            <attribute name="id"></attribute>
+			<attribute name="explain" type="tns:trueOrFalse"></attribute>
+            <attributeGroup ref="tns:css-attribute" />
+        </complexType>
+    </element>
+
+    <element name="thead">
+		<annotation>
+			<documentation>与网页 html 中的 table 中的 thead 概念相近,thead 的第一行通常放空,写清楚列数和列宽,以方便程序读取</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+                <!--<group ref="tns:css-element2"/>-->
+                <element ref="tns:params" minOccurs="0" maxOccurs="1" />
+                <element ref="tns:tr" minOccurs="0" maxOccurs="unbounded" />
+            </sequence>
+            <attribute name="id"></attribute>
+            <!--<attributeGroup ref="tns:css-attribute" />-->
+			<attribute name="showPosition" default="firstPage">
+				<simpleType>
+					<restriction base="string">
+						<enumeration value="firstPage" />
+						<enumeration value="everyPage" />
+					</restriction>
+				</simpleType>
+			</attribute>
+        </complexType>
+    </element>
+
+    <element name="tbody">
+		<annotation>
+			<documentation>与网页 html 中的 table 中的 tbody 概念相近</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+                <!--<group ref="tns:css-element2"/>-->
+                <element ref="tns:params" minOccurs="0" maxOccurs="1" />
+                <element ref="tns:tr" minOccurs="0" maxOccurs="unbounded" />
+            </sequence>
+            <attribute name="id"></attribute>
+            <!--<attributeGroup ref="tns:css-attribute" />-->
+        </complexType>
+    </element>
+
+    <element name="tloop">
+		<annotation>
+			<documentation>用于表身空白行的填充,mode="two",需要设置两个 tr,以便交替行填充</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+                <!--<group ref="tns:css-element2"/>-->
+                <element ref="tns:params" minOccurs="0" maxOccurs="1" />
+                <element ref="tns:tr" minOccurs="0" maxOccurs="unbounded" />
+            </sequence>
+            <attribute name="id"></attribute>
+			<attribute name="countJs" type="int" default="1"></attribute>
+			<attribute name="mode">
+				<simpleType>
+					<union>
+						<simpleType>
+							<restriction base="string">
+								<enumeration value="one" />
+								<enumeration value="two" />
+							</restriction>
+						</simpleType>
+						<simpleType>
+							<restriction base="string">
+								<pattern value="js:.+" />
+							</restriction>
+						</simpleType>
+					</union>
+				</simpleType>
+			</attribute>
+            <!--<attributeGroup ref="tns:css-attribute" />-->
+        </complexType>
+    </element>
+
+    <element name="tbottom">
+		<annotation>
+			<documentation>通常用于表尾固定</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+                <!--<group ref="tns:css-element2"/>-->
+                <element ref="tns:params" minOccurs="0" maxOccurs="1" />
+                <element ref="tns:tr" minOccurs="0" maxOccurs="unbounded" />
+            </sequence>
+            <attribute name="id"></attribute>
+            <!--<attributeGroup ref="tns:css-attribute" />-->
+			<attribute name="showPosition" default="lastPage">
+				<simpleType>
+					<restriction base="string">
+						<enumeration value="everyPage" />
+						<enumeration value="lastPage" />
+					</restriction>
+				</simpleType>
+			</attribute>
+        </complexType>
+    </element>
+
+    <element name="tr">
+		<annotation>
+			<documentation>与网页 html 中的 tr 相类似</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+                <element ref="tns:css" minOccurs="0" maxOccurs="1" />
+                <element ref="tns:params" minOccurs="0" maxOccurs="1" />
+				<element ref="tns:td" minOccurs="0" maxOccurs="unbounded" />
+				<element ref="tns:th" minOccurs="0" maxOccurs="unbounded" />
+            </sequence>
+            <attribute name="id"></attribute>
+            <attributeGroup ref="tns:css-attribute" />
+        </complexType>
+    </element>
+
+	<element name="td">
+		<annotation>
+			<documentation>与网页 html 中的 td 相类似</documentation>
+		</annotation>
+		<complexType>
+			<sequence maxOccurs="unbounded">
+				<group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+				<element ref="tns:css" minOccurs="0" maxOccurs="1" />
+				<group ref="tns:nest-element" minOccurs="0" maxOccurs="unbounded" />
+				<!--<element ref="tns:expression" minOccurs="0" maxOccurs="unbounded" />-->
+				<element ref="tns:params" minOccurs="0" maxOccurs="1" />
+				<element ref="tns:span" minOccurs="0" maxOccurs="unbounded" />
+				<!--<element ref="tns:img" minOccurs="0" maxOccurs="unbounded" />-->
+				<!--<element ref="tns:table" minOccurs="0" maxOccurs="unbounded" />-->
+			</sequence>
+			<attribute name="id"></attribute>
+			<attribute name="scaleToFitContentByPdf" type="tns:trueOrFalse"></attribute>
+			<attribute name="explain" type="tns:trueOrFalse"></attribute>
+			<attributeGroup ref="tns:css-attribute" />
+		</complexType>
+	</element>
+
+	<element name="th">
+		<annotation>
+			<documentation>与网页 html 中的 th 相类似</documentation>
+		</annotation>
+		<complexType>
+			<sequence maxOccurs="unbounded">
+				<group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+				<element ref="tns:css" minOccurs="0" maxOccurs="1" />
+				<group ref="tns:nest-element" minOccurs="0" maxOccurs="unbounded" />
+				<!--<element ref="tns:expression" minOccurs="0" maxOccurs="unbounded" />-->
+				<element ref="tns:params" minOccurs="0" maxOccurs="1" />
+				<element ref="tns:span" minOccurs="0" maxOccurs="unbounded" />
+				<!--<element ref="tns:img" minOccurs="0" maxOccurs="unbounded" />-->
+				<!--<element ref="tns:table" minOccurs="0" maxOccurs="unbounded" />-->
+			</sequence>
+			<attribute name="id"></attribute>
+			<attribute name="scaleToFitContentByPdf" type="tns:trueOrFalse"></attribute>
+			<attribute name="explain" type="tns:trueOrFalse"></attribute>
+			<attributeGroup ref="tns:css-attribute" />
+		</complexType>
+	</element>
+
+    <element name="div">
+		<annotation>
+			<documentation>与网页 html 中的 div 相类似, 后端 pdf 在解析 div 时,是解析成只有一个表格的 PdfPTable</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+                <element ref="tns:css" minOccurs="0" maxOccurs="1" />
+                <group ref="tns:nest-element" minOccurs="0" maxOccurs="unbounded" />
+                <!--<element ref="tns:expression" minOccurs="0" maxOccurs="unbounded" />-->
+                <element ref="tns:params" minOccurs="0" maxOccurs="1" />
+                <element ref="tns:span" minOccurs="0" maxOccurs="unbounded" />
+                <!--<element ref="tns:img" minOccurs="0" maxOccurs="unbounded" />-->
+            </sequence>
+            <attribute name="id"></attribute>
+			<attribute name="scaleToFitContentByPdf" type="tns:trueOrFalse"></attribute>
+			<attribute name="explain" type="tns:trueOrFalse"></attribute>
+            <attributeGroup ref="tns:css-attribute" />
+        </complexType>
+    </element>
+
+    <element name="span">
+		<annotation>
+			<documentation><![CDATA[与网页 html 中的 span 相类似, 使用方法有点区别, 网页中是用 <span>{xxxxx}</span>,配置中是用 <span value="{xxxxx}"></span>]]></documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <element ref="tns:css" minOccurs="0" maxOccurs="1" />
+                <!--<element ref="tns:expression" minOccurs="0" maxOccurs="unbounded" />-->
+                <element ref="tns:params" minOccurs="0" maxOccurs="1" />
+            </sequence>
+            <attribute name="id"></attribute>
+            <attribute name="value"></attribute>
+			<attribute name="explain" type="tns:trueOrFalse"></attribute>
+			<attribute name="format">
+				<simpleType>
+					<union>
+						<simpleType>
+							<restriction base="string">
+								<enumeration value="num" />
+								<enumeration value="unitPrice" />
+								<enumeration value="amt" />
+							</restriction>
+						</simpleType>
+						<simpleType>
+							<restriction base="string">
+								<pattern value="js:.+" />
+							</restriction>
+						</simpleType>
+					</union>
+				</simpleType>
+			</attribute>
+            <attributeGroup ref="tns:css-attribute" />
+        </complexType>
+    </element>
+
+    <element name="params">
+		<annotation>
+			<documentation>参数标签,用于一些自定义处理的参数</documentation>
+		</annotation>
+        <complexType>
+            <sequence>
+                <element ref="tns:param" minOccurs="0" maxOccurs="unbounded" />
+            </sequence>
+			<attribute name="id"></attribute>
+        </complexType>
+    </element>
+
+    <element name="param">
+		<annotation>
+			<documentation>参数标签,用于一些自定义处理的参数</documentation>
+		</annotation>
+        <complexType>
+            <attribute name="name">
+				<simpleType>
+					<union>
+						<simpleType>
+							<restriction base="string">
+								<enumeration value="extendToFillBody" />
+								<enumeration value="waterMark" />
+								<enumeration value="waterMarkText" />
+								<enumeration value="waterMarkOpacity" />
+								<enumeration value="waterMarkTextFontSize" />
+								<enumeration value="waterMarkOffsetX" />
+								<enumeration value="waterMarkOffsetY" />
+								<enumeration value="waterMarkImage" />
+								<enumeration value="waterMarkImageWidth" />
+								<enumeration value="waterMarkImageHeight" />
+								<enumeration value="waterMarkRotation" />
+								<enumeration value="waterMarkLayer" /><!-- default, under -->
+								<enumeration value="customContent" />
+								<enumeration value="customContentFormat" />
+								<enumeration value="calcWidth" />
+								<enumeration value="calcWidthTagId" />
+								<enumeration value="firstLineOfTbodyCss" />
+								<enumeration value="lastLineofTbodyCss" />
+								<enumeration value="firstLineOfPageCss" />
+								<enumeration value="lastLineOfPageCss" />
+							</restriction>
+						</simpleType>
+						<simpleType>
+							<restriction base="string">
+								<pattern value="js:.+" />
+							</restriction>
+						</simpleType>
+					</union>
+				</simpleType>
+			</attribute>
+            <attribute name="value"></attribute>
+        </complexType>
+    </element>
+
+    <!--
+    <element name="img">
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <element ref="tns:css" minOccurs="0" maxOccurs="1" />
+                <element ref="tns:params" minOccurs="0" maxOccurs="1" />
+            </sequence>
+            <attribute name="id"></attribute>
+            <attribute name="src"></attribute>
+            <attributeGroup ref="tns:css-attribute" />
+        </complexType>
+    </element>
+    -->
+
+    <!-- ================================动态标签 begin================================ -->
+    <element name="if">
+		<annotation>
+			<documentation>选择标签</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-body-element" minOccurs="0" maxOccurs="unbounded" />
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+            </sequence>
+            <attribute name="testJs"></attribute>
+            <!--<attribute name="var"></attribute>-->
+            <!--<attribute name="scope"></attribute>-->
+        </complexType>
+    </element>
+
+    <element name="forEach">
+		<annotation>
+			<documentation>循环标签</documentation>
+		</annotation>
+        <complexType>
+            <sequence maxOccurs="unbounded">
+                <group ref="tns:all-body-element" minOccurs="0" maxOccurs="unbounded" />
+                <group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+            </sequence>
+            <attribute name="itemsJs"></attribute>
+            <!--<attribute name="begin"></attribute>-->
+            <!--<attribute name="end"></attribute>-->
+            <!--<attribute name="step"></attribute>-->
+            <attribute name="var"></attribute>
+            <attribute name="varStatus"></attribute>
+        </complexType>
+    </element>
+
+    <element name="set">
+		<annotation>
+			<documentation>赋值标签</documentation>
+		</annotation>
+        <complexType>
+            <attribute name="var"></attribute>
+            <attribute name="valueJs"></attribute>
+            <!--<attribute name="target"></attribute>-->
+            <!--<attribute name="property"></attribute>-->
+            <!--<attribute name="scope"></attribute>-->
+        </complexType>
+    </element>
+
+	<element name="macroRef">
+		<annotation>
+			<documentation>宏引用</documentation>
+		</annotation>
+		<complexType>
+			<sequence maxOccurs="unbounded">
+				<group ref="tns:all-body-element" minOccurs="0" maxOccurs="unbounded" />
+				<group ref="tns:all-dynamic-element" minOccurs="0" maxOccurs="unbounded" />
+			</sequence>
+			<attribute name="name"></attribute>
+			<attribute name="paramJs"></attribute>
+		</complexType>
+	</element>
+
+    <group name="all-dynamic-element">
+		<annotation>
+			<documentation>动态标签集合</documentation>
+		</annotation>
+        <sequence>
+            <element ref="tns:if" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:forEach" minOccurs="0" maxOccurs="unbounded" />
+			<element ref="tns:set" minOccurs="0" maxOccurs="unbounded" />
+			<element ref="tns:macroRef" minOccurs="0" maxOccurs="unbounded" />
+        </sequence>
+    </group>
+    <!-- ================================动态标签 end================================ -->
+
+    <group name="all-body-element">
+		<annotation>
+			<documentation>body 中所有元素集合</documentation>
+		</annotation>
+        <sequence>
+            <group ref="tns:css-element2" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:table" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:thead" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:tr" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:tbody" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:tloop" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:tbottom" minOccurs="0" maxOccurs="unbounded" />
+			<element ref="tns:th" minOccurs="0" maxOccurs="unbounded" />
+			<element ref="tns:td" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:div" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:span" minOccurs="0" maxOccurs="unbounded" />
+            <!--<element ref="tns:img" minOccurs="0" maxOccurs="unbounded" />-->
+            <element ref="tns:css" minOccurs="0" maxOccurs="unbounded" />
+            <!--<element ref="tns:expression" minOccurs="0" maxOccurs="unbounded" />-->
+        </sequence>
+    </group>
+
+    <!-- 可互相嵌套的 element,例如 div 包 table, table 中的 td 也可以包 div -->
+    <group name="nest-element">
+        <sequence>
+            <element ref="tns:table" minOccurs="0" maxOccurs="unbounded" />
+            <element ref="tns:div" minOccurs="0" maxOccurs="unbounded" />
+        </sequence>
+    </group>
+
+    <attributeGroup name="css-attribute2">
+        <attribute name="js" />
+        <attribute name="pdf" />
+    </attributeGroup>
+
+    <!-- 用于各个页面元素样式自定义 -->
+    <group name="css-element2">
+        <sequence>
+            <!-- 生成的子元素数组名类似于:widthAndHeightAndMarginLeft,因此,不要在这个地方的前面插入元素,否则程序要修改,add by hongjinqiu 2018.07.27 -->
+            <element name="width" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="height" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="paddingLeft" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="paddingTop" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="paddingRight" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="paddingBottom" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="marginLeftByJs" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="marginTopByJs" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="marginRightByJs" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="marginBottomByJs" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="fontFamily" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:fontFamilyType" />
+					<attribute name="pdf" type="tns:fontFamilyType" />
+                </complexType>
+            </element>
+            <element name="fontStyle" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:fontStyleType" />
+					<attribute name="pdf" type="tns:fontStyleType" />
+                </complexType>
+            </element>
+			<element name="fontWeight" minOccurs="0" maxOccurs="1" >
+				<complexType>
+					<!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:fontWeightType" />
+					<attribute name="pdf" type="tns:fontWeightType" />
+				</complexType>
+			</element>
+			<element name="textDecoration" minOccurs="0" maxOccurs="1" >
+				<complexType>
+					<!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:textDecorationType" />
+					<attribute name="pdf" type="tns:textDecorationType" />
+				</complexType>
+			</element>
+            <element name="borderCollapse" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="borderSpacing" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="tableLayout" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:tableLayoutType" />
+					<attribute name="pdf" type="tns:tableLayoutType" />
+                </complexType>
+            </element>
+            <element name="textAlign" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:textAlignType" />
+					<attribute name="pdf" type="tns:textAlignType" />
+                </complexType>
+            </element>
+            <element name="whiteSpace" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:whiteSpaceType" />
+					<attribute name="pdf" type="tns:whiteSpaceType" />
+                </complexType>
+            </element>
+            <element name="wordWrap" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="display" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:displayType" />
+					<attribute name="pdf" type="tns:displayType" />
+                </complexType>
+            </element>
+            <element name="visibility" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:visibilityType" />
+					<attribute name="pdf" type="tns:visibilityType" />
+                </complexType>
+            </element>
+            <element name="clear" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="zoom" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="floatAlign" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:floatAlignType" />
+					<attribute name="pdf" type="tns:floatAlignType" />
+                </complexType>
+            </element>
+            <element name="fontSize" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="webkitBoxSizing" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="mozBoxSizing" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="boxSizing" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="minHeight" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="position" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="lineHeight" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="color" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:colorType" />
+					<attribute name="pdf" type="tns:colorType" />
+                </complexType>
+            </element>
+            <element name="borderTopWidth" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+			<!--
+			<element name="borderStyle" minOccurs="0" maxOccurs="1" >
+				<complexType>
+					<attributeGroup ref="tns:css-attribute2" />
+				</complexType>
+			</element>
+			-->
+            <element name="borderTopStyle" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:borderStyleType" />
+					<attribute name="pdf" type="tns:borderStyleType" />
+                </complexType>
+            </element>
+            <element name="borderTopColor" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:colorType" />
+					<attribute name="pdf" type="tns:colorType" />
+                </complexType>
+            </element>
+            <element name="borderLeftWidth" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="borderLeftStyle" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:borderStyleType" />
+					<attribute name="pdf" type="tns:borderStyleType" />
+                </complexType>
+            </element>
+            <element name="borderLeftColor" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:colorType" />
+					<attribute name="pdf" type="tns:colorType" />
+                </complexType>
+            </element>
+            <element name="borderRightWidth" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="borderRightStyle" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:borderStyleType" />
+					<attribute name="pdf" type="tns:borderStyleType" />
+                </complexType>
+            </element>
+            <element name="borderRightColor" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:colorType" />
+					<attribute name="pdf" type="tns:colorType" />
+                </complexType>
+            </element>
+            <element name="borderBottomWidth" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="borderBottomStyle" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:borderStyleType" />
+					<attribute name="pdf" type="tns:borderStyleType" />
+                </complexType>
+            </element>
+            <element name="borderBottomColor" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:colorType" />
+					<attribute name="pdf" type="tns:colorType" />
+                </complexType>
+            </element>
+            <element name="maxWidth" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="left" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="top" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="right" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="bottom" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="verticalAlign" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:verticalAlignType" />
+					<attribute name="pdf" type="tns:verticalAlignType" />
+                </complexType>
+            </element>
+            <element name="overflowX" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="overflowY" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="maxHeight" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="backgroundColor" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:colorType" />
+					<attribute name="pdf" type="tns:colorType" />
+                </complexType>
+            </element>
+			<element name="backgroundImage" minOccurs="0" maxOccurs="1" >
+				<complexType>
+					<attributeGroup ref="tns:css-attribute2" />
+				</complexType>
+			</element>
+			<element name="backgroundImageOpacityByPdf" minOccurs="0" maxOccurs="1" >
+				<complexType>
+					<attributeGroup ref="tns:css-attribute2" />
+				</complexType>
+			</element>
+            <element name="backgroundSize" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:backgroundSizeType" />
+					<attribute name="pdf" type="tns:backgroundSizeType" />
+                </complexType>
+            </element>
+            <element name="backgroundPositionX" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:backgroundPositionXType" />
+					<attribute name="pdf" type="tns:backgroundPositionXType" />
+                </complexType>
+            </element>
+            <element name="backgroundPositionY" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <!--<attributeGroup ref="tns:css-attribute2" />-->
+					<attribute name="js" type="tns:backgroundPositionYType" />
+					<attribute name="pdf" type="tns:backgroundPositionYType" />
+                </complexType>
+            </element>
+			<element name="transformByJs" minOccurs="0" maxOccurs="1" >
+				<complexType>
+					<attributeGroup ref="tns:css-attribute2" />
+				</complexType>
+			</element>
+			<element name="opacityByJs" minOccurs="0" maxOccurs="1" >
+				<complexType>
+					<attributeGroup ref="tns:css-attribute2" />
+				</complexType>
+			</element>
+			<element name="zIndexByJs" minOccurs="0" maxOccurs="1" >
+				<complexType>
+					<attributeGroup ref="tns:css-attribute2" />
+				</complexType>
+			</element>
+			<element name="backgroundRepeatByJs" minOccurs="0" maxOccurs="1" >
+				<complexType>
+					<attributeGroup ref="tns:css-attribute2" />
+				</complexType>
+			</element>
+            <!--
+            <element name="cls" minOccurs="0" maxOccurs="1">
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            -->
+            <!--
+            <element name="cellspacing" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="cellpadding" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="colspan" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            <element name="rowspan" minOccurs="0" maxOccurs="1" >
+                <complexType>
+                    <attributeGroup ref="tns:css-attribute2" />
+                </complexType>
+            </element>
+            -->
+        </sequence>
+    </group>
+
+    <attributeGroup name="css-attribute">
+        <annotation>
+            <documentation>css属性</documentation>
+        </annotation>
+        <attribute name="cls"></attribute>
+        <attribute name="width"></attribute>
+        <attribute name="height"></attribute>
+        <attribute name="paddingLeft"></attribute>
+        <attribute name="paddingTop"></attribute>
+        <attribute name="paddingRight"></attribute>
+        <attribute name="paddingBottom"></attribute>
+        <attribute name="marginLeftByJs"></attribute>
+        <attribute name="marginTopByJs"></attribute>
+        <attribute name="marginRightByJs"></attribute>
+        <attribute name="marginBottomByJs"></attribute>
+        <attribute name="fontFamily" type="tns:fontFamilyType"></attribute>
+        <attribute name="fontStyle" type="tns:fontStyleType"></attribute>
+        <attribute name="fontWeight" type="tns:fontWeightType"></attribute>
+		<attribute name="textDecoration" type="tns:textDecorationType"></attribute>
+        <attribute name="borderCollapse"></attribute>
+        <attribute name="borderSpacing"></attribute>
+        <attribute name="tableLayout" type="tns:tableLayoutType"></attribute>
+        <attribute name="textAlign" type="tns:textAlignType"></attribute>
+        <attribute name="whiteSpace" type="tns:whiteSpaceType"></attribute>
+        <attribute name="wordWrap"></attribute>
+        <attribute name="display" type="tns:displayType"></attribute>
+        <attribute name="visibility" type="tns:visibilityType"></attribute>
+        <attribute name="clear"></attribute>
+        <attribute name="zoom"></attribute>
+        <attribute name="floatAlign"></attribute>
+        <attribute name="fontSize"></attribute>
+        <attribute name="webkitBoxSizing"></attribute>
+        <attribute name="mozBoxSizing"></attribute>
+        <attribute name="boxSizing"></attribute>
+        <attribute name="minHeight"></attribute>
+        <attribute name="position"></attribute>
+        <attribute name="lineHeight"></attribute>
+        <attribute name="color" type="tns:colorType"></attribute>
+		<attribute name="borderTopWidth"></attribute>
+		<!--<attribute name="borderStyle"></attribute>-->
+        <attribute name="borderTopStyle" type="tns:borderStyleType"></attribute>
+        <attribute name="borderTopColor" type="tns:colorType"></attribute>
+        <attribute name="borderLeftWidth"></attribute>
+        <attribute name="borderLeftStyle" type="tns:borderStyleType"></attribute>
+        <attribute name="borderLeftColor" type="tns:colorType"></attribute>
+        <attribute name="borderRightWidth"></attribute>
+        <attribute name="borderRightStyle" type="tns:borderStyleType"></attribute>
+        <attribute name="borderRightColor" type="tns:colorType"></attribute>
+        <attribute name="borderBottomWidth"></attribute>
+        <attribute name="borderBottomStyle" type="tns:borderStyleType"></attribute>
+        <attribute name="borderBottomColor" type="tns:colorType"></attribute>
+        <attribute name="maxWidth"></attribute>
+        <attribute name="left"></attribute>
+        <attribute name="top"></attribute>
+        <attribute name="right"></attribute>
+        <attribute name="bottom"></attribute>
+        <attribute name="verticalAlign" type="tns:verticalAlignType"></attribute>
+        <attribute name="overflowX"></attribute>
+        <attribute name="overflowY"></attribute>
+        <attribute name="maxHeight"></attribute>
+        <attribute name="backgroundColor" type="tns:colorType"></attribute>
+        <attribute name="backgroundImage"></attribute>
+		<attribute name="backgroundImageOpacityByPdf"></attribute>
+        <attribute name="backgroundSize" type="tns:backgroundSizeType"></attribute>
+        <attribute name="backgroundPositionX" type="tns:backgroundPositionXType"></attribute>
+        <attribute name="backgroundPositionY" type="tns:backgroundPositionYType"></attribute>
+		<attribute name="transformByJs"></attribute>
+		<attribute name="opacityByJs"></attribute>
+		<attribute name="zIndexByJs"></attribute>
+		<attribute name="backgroundRepeatByJs"></attribute>
+        <attribute name="cellspacing"></attribute>
+        <attribute name="cellpadding"></attribute>
+        <attribute name="colspan" ></attribute>
+        <attribute name="rowspan" ></attribute>
+    </attributeGroup>
+
+	<simpleType name="trueOrFalse">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="true" />
+					<enumeration value="false" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="fontFamilyType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="Arial" />
+					<enumeration value="Times New Roman" />
+					<enumeration value="Calibri" />
+					<enumeration value="Century" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value=".+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="fontStyleType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="normal" />
+					<enumeration value="italic" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="fontWeightType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="normal" />
+					<enumeration value="bold" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="textDecorationType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="none" />
+					<enumeration value="underline" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="tableLayoutType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="auto" />
+					<enumeration value="fixed" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="textAlignType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="left" />
+					<enumeration value="center" />
+					<enumeration value="right" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="whiteSpaceType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="nowrap" />
+					<enumeration value="pre-wrap" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="displayType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="block" />
+					<enumeration value="none" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="visibilityType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="hidden" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="floatAlignType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="left" />
+					<enumeration value="right" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="colorType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="white" />
+					<enumeration value="light_gray" />
+					<enumeration value="gray" />
+					<enumeration value="dark_gray" />
+					<enumeration value="black" />
+					<enumeration value="red" />
+					<enumeration value="pink" />
+					<enumeration value="orange" />
+					<enumeration value="yellow" />
+					<enumeration value="green" />
+					<enumeration value="magenta" />
+					<enumeration value="cyan" />
+					<enumeration value="blue" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="#[a-zA-Z\d]{6}" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="borderStyleType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="solid" />
+					<enumeration value="dashed" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="verticalAlignType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="top" />
+					<enumeration value="middle" />
+					<enumeration value="bottom" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="backgroundSizeType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="contain" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value=".*%" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="backgroundPositionXType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="left" />
+					<enumeration value="center" />
+					<enumeration value="right" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value=".*%" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+
+	<simpleType name="backgroundPositionYType">
+		<union>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="top" />
+					<enumeration value="center" />
+					<enumeration value="bottom" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value=".*%" />
+				</restriction>
+			</simpleType>
+			<simpleType>
+				<restriction base="string">
+					<pattern value="js:.+" />
+				</restriction>
+			</simpleType>
+		</union>
+	</simpleType>
+</schema>

--- a/nanhu-pdf/references/xml-template.md
+++ b/nanhu-pdf/references/xml-template.md
@@ -1,0 +1,484 @@
+# XML Template Reference
+
+## Document Structure
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<html xmlns="https://github.com/hongjinqiu/nanhu-print-java"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <style>
+    <!-- CSS class definitions -->
+  </style>
+  <body>
+    <!-- page layout -->
+  </body>
+</html>
+```
+
+## CSS Definitions (`<style>`)
+
+Define reusable CSS classes:
+```xml
+<style>
+  <css name="f12">
+    <fontSize js="12px" pdf="js:12/1.3" />
+  </css>
+  <css name="fwb">
+    <fontWeight js="bold" />
+  </css>
+  <css name="tc">
+    <textAlign js="center" />
+  </css>
+  <css name="borderAll">
+    <borderLeftStyle js="solid" /><borderLeftWidth js="1px" pdf="0.1" /><borderLeftColor js="black" />
+    <borderTopStyle js="solid" /><borderTopWidth js="1px" pdf="0.1" /><borderTopColor js="black" />
+    <borderRightStyle js="solid" /><borderRightWidth js="1px" pdf="0.1" /><borderRightColor js="black" />
+    <borderBottomStyle js="solid" /><borderBottomWidth js="1px" pdf="0.1" /><borderBottomColor js="black" />
+  </css>
+</style>
+```
+
+Apply with `cls` attribute: `<div cls="f12 fwb">`.
+
+## Body Layout
+
+### Page size and margins
+
+```xml
+<body width="595px" height="842px" paddingLeft="30px" paddingRight="30px"
+      paddingTop="20px" paddingBottom="20px">
+```
+
+Default is A4 (595×842 pt). Use `<params>` for advanced layout:
+
+```xml
+<body>
+  <params>
+    <param name="extendToFillBody" value="default" />
+  </params>
+  ...
+</body>
+```
+
+`extendToFillBody` enables fixed header/footer across pages. **When using this param, `<tloop>` is mandatory** — see RULE 3 in the table section below.
+
+## Static Tags
+
+### `<div>`
+
+Block container. Supports: `width`, `height`, `paddingLeft/Right/Top/Bottom`, `cls`, `backgroundColor`, `backgroundImage`, `backgroundSize`, `whiteSpace`, `scaleToFitContentByPdf`.
+
+```xml
+<div width="200px" paddingTop="10px" cls="f12">
+  <span value="Hello" />
+</div>
+```
+
+### `<span>`
+
+Inline text. Key attributes:
+- `value="literal text"` or `value="js:varName"` for dynamic values
+- `format="num|unitPrice|amt"` for number formatting
+- `cls`, `fontFamily`, `fontSize`, `fontWeight`, `color`
+
+```xml
+<span value="js:order.totalAmt" format="amt" />
+```
+
+### `<table>`, `<thead>`, `<tbody>`, `<tloop>`, `<tbottom>`, `<tr>`, `<td>`
+
+`showPosition` values: `firstPage`, `everyPage`, `lastPage`.
+
+#### RULE 1 — Column count must be consistent across all sections
+
+Every `<tr>` in `<thead>`, `<tbody>`, `<tloop>`, `<tbottom>` must produce the same number of columns as the table. Use `colspan` to merge cells when a row needs fewer `<td>` elements.
+
+Error you'll see if violated: `表格列数与 tr 底下的表格列数不匹配` or `ArrayIndexOutOfBoundsException`.
+
+#### RULE 2 — Multi-column table: define widths in a hidden first row
+
+When the table has multiple columns AND you need a `<thead showPosition="firstPage">` with a spanning header (e.g., company name), use this pattern:
+
+```xml
+<table>
+  <!-- Step 1: define column widths in an invisible row (height="1px") -->
+  <thead showPosition="firstPage">
+    <tr>
+      <td width="6%"  height="1px"></td>
+      <td width="40%" height="1px"></td>
+      <td width="12%" height="1px"></td>
+      <td width="21%" height="1px"></td>
+      <td width="21%" height="1px"></td>
+    </tr>
+    <!-- Step 2: spanning header rows using colspan -->
+    <tr>
+      <td colspan="5">
+        <div cls="f18 fwb tc"><span value="js:invoice.companyName" /></div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3"><div cls="f12"><span value="js:invoice.billTo" /></div></td>
+      <td colspan="2"><div cls="f12 tr"><span value="js:invoice.date" /></div></td>
+    </tr>
+  </thead>
+
+  <!-- Step 3: column header row (everyPage) -->
+  <thead showPosition="everyPage">
+    <tr>
+      <td width="6%"  cls="fwb tc"><span value="No." /></td>
+      <td width="40%" cls="fwb tc"><span value="Description" /></td>
+      <td width="12%" cls="fwb tc"><span value="Qty" /></td>
+      <td width="21%" cls="fwb tc"><span value="Unit Price" /></td>
+      <td width="21%" cls="fwb tc"><span value="Amount" /></td>
+    </tr>
+  </thead>
+
+  <tbody>
+    <!-- data rows, 5 columns each -->
+  </tbody>
+
+  <!-- Step 4: tloop filler (REQUIRED when using extendToFillBody) -->
+  <tloop>
+    <tr><td colspan="5"><span value=" " /></td></tr>
+  </tloop>
+
+  <!-- Step 5: tbottom must also match column count -->
+  <tbottom>
+    <tr>
+      <td colspan="3"><!-- left content --></td>
+      <td cls="fwb tr"><span value="Total:" /></td>
+      <td cls="tr"><span value="js:invoice.total" format="amt" /></td>
+    </tr>
+  </tbottom>
+</table>
+```
+
+#### RULE 3 — `extendToFillBody` requires a non-empty `<tloop>`
+
+When `<body>` has `<param name="extendToFillBody" value="default" />`, you MUST include `<tloop>` with at least one row that has non-empty content. An empty `<tloop>` causes:
+
+```
+NanhuprintException: tloop中的数据高度不能为0
+```
+
+Minimum valid tloop:
+```xml
+<tloop>
+  <tr><td colspan="N"><span value=" " /></td></tr>
+</tloop>
+```
+
+#### RULE 4 — Do NOT put a `<table>` directly inside `<thead>/<tr>`
+
+Nesting a `<table>` directly inside a `<tr>` of the outer table causes:
+```
+NanhuprintException: tr 下的表格元素不匹配
+```
+
+Instead, put the nested `<table>` inside a `<td>`:
+```xml
+<!-- WRONG -->
+<thead showPosition="firstPage">
+  <tr>
+    <table>...</table>   <!-- ERROR: table directly under tr -->
+  </tr>
+</thead>
+
+<!-- CORRECT -->
+<thead showPosition="firstPage">
+  <tr>
+    <td colspan="5">
+      <table>...</table>  <!-- OK: table inside td -->
+    </td>
+  </tr>
+</thead>
+```
+
+#### RULE 5 — colspan in `<tbottom>` must align precisely with column headers
+
+When a `<tbottom>` row needs a cell to align with a specific column (e.g., a "Total Price" label under the "Price" column), count the colspan values carefully so the cell lands on exactly the right column. Using `colspan` to span extra columns will shift the cell right of the intended column.
+
+Example — 6-column table where "This is total Price" must align with column 5 (index 4):
+
+```xml
+<!-- WRONG: colspan="2" shifts the label into columns 5+6 -->
+<tr>
+  <td colspan="4"></td>
+  <td colspan="2"><span value="This is total Price" /></td>
+</tr>
+
+<!-- CORRECT: one td per column, label only in column 5 -->
+<tr>
+  <td colspan="4"></td>
+  <td cls="borderAll"><span value="This is total Price" /></td>
+  <td></td>
+</tr>
+```
+
+#### RULE 6 — Apply border CSS only to cells that need it
+
+`borderAll` (or any border CSS) applies only to the `<td>` it is set on. To have a row where only one cell has a border and the rest are borderless, simply omit the border class from the other cells.
+
+```xml
+<!-- Only the middle cell has a border; left and right cells are borderless -->
+<tr>
+  <td colspan="4" cls="pad"></td>
+  <td cls="f9 fwb tc pad borderAll"><span value="This is total Price" /></td>
+  <td cls="pad"></td>
+</tr>
+```
+
+#### Simple single-column table (no pitfalls)
+
+```xml
+<table>
+  <thead showPosition="firstPage">
+    <tr><td width="100%"><span value="Title" /></td></tr>
+  </thead>
+  <thead showPosition="everyPage">
+    <tr><td width="100%"><span value="Column Header" /></td></tr>
+  </thead>
+  <tbody>
+    <tr><td width="100%"><span value="js:item" /></td></tr>
+  </tbody>
+  <tloop>
+    <tr><td width="100%"><span value=" " /></td></tr>
+  </tloop>
+  <tbottom>
+    <tr><td width="100%"><span value="Footer" /></td></tr>
+  </tbottom>
+</table>
+```
+
+## Dynamic Tags
+
+### `<if>`
+
+```xml
+<if testJs="order.showRemark">
+  <span value="js:order.remark" />
+</if>
+```
+
+### `<forEach>`
+
+```xml
+<forEach var="item" itemsJs="order.itemList" varStatus="index">
+  <tr>
+    <td><span value="js:item.name" /></td>
+    <td><span value="js:item.qty" format="num" /></td>
+    <td><span value="js:item.price" format="unitPrice" /></td>
+  </tr>
+</forEach>
+```
+
+### `<set>`
+
+```xml
+<set var="bgColor" valueJs="index % 2 == 0 ? 'white' : '#f5f5f5'" />
+<tr backgroundColor="js:bgColor">...</tr>
+```
+
+### `<macro>` and `<macroRef>`
+
+Define reusable blocks:
+```xml
+<macro name="companyHeader">
+  <div cls="f16 fwb tc"><span value="js:company.name" /></div>
+</macro>
+
+<!-- use it -->
+<macroRef name="companyHeader" />
+```
+
+## Special Features
+
+### Page numbers
+
+```xml
+<div>
+  <params>
+    <param name="customContent" value="com.hongjinqiu.nanhuprint.eval.custom.CustomPageNumber" />
+    <param name="customContentFormat" value="{currentPageNumber} / {totalPageNumber}" />
+  </params>
+</div>
+```
+
+### Watermark (text)
+
+```xml
+<div>
+  <params>
+    <param name="waterMark" value="default" />
+    <param name="waterMarkText" value="CONFIDENTIAL" />
+    <param name="waterMarkOpacity" value="0.3" />
+    <param name="waterMarkTextFontSize" value="36" />
+    <param name="waterMarkRotation" value="45" />
+    <param name="waterMarkLayer" value="under" />
+  </params>
+</div>
+```
+
+### Watermark (image)
+
+```xml
+<div>
+  <params>
+    <param name="waterMark" value="default" />
+    <param name="waterMarkImage" value="http://host/logo.png" />
+    <param name="waterMarkImageWidth" value="200" />
+    <param name="waterMarkImageHeight" value="78" />
+    <param name="waterMarkOpacity" value="0.5" />
+    <param name="waterMarkRotation" value="45" />
+    <param name="waterMarkLayer" value="default" />
+  </params>
+</div>
+```
+
+### Table border control on page breaks
+
+```xml
+<td>
+  <params>
+    <param name="firstLineOfTbodyCss" value="borderTopSolid" />
+    <param name="lastLineofTbodyCss" value="borderBottomSolid" />
+    <param name="firstLineOfPageCss" value="borderTopSolid" />
+    <param name="lastLineOfPageCss" value="borderBottomSolid" />
+  </params>
+  <span value="js:item.name" />
+</td>
+```
+
+### Scale content to fit cell
+
+```xml
+<div width="60px" scaleToFitContentByPdf="true">
+  <span value="js:item.longText" />
+</div>
+```
+
+### Dynamic cell width
+
+```xml
+<td>
+  <params>
+    <param name="calcWidth" value="com.hongjinqiu.nanhuprint.eval.custom.CalcWidth" />
+    <param name="calcWidthTagId" value="myCell" />
+  </params>
+  <div id="myCell" whiteSpace="nowrap"><span value="js:item.label" /></div>
+</td>
+```
+
+## Expression Syntax
+
+All `js:` expressions use JavaScript syntax:
+- `js:varName` — variable reference
+- `js:obj.field` — object property
+- `js:arr[0]` — array index
+- `js:a + ' ' + b` — string concat
+- `js:index % 2 == 0 ? 'white' : 'gray'` — ternary
+- `js:item.price * item.qty` — arithmetic
+
+## Lessons Learned
+
+### LESSON 1 — Do NOT nest `<table>` inside `<thead>/<tr>` for company-info + logo layout
+
+When the header has a two-column layout (e.g., company info on the left, logo on the right), the instinct is to put a nested `<table>` directly inside the `<thead><tr>`. This violates RULE 4 and causes a runtime error.
+
+**Wrong approach (causes error):**
+```xml
+<thead showPosition="firstPage">
+  <tr>
+    <td colspan="6">
+      <table>          <!-- nested table inside td is OK -->
+        <thead showPosition="everyPage">   <!-- ERROR: inner thead repeats on every page -->
+          ...
+        </thead>
+        <tbody>...</tbody>
+      </table>
+    </td>
+  </tr>
+</thead>
+```
+
+**Correct approach — use two `<td>` cells side by side in the outer `<tr>`:**
+```xml
+<thead showPosition="firstPage">
+  <tr>
+    <!-- invisible width-definition row first -->
+    <td width="12%" height="1px"></td>
+    ...
+  </tr>
+  <tr>
+    <td colspan="3" cls="pad">
+      <!-- company info stacked in divs -->
+      <div cls="f12"><span value="js:header.name" /></div>
+      <div cls="f12"><span value="js:header.address" /></div>
+      <div cls="f12"><span value="js:header.phone" /></div>
+    </td>
+    <td colspan="3" cls="pad tr">
+      <!-- logo as background image -->
+      <div width="238px" height="72px">
+        <css>
+          <backgroundImage pdf="js:&quot;url('&quot; + header.logoUrl + &quot;')&quot;" />
+          <backgroundSize js="contain" />
+        </css>
+      </div>
+    </td>
+  </tr>
+</thead>
+```
+
+### LESSON 2 — italic currency prefix: use separate `<span>` with `cls="fi"`
+
+In the HTML source, currency symbols like "SGB " are rendered in italic while the amount is normal weight. In the XML template, split them into two `<span>` elements:
+
+```xml
+<!-- WRONG: single span loses the italic on the currency prefix -->
+<span value="js:'SGB ' + summary.subtotal" />
+
+<!-- CORRECT: two spans, first one italic -->
+<span value="js:summary.subtotalCurrency" cls="fi" />
+<span value="js:summary.subtotal" />
+```
+
+And in the JSON data, store currency and amount separately:
+```json
+"summary": {
+  "subtotalCurrency": "SGB ",
+  "subtotal": "2.00",
+  ...
+}
+```
+
+### LESSON 3 — Read large HTML source files in chunks before writing the XML
+
+When converting an existing HTML file to a nanhu-print-java XML template, the HTML can be 40–50 KB. The Read tool returns at most ~200 lines per call. **Read the entire HTML first (multiple Read calls with offset) before writing any XML.** Writing the XML before fully understanding the HTML structure leads to mistakes that require costly rewrites.
+
+Recommended approach:
+1. Read HTML lines 1–200
+2. Read HTML lines 200–400
+3. Read HTML lines 400–end
+4. Only then start writing the XML template
+
+### LESSON 4 — Write the complete XML in one Write call, not incremental Edits
+
+When generating a new XML template file, write the entire file content in a single `Write` call. Using `Write` for the first part and then `Edit` to append the rest is error-prone: if the `old_string` in `Edit` contains trailing whitespace or newline differences, the match fails and you must rewrite the whole file anyway.
+
+If the file exceeds 50 lines, split into: one `Write` for the first ~50 lines, then use `Edit` to replace the last line with the remaining content (ensuring the `old_string` is a unique, short anchor like the last line written).
+
+### LESSON 5 — XSD allows only one `<thead>`/`<tbottom>` per `<table>`, but the runtime supports multiple
+
+The XSD definition for `<table>` lists `<thead>`, `<tbody>`, `<tloop>`, `<tbottom>` without `maxOccurs="unbounded"`, which implies only one of each is allowed. **This is misleading.** The runtime actually supports multiple elements of the same type, each with a different `showPosition`:
+
+```xml
+<!-- Two <thead> elements: one for first page, one for every page -->
+<thead showPosition="firstPage">...</thead>
+<thead showPosition="everyPage">...</thead>
+
+<!-- Two <tbottom> elements: one for last page, one for every page -->
+<tbottom showPosition="lastPage">...</tbottom>
+<tbottom showPosition="everyPage">...</tbottom>
+```
+
+**Rule of thumb: trust working test cases over the XSD.** The project's own test files (e.g., `twoPage/twoPage1.xml`, `fixedHeaderFooter3/fixedHeaderFooter3.xml`) are the authoritative source for what the runtime actually supports.


### PR DESCRIPTION
Summary

  This PR adds a new nanhu-pdf skill that enables Claude to generate PDF documents using the
  https://github.com/hongjinqiu/nanhu-print-java framework — an XML-to-PDF generation library for Java.

  What's Included

  - SKILL.md — skill definition with trigger description, Maven dependency, quick start example, and workflow overview
  - references/xml-template.md — comprehensive guide to XML template syntax, supported tags, CSS properties, and dynamic tags
  - references/java-api.md — Java API reference covering NanhuprintInterpreter methods and Spring Boot integration patterns
  - references/nanhuprint.xsd — the official XSD schema (authoritative source of truth for valid XML templates)
  - references/examples.md — real-world examples including invoices, reports, and tables

  How It Works

  Users describe a PDF they want to generate. Claude then:
  1. Writes an XML template conforming to the nanhu-print-java schema
  2. Prepares the JSON business data
  3. Shows how to call NanhuprintInterpreter to produce the PDF

  Trigger Examples

  - "Generate a PDF invoice with nanhu-print-java"
  - "Write an XML template for nanhu-print-java"
  - "How do I call NanhuprintInterpreter?"
  - "Create a report PDF using nanhu-print-java"