### PR TITLE
Add widemem: Claude Code memory skill with semantic search and confidence scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
+- [widemem-ai](https://github.com/remete618/widemem-ai) - Next-gen AI memory layer with importance scoring, temporal decay, hierarchical memory, and YMYL prioritization. *By [@remete618](https://github.com/remete618)*
 ### Data & Analysis
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*


### PR DESCRIPTION
Adding [widemem-skill](https://github.com/remete618/widemem-skill), a Claude Code memory skill powered by [widemem-ai](https://github.com/remete618/widemem-ai).

**What it does:** Persistent AI memory with `/mem` slash commands: search, add, pin, prune, export, reflect.

**Why it's different from other memory skills:**
- Semantic vector search (FAISS/Qdrant), not grep over markdown
- 4-level confidence scoring: says "I don't know" instead of guessing
- Quality gates: classifies facts before storing (SKIP/LOW/MEDIUM/HIGH/CRITICAL)
- LLM-based conflict resolution and dedup
- Self-reflection audit (`/mem reflect`) for duplicates, contradictions, stale entries
- Frustration detection: searches harder when users say "I already told you"

**Install:** `pip install widemem-ai[mcp]` + copy skill or `/plugin install widemem`

- Skill repo: https://github.com/remete618/widemem-skill
- SDK repo: https://github.com/remete618/widemem-ai
- Website: https://widemem.ai
- License: Apache 2.0