### PR TITLE
Add Product & Brand Naming skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Product & Brand Naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming for products, SaaS, brands, and open source projects that produces memorable, meaningful names. *By [@glacierphonk](https://github.com/glacierphonk)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Summary

Adds a link to the Product & Brand Naming skill under Business & Marketing.

## What problem it solves

Naming products, SaaS apps, brands, bots, and open source projects is one of the hardest non-technical decisions in product development. This skill uses a metaphor-driven process to generate memorable, meaningful names — avoiding generic AI-generated suggestions.

## Who uses this workflow

Solo developers, indie hackers, and small teams who need to name new products, services, or brands without hiring a branding agency.

## Example usage

"Name my fridge inventory tracking Telegram bot" → produces a shortlist of metaphor-grounded names with rationale, domain availability considerations, and brand personality fit.