### PR TITLE
Add PM Pilot skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
+- [PM Pilot](https://github.com/mshadmanrahman/pm-pilot) - The PM toolkit for Claude Code with 20 skills, 5 rules, 5 agents, and 4 commands for product managers covering meeting prep, bug triage, weekly status, PRD generation, and stakeholder communication. *By [@mshadmanrahman](https://github.com/mshadmanrahman)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
 


### PR DESCRIPTION
## What problem it solves
Product managers using Claude Code lack purpose-built skills for PM workflows like meeting prep, bug triage handoff, sprint ceremonies, and stakeholder updates.

## Who uses this workflow
Product managers and program managers who use Claude Code for day-to-day work.

## Attribution
Created by Shadman Rahman (@mshadmanrahman)

## Example usage
- `/meeting-prep` to prepare for upcoming meetings with agenda, context, and talking points
- `/weekly-status` to generate cross-project status reports
- `/shepherd-triage` to hand off bug investigation to Bug Shepherd