### PR TITLE
Add claude-obsidian-reporter: auto daily Git reports in Obsidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
+- [claude-obsidian-reporter](https://github.com/sinaayyy/claude-obsidian-reporter) - Auto-generates daily, weekly, and monthly Git activity reports into your Obsidian vault. Smart backfill, Dataview dashboard, multi-language, Windows/macOS/Linux. *By [@sinaayyy](https://github.com/sinaayyy)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*


### PR DESCRIPTION
## What is this skill?

**[claude-obsidian-reporter](https://github.com/sinaayyy/claude-obsidian-reporter)** is a Claude Code skill that automatically generates daily, weekly, and monthly Git activity reports and saves them directly into your Obsidian vault.

## Why add it?

- Type `/report-orchestrator` at end of day — Claude reads your Git commits and writes structured reports instantly
- Smart backfill: generates all missing reports from day one (`backfill=all`) or from a chosen date
- Dataview dashboard auto-generated on first run
- Graph view with color-coded nodes and hierarchy (daily → weekly → monthly → project index)
- Multi-language support, Windows/macOS/Linux compatible
- Install in 2 minutes

## Links

- Repo: https://github.com/sinaayyy/claude-obsidian-reporter
- License: MIT