### PR TITLE
Add Tech-to-PM Translator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [Tech-to-PM Translator](https://github.com/mshadmanrahman/tech-to-pm-translator) - Converts technical developer documentation into PM and designer-friendly knowledge base documents with clear explanations, visual diagrams, and decision context. *By [@mshadmanrahman](https://github.com/mshadmanrahman)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 
 ### Creative & Media


### PR DESCRIPTION
## What problem it solves
Non-engineers (PMs, designers, QA) struggle to understand technical architecture docs, API references, and ADRs written for engineers. This skill translates them into accessible knowledge base documents.

## Who uses this workflow
Product managers and designers who need to understand technical systems without reading code.

## Attribution
Created by Shadman Rahman (@mshadmanrahman)

## Example usage
- `/tech-to-pm` to convert an API doc into a PM-friendly context document
- Reads architecture refs, runbooks, ADRs and produces code-free knowledge base files