### PR TITLE
Fix tapestry skills article-extractor link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Communication & Writing
 
-- [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
+- [article-extractor](https://github.com/michalparkola/tapestry-skills/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.


### PR DESCRIPTION
Updated the link to point to correct repo.

Since repo name has changed to `michalparkola/tapestry-skills`