### PR TITLE
Add Audit Skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Development & Code Tools
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
+- [Audit Skill](https://github.com/adewale/audit-skill) - Comprehensive audit toolkit with 14 audit types — branch audits with Clean/Minor/Blocking verdicts plus deep-dive audits for concurrency, security, performance, and more. *By [@adewale](https://github.com/adewale)*
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.


### PR DESCRIPTION
Adds [Audit Skill](https://github.com/adewale/audit-skill) — a comprehensive audit toolkit with 14 audit types for Claude Code.

**What it does:**
- Branch audit (default): pre-push review with 8-category checklist producing Clean/Minor/Blocking verdicts
- 13 deep-dive audits via sub-agents: code quality, docs brittleness, docs-code sync, language best practices, concurrency, resource management, test quality, feature completeness, performance, bug patterns, design philosophy, security, and UI design

**Category:** Development & Code Tools (alphabetical placement between `artifacts-builder` and `aws-skills`)