### PR TITLE
Add vibecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [vibecosystem](https://github.com/vibeeval/vibecosystem) - Complete AI software team for Claude Code with 119 agents, 202 skills, 48 hooks, self-learning pipeline, and cross-project pattern promotion. *By [@vibeeval](https://github.com/vibeeval)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
Adding vibecosystem — a complete AI software team for Claude Code with 119 agents, 202 skills, 48 hooks, self-learning pipeline, and cross-project pattern promotion.

Repo: https://github.com/vibeeval/vibecosystem
License: MIT