### PR TITLE
Add thinking-skills: 20 structured thinking framework commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 
+- [thinking-skills](https://github.com/wanikua/thinking-skills) - 20 structured thinking framework commands (Critical Thinking, First Principles, Red Team, Bayesian, Six Thinking Hats, Premortem, etc.) that guide Claude through rigorous analytical processes for decision-making and problem-solving.
+
 ### Collaboration & Project Management
 
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.


### PR DESCRIPTION
## New Skill: thinking-skills

**Category:** Productivity & Organization

**Repository:** https://github.com/wanikua/thinking-skills

### Description

A collection of **20 human thinking framework** commands for Claude Code. Each command guides Claude through a structured, step-by-step analytical process — not just a prompt, but a full guided workflow.

### Included Frameworks

- `/critical-thinking` — Question assumptions, evaluate evidence, detect biases
- `/first-principles` — Strip to ground truth, rebuild from scratch
- `/red-team` — Adversarially attack your own plan to find weaknesses
- `/bayesian-thinking` — Prior → Evidence → Update beliefs
- `/six-thinking-hats` — Six-perspective parallel analysis (de Bono)
- `/premortem` — Assume failure, work backwards to find causes
- `/second-order-thinking` — Chain reactions & long-term consequences
- `/inversion-thinking` — Flip it: how would this fail?
- `/steelman` — Strengthen opposing argument before addressing it
- `/mental-models` — Munger-style multi-disciplinary reasoning
- ... and 10 more (systems thinking, design thinking, dialectical, analogical, etc.)

### Usage

Copy `.claude/commands/` into any project root, then:

```
/red-team Our plan to launch in 3 markets simultaneously
/premortem The new pricing model we're about to ship
/critical-thinking Should we switch from REST to GraphQL?
```

### Checklist
- [x] Solves a real problem (structured decision-making and analysis)
- [x] Well-documented (README with full table + usage examples)
- [x] Tested across Claude Code
- [x] Portable (standard `.claude/commands/` format)