### PR TITLE
feat: Add API Design Reviewer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [API Design Reviewer](https://github.com/sharmasundip/claudeskills/tree/master/api-design-reviewer) - High-performance audit logic for REST, GraphQL, and gRPC APIs. *By [@sharmasundip](https://github.com/sharmasundip)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
Added the API Design Reviewer skill to the Development & Code Tools section. This skill provides an opinionated audit of REST, GraphQL, and gRPC APIs. Link: https://github.com/sharmasundip/claudeskills/tree/master/api-design-reviewer