### PR TITLE
Add SkillHub - Chinese AI Skill Marketplace (50+ skills, 5000+ index)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Productivity & Organization
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
+- [SkillHub / 技能宝](https://github.com/kevinaimonster/skill-hub) - Chinese AI skill marketplace with 50+ curated skills. Covers Xiaohongshu, Douyin, WeChat, code review, security audit, and more. 5000+ skill index, 12-layer security check, supports 42 agent platforms. *By [@kevinaimonster](https://github.com/kevinaimonster)*
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.


### PR DESCRIPTION
## What is SkillHub / 技能宝?

Chinese-first AI skill marketplace with:
- 50+ curated skills (20 Chinese-specific originals like Xiaohongshu, Douyin, WeChat)
- 5,000+ skill index covering 13 categories
- 12-layer security scanning
- Support for 42 agent platforms (Claude Code, Cursor, Windsurf, etc.)

Install: `npx skills add kevinaimonster/skill-hub --full-depth --skill '*' -g -y`

GitHub: https://github.com/kevinaimonster/skill-hub