### PR TITLE
Add Factory Floor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [Factory Floor](https://github.com/Swiftner/Factory-Floor) - Startup coaching skill that combines Theory of Constraints, Customer Factory, How Brands Grow, and Marketing Strategy Discipline to help founders find and work their bottleneck. *By [@Swiftner](https://github.com/Swiftner)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
## What problem does it solve?

Founders waste time building features when the real bottleneck is awareness, or optimizing marketing when onboarding is broken. Factory Floor diagnoses the actual constraint and assigns a concrete experiment — not a list of advice.

## Who uses the workflow?

Solo founders and early-stage startup teams (pre-revenue through ~$100K MRR) who need help figuring out what to work on next.

## Attribution / Inspiration

Combines frameworks from Eli Goldratt (*The Goal*), Ash Maurya (*Scaling Lean*), Byron Sharp (*How Brands Grow*), Mark Ritson (Mini MBA in Marketing), and Clayton Christensen (*Competing Against Luck*).

## Example

```
User: "I have a B2B SaaS doing $4K MRR with 20 customers. Getting 50 trial
signups/month but only converting 8%. I'm a solo founder."

Skill: Routes to growth stage, identifies conversion as the constraint,
asks "What happens in the first 10 minutes after signup?", then assigns
a 2-week GOLEAN experiment focused on activation.
```

Install: `npx @swiftner/factory-floor`