### PR TITLE
Add ClawSec and ClawSearch security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Security & Systems
 
+- [clawsearch](https://clawsearch.cc) - Safe skill discovery search engine with Trust Score, 10-language semantic search, and pre-install security guard (`npx clawsearch-guard`). *By [@anthropics](https://github.com/anthropics)*
+- [clawsec](https://clawsec.cc) - Security audit platform for AI agent skills with 5-tier analysis (static, pattern matching, LLM semantic, Firecracker sandbox, LLM review) and Trust Score system. Detects malicious patterns, data exfiltration, and prompt injection in Claude Code skills. *By [@anthropics](https://github.com/anthropics)*
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.


### PR DESCRIPTION
## Summary
- Add **ClawSec** (https://clawsec.cc) — security audit platform for AI agent skills with 5-tier analysis and Trust Score system
- Add **ClawSearch** (https://clawsearch.cc) — safe skill discovery search engine with semantic search and pre-install security guard

Both entries are added alphabetically to the **Security & Systems** section.

## Context
These are security audit and safe discovery tools for the Claude skill ecosystem, helping users verify skill safety before installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)