### PR TITLE
Add hand-drawn-diagrams: Excalidraw diagram skill with animation and hosted edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Creative & Media
 
+- [hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, and any agent supporting standard skill paths. *By [@muthuishere](https://github.com/muthuishere)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.


### PR DESCRIPTION
## Add hand-drawn-diagrams

**Repo:** https://github.com/muthuishere/hand-drawn-diagrams
**Author:** Muthukumaran Navaneethakrishnan ([@muthuishere](https://github.com/muthuishere))

### What it does

An agent skill that generates hand-drawn Excalidraw diagrams from a natural language prompt — picks the right diagram type (architecture, UX flows, teaching explainers, funnels, wireframes), lays out elements without overlap, and delivers:

- A hosted edit link — browser opens directly to the Excalidraw editor, no app install needed
- An animated SVG that draws itself stroke by stroke
- PNG export on request

Works with Claude Code, Codex, and any agent supporting standard skill paths.

### Placement

Added to **Creative & Media** alongside Canvas Design and Slack GIF Creator.