### PR TITLE
improve baserow-automation skill structure + add skill-review CI

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,14 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@14b47c8420ff9ac9a12c30ed4b89ce0e9d0355ae # main

--- a/composio-skills/baserow-automation/SKILL.md
+++ b/composio-skills/baserow-automation/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: baserow-automation
-description: "Automate Baserow tasks via Rube MCP (Composio). Always search tools first for current schemas."
+description: >
+  Create, read, update, and delete rows in Baserow tables, manage fields,
+  and query records via Rube MCP (Composio). Use when the user mentions
+  "Baserow", "no-code database", or needs to interact with Baserow tables,
+  rows, or fields.
 requires:
   mcp: [rube]
 ---
@@ -26,29 +30,17 @@ Automate Baserow operations through Composio's Baserow toolkit via Rube MCP.
 3. If connection is not ACTIVE, follow the returned auth link to complete setup
 4. Confirm connection status shows ACTIVE before running any workflows
 
-## Tool Discovery
+## Core Workflow
 
-Always discover available tools before executing workflows:
+### Step 1: Discover tools
 
 ```
 RUBE_SEARCH_TOOLS
-queries: [{use_case: "Baserow operations", known_fields: ""}]
+queries: [{use_case: "list rows in a Baserow table", known_fields: ""}]
 session: {generate_id: true}
 ```
 
-This returns available tool slugs, input schemas, recommended execution plans, and known pitfalls.
-
-## Core Workflow Pattern
-
-### Step 1: Discover Available Tools
-
-```
-RUBE_SEARCH_TOOLS
-queries: [{use_case: "your specific Baserow task"}]
-session: {id: "existing_session_id"}
-```
-
-### Step 2: Check Connection
+### Step 2: Check connection
 
 ```
 RUBE_MANAGE_CONNECTIONS
@@ -56,13 +48,15 @@ toolkits: ["baserow"]
 session_id: "your_session_id"
 ```
 
-### Step 3: Execute Tools
+Verify status is ACTIVE before continuing.
+
+### Step 3: Execute
 
 ```
 RUBE_MULTI_EXECUTE_TOOL
 tools: [{
-  tool_slug: "TOOL_SLUG_FROM_SEARCH",
-  arguments: {/* schema-compliant args from search results */}
+  tool_slug: "BASEROW_LIST_ROWS",
+  arguments: {"table_id": 42, "page": 1, "size": 50}
 }]
 memory: {}
 session_id: "your_session_id"


### PR DESCRIPTION
hey @ComposioHQ, thanks for building this collection. really like the composio toolkit integration approach across all the skills. Kudos on passing `44k` stars! I've just starred it.

ran your baserow-automation skill through agent evals and spotted a few quick wins that took it from `~54%` to `~100%` performance:

- rewrote description with concrete CRUD actions + trigger terms like _"Baserow"_, _"no-code database"_, _"tables"_, _"rows"_

- replaced placeholder tool arguments with realistic example values so the agent can execute immediately

- merged redundant Tool Discovery section into Core Workflow to cut duplication

also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

this means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make! happy to answer any questions on the changes.