### PR TITLE
Add gh-star-history to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [gh-star-history](https://github.com/ykdojo/gh-star-history) - Visualize and compare GitHub star history as interactive charts, with regional breakdown of stargazers. *By [@ykdojo](https://github.com/ykdojo)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds [gh-star-history](https://github.com/ykdojo/gh-star-history) to the Data & Analysis section.

A Claude Code plugin that visualizes GitHub star history as interactive charts with regional breakdown of stargazers.

Features:
- Interactive Plotly charts for star history
- Multi-repo comparison
- Regional breakdown of stargazers by location
- Local caching for fast re-runs