### PR TITLE
Add ai-native-cli — CLI design spec for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [ai-native-cli](https://github.com/ChaosRealmsAI/agent-cli-spec) - Design spec with 98 rules for building CLI tools that AI agents can safely use. Covers JSON output, error handling, safety guardrails, exit codes, and agent self-description. Includes audit protocol. *By [@ChaosRealmsAI](https://github.com/ChaosRealmsAI)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## Summary

- Adds **ai-native-cli** to the "Development & Code Tools" section (alphabetical order)
- A design spec with 98 rules for building CLI tools that AI agents can safely use
- Covers JSON output, error handling, safety guardrails, exit codes, and agent self-description
- Includes an audit protocol for verifying compliance
- Repo: https://github.com/ChaosRealmsAI/agent-cli-spec

## Who uses this

CLI tool authors who want their tools to be safely and reliably consumed by AI coding agents (Claude Code, Codex CLI, etc.). The spec provides concrete, testable rules rather than vague guidelines.

## Test plan

- [x] Entry follows existing README format (link, description, attribution)
- [x] Placed in alphabetical order within "Development & Code Tools"
- [x] No duplicate entries in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)