### PR TITLE
Add Junshi skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
-- [Junshi](./research-junshi/) - Personalized research strategist for Claude Code that reads your papers, tracks relevant literature, and proposes ranked research ideas with suggested first experiments.
+- [Junshi](./research-junshi/) - Personalized research strategist for Claude Code that reads your papers, tracks relevant literature, and proposes ranked research ideas with suggested first experiments. *By [@guanyangwang](https://github.com/guanyangwang)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [Junshi](./research-junshi/) - Personalized research strategist for Claude Code that reads your papers, tracks relevant literature, and proposes ranked research ideas with suggested first experiments.
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 

--- a/research-junshi/SKILL.md
+++ b/research-junshi/SKILL.md
@@ -39,6 +39,38 @@ Run:
 - Read my papers and tell me what ideas are worth trying.
 - What papers matter most for my current problem?
 
+## Example
+
+### Example Input
+
+User prompt:
+
+> I work on diffusion models and inverse problems. My papers are in `~/papers/`. Please read my papers and give me today's research digest.
+
+### Example Output
+
+Saved digest to:
+
+`~/.claude/research-junshi/digests/2026-03-19.md`
+
+Top ideas for today:
+
+1. **Weak-prior posterior calibration for inverse problems**  
+   - **Pitch**: Study when weak diffusion priors still give calibrated uncertainty in data-informative regimes.  
+   - **First experiment**: Compare posterior coverage under strong vs. weak priors on a small Gaussian deblurring benchmark.  
+   - **Main risk**: Coverage may look good only because the test setting is too simple.
+
+2. **Noise-space proposal learning for faster posterior sampling**  
+   - **Pitch**: Replace per-instance noise optimization with a learned conditional proposal over latent noise.  
+   - **First experiment**: Train a small conditional model to predict good initial noise on one inverse-problem task and compare runtime against optimization-based baselines.  
+   - **Main risk**: The learned proposal may collapse to a narrow set of modes.
+
+3. **Antithetic latent sampling for uncertainty quantification**  
+   - **Pitch**: Use negatively correlated latent-noise pairs to reduce Monte Carlo variance in posterior summaries.  
+   - **First experiment**: Measure variance reduction for posterior mean estimation using paired vs. independent latent samples.  
+   - **Main risk**: Negative correlation may weaken after passing through the generator.
+
+
 ## What This Skill Does
 
 Junshi works in three stages:

--- a/research-junshi/SKILL.md
+++ b/research-junshi/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: research-junshi
+description: Personalized research strategist for Claude Code that reads your papers, tracks relevant literature, and proposes ranked research ideas with suggested first experiments.
+---
+
+# Junshi (军师)
+
+Junshi is a personalized research strategist for Claude Code.
+
+It is designed for researchers who do not just want paper summaries. It first reads the user's papers and research context, then scans recent literature, and finally produces a short digest with a small number of ranked research ideas, each with a suggested first experiment and main risk.
+
+The goal is not to replace the researcher. The goal is to help the researcher think more clearly, focus faster, and move from literature overload to actionable next steps.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- asks what they should work on next
+- wants a personalized research digest
+- wants research ideas grounded in their own prior work
+- wants help staying on top of the literature in a focused way
+- wants ideas plus a concrete first step, not just paper summaries
+
+## How to Use
+
+### Basic Usage
+
+Run:
+
+```bash
+/research-junshi
+```
+
+### Example Prompts
+
+- What should I work on next?
+- Give me today's research digest.
+- Update my profile and suggest three new directions.
+- Read my papers and tell me what ideas are worth trying.
+- What papers matter most for my current problem?
+
+## What This Skill Does
+
+Junshi works in three stages:
+
+1. **Understand the researcher**
+   - asks for research area, problem description, and paper folder
+   - infers target venues and arXiv categories when needed
+   - reads the researcher's papers to build a profile
+
+2. **Scan the literature**
+   - searches arXiv for recent papers
+   - searches target venues using patterns from `references/venues.md`
+   - selects the most relevant papers based on the research profile
+
+3. **Propose ranked ideas**
+   - summarizes the most relevant recent work
+   - generates 8–10 candidate ideas
+   - ranks them by novelty, feasibility, and impact
+   - returns the top 3–5 ideas, each with:
+     - **First experiment**
+     - **Main risk**
+
+## First-Time Setup
+
+On the first run, or when the user says "update my profile" or "update my config", do setup before generating ideas.
+
+### 1. Collect context
+
+Ask for:
+
+- **Research area**: What field(s) do you work in?
+- **Problem description**: What rough problem are you thinking about?
+- **Papers folder path**: Where are your PDF papers? Skip if they have none.
+
+Also collect or infer:
+
+- **Target venues**
+  - If the user does not specify them, infer the 4–6 most relevant venues from `references/venues.md` and tell the user what you chose.
+- **arXiv categories**
+  - If the user does not specify them, infer them from `references/venues.md`.
+- **Preliminary results**
+  - Ask for early observations, failed attempts, partial results, or surprising findings.
+  - Tell the user that even one strong observation can lead to better ideas than a finished paper.
+
+Do not block on missing answers. Make a good default choice and tell the user what you chose.
+
+### 2. Read the user's papers
+
+If the user provides a paper folder and it exists, read the PDFs using the available tools.
+
+For each paper, extract:
+
+- core technical contribution
+- methods and frameworks used
+- open problems and limitations
+- assumptions
+- research trajectory across papers
+
+If no paper folder is provided, continue with an empty profile.
+
+### 3. Build the research profile
+
+Save to `~/.claude/research-junshi/profile.md`:
+
+```markdown
+# Research Profile
+
+## Research Area
+[Field(s) the researcher works in]
+
+## Target Venues
+[List of conferences/journals to monitor]
+
+## arXiv Categories
+[List of arXiv category codes, e.g. cs.CL, cs.LG]
+
+## Research Themes
+[Key topics and directions from the papers]
+
+## Methods & Frameworks Used
+[Technical frameworks the researcher is fluent in]
+
+## What's Already Been Done
+[Brief list of prior contributions]
+
+## Open Problems in Their Work
+[Gaps, limitations, and future work]
+
+## Research Taste
+[What kinds of contributions do they value? Theory? Empirical? Applications?]
+
+## Problem Statement
+[The rough problem the user gave, with your interpretation]
+
+## Preliminary Results
+[All results, observations, and hypotheses the user has shared.
+Append new entries — never overwrite old ones.
+Format:
+- [Date] [Observation]
+  → [Interpretation]
+]
+
+## Last Updated
+[Date]
+```
+
+### 4. Save config
+
+Save to `~/.claude/research-junshi/config.md`:
+
+```markdown
+# Config
+- Papers folder: [path]
+- Problem: [problem statement]
+- Research area: [field]
+- arXiv categories: [comma-separated list]
+- Target venues: [comma-separated list]
+```
+
+## Daily Digest Workflow
+
+On each run, first load:
+
+- `~/.claude/research-junshi/profile.md`
+- `~/.claude/research-junshi/config.md`
+
+### Step 1: Search arXiv
+
+Search arXiv using categories and keywords from the profile.
+
+Use one broad search and one targeted search. From the candidate papers, select the 10 most relevant.
+
+### Step 2: Search target venues
+
+Search the user's target venues using patterns from `references/venues.md`.
+
+For venues not listed there, use:
+
+```text
+site:[venue-proceedings-url] [user keywords]
+```
+
+Focus on papers from the last 1–2 years and select the 3–5 most relevant venue papers.
+
+Keep arXiv papers and venue papers in separate subsections.
+
+### Step 3: Summarize papers
+
+For each selected paper, write:
+
+```markdown
+**[Title]** ([arXiv ID or venue + year])
+- **Core idea**: [1–2 sentences]
+- **Key insight**: [What makes it work]
+- **What it leaves open**: [Limitations or assumptions]
+- **Relevance**: [Why it matters for the user's research]
+```
+
+### Step 4: Generate ideas
+
+Before generating ideas, read the **Preliminary Results** section carefully.
+
+Use both the recent papers and the user's prior work to think about:
+
+- assumptions that can be challenged
+- combinations that nobody has tried
+- missing pieces that could make a line of work much stronger
+- unexplained observations in the user's preliminary results
+- opportunities revealed by recent trends
+
+Generate **8–10 raw ideas**. Each idea should be specific and actionable.
+
+### Step 5: Rank ideas
+
+Score each idea on:
+
+- **Novelty** (1–5)
+- **Feasibility** (1–5)
+- **Impact** (1–5)
+
+Use:
+
+**Score = Novelty × 0.4 + Feasibility × 0.3 + Impact × 0.3**
+
+Select the top 3–5 ideas.
+
+### Step 6: Save the digest
+
+Save to `~/.claude/research-junshi/digests/YYYY-MM-DD.md`:
+
+```markdown
+# Research Digest — [DATE]
+
+## Today's Landscape
+[2–3 sentences on the current field landscape]
+
+## Papers Read
+
+### arXiv
+[Summaries of top arXiv papers]
+
+### Venues
+[Summaries of relevant venue papers]
+
+## Today's Ideas
+
+### [Rank 1] [Title]
+**Score**: Novelty [N]/5 · Feasibility [F]/5 · Impact [I]/5 → **[total]/5**
+**The pitch**: [2–3 sentences]
+**Why now**: [Why this is timely]
+**Connection to your work**: [Why it fits the user's background]
+**First experiment**: [Smallest useful test]
+**Main risk**: [Most likely failure mode]
+
+[Repeat for top 3–5 ideas]
+
+---
+
+## Raw Ideas
+[Brief bullet list of remaining ideas]
+```
+
+### Step 7: Report back
+
+After saving the digest, report:
+
+1. a one-line summary of today's landscape
+2. the top 3–5 ideas with title, one-line pitch, and score
+3. the path to the saved digest file
+
+## Example Output Style
+
+A good Junshi output does not just say what papers exist. It answers:
+
+- what matters most today
+- what idea is worth trying next
+- what first experiment should be run
+- what the main risk is
+
+## Tips
+
+- Do not overwhelm the user with summaries.
+- Prefer a small number of sharp ideas over a long list of weak ones.
+- Use the user's prior work as the main filter.
+- Give concrete first steps whenever possible.
+- Treat preliminary results as high-value input.
+
+## Tone
+
+Be direct, sharp, and strategically useful.
+
+Do not act like a generic summarizer. Act like a strong research collaborator who understands the user's work and helps them see what is worth trying next.

--- a/research-junshi/SKILL.md
+++ b/research-junshi/SKILL.md
@@ -41,13 +41,10 @@ Run:
 
 ## Example
 
-### Example Input
+**User**: "I work on diffusion models and inverse problems. My papers are in `~/papers/`. Please read my papers and give me today's research digest."
 
-User prompt:
 
-> I work on diffusion models and inverse problems. My papers are in `~/papers/`. Please read my papers and give me today's research digest.
-
-### Example Output
+**Output**:
 
 Saved digest to:
 

--- a/research-junshi/references/venues.md
+++ b/research-junshi/references/venues.md
@@ -1,0 +1,101 @@
+# Venue Search Reference (Internal — for Claude's use during setup)
+
+This file is used by the skill to suggest and infer appropriate venues when the user
+doesn't specify them. Users never need to read or edit this file.
+
+When inferring venues for a user's field:
+1. Pick the 4-6 most prominent venues for their area from the tables below
+2. State your choice to the user: "I'll watch X, Y, Z for you — correct me if you'd like others"
+3. Save the chosen venues to the user's profile
+
+For venues not listed here, use: `site:[proceedings-url] [keywords]`
+
+---
+
+## Machine Learning / AI
+
+| Venue | Search pattern |
+|---|---|
+| NeurIPS | `site:proceedings.neurips.cc [keywords]` |
+| ICML | `site:proceedings.mlr.press [keywords]` |
+| ICLR | `site:openreview.net [keywords]` |
+| AAAI | `site:ojs.aaai.org [keywords]` |
+| JMLR | `site:jmlr.org [keywords]` |
+
+## Computer Vision
+
+| Venue | Search pattern |
+|---|---|
+| CVPR | `site:openaccess.thecvf.com CVPR [keywords]` |
+| ICCV | `site:openaccess.thecvf.com ICCV [keywords]` |
+| ECCV | `site:ecva.net [keywords]` |
+
+## NLP
+
+| Venue | Search pattern |
+|---|---|
+| ACL | `site:aclanthology.org ACL [keywords]` |
+| EMNLP | `site:aclanthology.org EMNLP [keywords]` |
+| NAACL | `site:aclanthology.org NAACL [keywords]` |
+
+## Robotics
+
+| Venue | Search pattern |
+|---|---|
+| ICRA | `site:ieeexplore.ieee.org ICRA [keywords]` |
+| RSS | `site:roboticsproceedings.org [keywords]` |
+| CoRL | `site:proceedings.mlr.press CoRL [keywords]` |
+
+## Biology / Bioinformatics
+
+| Venue | Search pattern |
+|---|---|
+| Nature | `site:nature.com [keywords]` |
+| Science | `site:science.org [keywords]` |
+| Cell | `site:cell.com [keywords]` |
+| Bioinformatics | `site:academic.oup.com/bioinformatics [keywords]` |
+| NeurIPS Comp Bio | `site:proceedings.neurips.cc computational biology [keywords]` |
+
+## Physics
+
+| Venue | Search pattern |
+|---|---|
+| Physical Review Letters | `site:journals.aps.org/prl [keywords]` |
+| Physical Review X | `site:journals.aps.org/prx [keywords]` |
+| Nature Physics | `site:nature.com/nphys [keywords]` |
+
+## Economics / Statistics
+
+| Venue | Search pattern |
+|---|---|
+| Econometrica | `site:econometricsociety.org [keywords]` |
+| AER | `site:aeaweb.org/articles [keywords]` |
+| Annals of Statistics | `site:projecteuclid.org/aos [keywords]` |
+| JRSS-B | `site:academic.oup.com/jrsssb [keywords]` |
+
+## Systems / HCI
+
+| Venue | Search pattern |
+|---|---|
+| SOSP / OSDI | `site:usenix.org [keywords]` |
+| SIGCHI | `site:dl.acm.org CHI [keywords]` |
+| UIST | `site:dl.acm.org UIST [keywords]` |
+
+---
+
+## Arxiv Category Codes by Field
+
+| Field | Categories |
+|---|---|
+| Machine Learning | cs.LG, stat.ML |
+| Computer Vision | cs.CV |
+| NLP | cs.CL |
+| AI (general) | cs.AI |
+| Robotics | cs.RO |
+| Computational Biology | q-bio.GN, q-bio.QM, cs.LG |
+| Physics (general) | physics.gen-ph, cond-mat |
+| Economics | econ.EM, econ.TH |
+| Statistics | stat.ME, stat.TH |
+| Quantum Computing | quant-ph |
+| Systems | cs.OS, cs.DC |
+| HCI | cs.HC |


### PR DESCRIPTION
This PR adds Junshi, a Claude Code skill for personalized research planning.

What problem it solves:
Researchers often drown in new papers and summaries, but still struggle to identify the most promising next idea and first experiment.

Who uses this workflow:
Researchers, PhD students, and technical teams who work in literature-heavy settings and want recommendations grounded in their own prior work.

Attribution / inspiration source:
Inspired by the idea of an AI “junshi” (strategist): not replacing the researcher, but helping them think more clearly and act faster.

Example of how it’s used:
Junshi reads a user’s local paper folder, builds a research profile, scans relevant literature, and produces a daily digest with 3–5 ranked ideas, first experiments, and main risks.

Placed under Data & Analysis to match the current README category structure.