### PR TITLE
Add Healthcare Agents skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [Healthcare Agents](https://github.com/ajhcs/healthcare-agents) - 51 specialized healthcare administration AI agents for Claude Code with MHA-level expertise across 10 divisions including revenue cycle, compliance, quality, clinical ops, payer relations, and health IT. *By [@ajhcs](https://github.com/ajhcs)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
## Summary

- Adds [healthcare-agents](https://github.com/ajhcs/healthcare-agents) to the Business & Marketing section
- 51 specialized healthcare administration AI agents for Claude Code with MHA-level expertise across 10 divisions: revenue cycle management, compliance & risk, quality & patient safety, clinical operations, payer relations, health IT, workforce management, patient access, supply chain, and strategic planning
- Each agent installs as a Claude Code slash command with deep domain knowledge equivalent to a Master of Health Administration

## Test plan

- [x] Entry follows existing list format (name, link, description, author attribution)
- [x] Alphabetical ordering maintained within the Business & Marketing section
- [x] Link points to valid public GitHub repository
- [x] Description is concise and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)