### PR TITLE
Add moodtrip-hotel-search — Hotel search & booking via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
+- [moodtrip-hotel-search](https://github.com/adiny/moodtrip-hotel-search) - Search, compare, and book hotels via MoodTrip.ai MCP server. 12 tools including semantic search, real-time pricing, reviews, and booking handoff. *By [@adiny](https://github.com/adiny)*
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.


### PR DESCRIPTION
Adding moodtrip-hotel-search — a skill connecting Claude to the MoodTrip.ai MCP server for hotel search, comparison, reviews, and booking handoff.

- 12 MCP tools for full hotel discovery workflow
- - Semantic/natural language search ("romantic getaway in Paris")
- - Real-time pricing, reviews with AI sentiment, room photo matching
- - No auth required for search operations
- - MIT-0 license
Repo: https://github.com/adiny/moodtrip-hotel-search