### PR TITLE
Add claude-auth-skill to 'Development and Code Tools' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [claude-auth-skill](https://github.com/scalekit-inc/claude-auth-skill) - Claude skill for implementing enterprise ready authentication across Python, NodeJS, and NextJS web applications, APIs, and MCP servers.
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adding claude-auth-skill which adds authentication capabilities to NextJS, NodeJS, and Python framework based web applications, APIs, and MCP servers.