### PR TITLE
Add translate-book skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
+- [translate-book](https://github.com/deusyu/translate-book) - Translate entire books (PDF/DOCX/EPUB) into any language using parallel sub-agents with chunk-level resume and multi-format output. *By [@deusyu](https://github.com/deusyu)*
 
 ### Development & Code Tools
 


### PR DESCRIPTION
Add [translate-book](https://github.com/deusyu/translate-book) to Document Processing section.

Claude Code skill that translates entire books (PDF/DOCX/EPUB) into any language using parallel sub-agents.

- **Parallel subagents** — 8 concurrent translators per batch, each with isolated context
- **Resumable** — chunk-level resume; already-translated chunks are skipped on re-run
- **Manifest validation** — SHA-256 hash tracking prevents stale or corrupt outputs
- **Multi-format output** — HTML (with floating TOC), DOCX, EPUB, PDF

Repository: https://github.com/deusyu/translate-book (400+ stars)