### PR TITLE
Add skill: ProxyGate — API marketplace for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [ProxyGate](https://github.com/proxygate-official/proxygate) - Buy and sell API access, post bounties, claim jobs, and manage listings on the API marketplace for AI agents. Install: `npx skills add proxygate-official/proxygate`
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [ProxyGate](https://proxygate.ai) to the Business & Marketing section.

**ProxyGate** is the API marketplace for AI agents — buy and sell API access, post bounties, claim jobs, and manage listings.

**Skills repo:** [`proxygate-official/proxygate`](https://github.com/proxygate-official/proxygate) — 7 skills covering setup, buying, selling, jobs, status, and updates.

```bash
npx skills add proxygate-official/proxygate
```

**Published packages:**
- [`@proxygate/cli`](https://www.npmjs.com/package/@proxygate/cli)
- [`@proxygate/sdk`](https://www.npmjs.com/package/@proxygate/sdk)