### PR TITLE
Add claude-handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Pre-built workflow skills for 78 SaaS apps via [Rube MCP (Composio)](https://com
 - [ClickUp Automation](./clickup-automation/) - Automate ClickUp: tasks, lists, spaces, goals, and time tracking.
 - [Jira Automation](./jira-automation/) - Automate Jira: issues, projects, boards, sprints, and JQL queries.
 - [Linear Automation](./linear-automation/) - Automate Linear: issues, projects, cycles, teams, and workflows.
+n- [claude-handoff](https://github.com/REMvisual/claude-handoff) - Cross-session handoff system for Claude Code enabling context continuity, chain tracking, and structured work summaries between sessions. *By [@REMvisual](https://github.com/REMvisual)*
 - [Monday Automation](./monday-automation/) - Automate Monday.com: boards, items, columns, groups, and workspaces.
 - [Notion Automation](./notion-automation/) - Automate Notion: pages, databases, blocks, comments, and search.
 - [Todoist Automation](./todoist-automation/) - Automate Todoist: tasks, projects, sections, labels, and filters.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
+- [claude-handoff](https://github.com/REMvisual/claude-handoff) - Cross-session handoff system for Claude Code enabling context continuity, chain tracking, and structured work summaries between sessions. *By [@REMvisual](https://github.com/REMvisual)*
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*
 - [FFUF Web Fuzzing](https://github.com/jthack/ffuf_claude_skill) - Integrates the ffuf web fuzzer so Claude can run fuzzing tasks and analyze results for vulnerabilities. *By [@jthack](https://github.com/jthack)*
 - [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.
@@ -212,7 +213,6 @@ Pre-built workflow skills for 78 SaaS apps via [Rube MCP (Composio)](https://com
 - [ClickUp Automation](./clickup-automation/) - Automate ClickUp: tasks, lists, spaces, goals, and time tracking.
 - [Jira Automation](./jira-automation/) - Automate Jira: issues, projects, boards, sprints, and JQL queries.
 - [Linear Automation](./linear-automation/) - Automate Linear: issues, projects, cycles, teams, and workflows.
-n- [claude-handoff](https://github.com/REMvisual/claude-handoff) - Cross-session handoff system for Claude Code enabling context continuity, chain tracking, and structured work summaries between sessions. *By [@REMvisual](https://github.com/REMvisual)*
 - [Monday Automation](./monday-automation/) - Automate Monday.com: boards, items, columns, groups, and workspaces.
 - [Notion Automation](./notion-automation/) - Automate Notion: pages, databases, blocks, comments, and search.
 - [Todoist Automation](./todoist-automation/) - Automate Todoist: tasks, projects, sections, labels, and filters.


### PR DESCRIPTION
## [claude-handoff](https://github.com/REMvisual/claude-handoff)

Session handoff skills for Claude Code that capture decisions, failed approaches, measurements, and next steps — so your next session picks up exactly where you left off.

### Why it exists

Claude already tries to hand off context between sessions — generating summaries with "What's broken" and "Next session paste-prompt." It looks like a handoff. It isn't one. We ran a controlled A/B test (same bug, same codebase, three fresh sessions) and found:

| | Session summary (no skill) | `/handoff` skill |
|---|---|---|
| User had to intervene | Yes | No — self-gated |
| Root cause precision | Surface-level | Precise call chain |
| Fix correctness | Correct but unjustified | Correct and justified |
| Chain awareness | Zero | Referenced prior session's analysis |

Full comparison data: [docs/COMPARISON](https://github.com/REMvisual/claude-handoff/blob/master/docs/COMPARISON_skill-vs-internal-handoff.md)

### Features (v1.5.0)

- **Deep context mining** — 12-item extraction checklist with tiered strategy for large contexts (map-reduce at 500K+ tokens)
- **Chain tracking** — handoffs link across sessions via task IDs, with sequence numbers and parent references
- **Self-validation** — enforces line minimums and data completeness; re-mines if too thin
- **Anti-shadowing guard** — prevents Claude from generating inferior freeform handoffs without the skill
- **Onboarding protocol** — next session must prove comprehension before executing
- **PreCompact hook** — safety net before context compression
- **Works standalone** — optional integrations with Beads (task tracking) and OpenViking (AI memory)

### Install

```bash
git clone https://github.com/REMvisual/claude-handoff.git
cp -r claude-handoff/skills/handoff ~/.claude/skills/
cp -r claude-handoff/skills/handoffplan ~/.claude/skills/
```