### PR TITLE
Add zclean — orphan process cleaner for AI coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
-- [zclean](https://github.com/whynowlab/zclean) - CLI tool that cleans up orphan processes left behind by AI coding tools like Claude Code to reduce wasted memory after sessions end.
+- [zclean](https://github.com/TheStack-ai/zclean) - CLI tool that cleans up orphan processes left behind by AI coding tools like Claude Code to reduce wasted memory after sessions end.
 
 ### App Automation via Composio
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [zclean](https://github.com/whynowlab/zclean) - CLI tool that cleans up orphan processes left behind by AI coding tools like Claude Code to reduce wasted memory after sessions end.
 
 ### App Automation via Composio
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
-- [zclean](https://github.com/TheStack-ai/zclean) - CLI tool that cleans up orphan processes left behind by AI coding tools like Claude Code to reduce wasted memory after sessions end.
+- [zclean](https://github.com/TheStack-ai/zclean) - Local-only AI coding runtime hygiene CLI for Claude Code, Codex, Cursor, Windsurf, MCP servers, and workspace caches. Reports first, then cleans only with explicit confirmation.
 
 ### App Automation via Composio
 


### PR DESCRIPTION
## Summary
- Adds [zclean](https://github.com/TheStack-ai/zclean) to the Security & Systems section
- CLI tool that automatically cleans up orphan processes left behind by AI coding tools (Claude Code, Codex)
- Zero dependencies, cross-platform (macOS/Linux/Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)