### PR TITLE
Add AgentShield to Security & Systems section

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [agent-shield](https://github.com/elliotllliu/agent-shield) - Security scanner for AI agent skills, MCP servers, and plugins. 31 rules detect prompt injection (8 languages, 55+ patterns), data exfiltration, backdoors, tool poisoning, and cross-file attack chains. Scan skills before installing: `npx @elliotllliu/agent-shield scan ./skill/`
 
 ### App Automation via Composio
 


### PR DESCRIPTION
Hi! 👋

Love this comprehensive skills collection!

I'd like to add [AgentShield](https://github.com/elliotllliu/agent-shield) to the Security & Systems section. It's a security scanner that helps developers vet skills before installing them — detects prompt injection (55+ patterns in 8 languages), data exfiltration, backdoors, tool poisoning, and cross-file attack chains.

```bash
npx @elliotllliu/agent-shield scan ./skill/
```

MIT licensed, free, offline, zero-config. Especially useful given the growing skill ecosystem where security vetting is increasingly important.

Thanks for maintaining such a great resource! 🙏