### PR TITLE
Add cc-safe-setup to Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [cc-safe-setup](https://github.com/yurukusa/cc-safe-setup) - One-command safety hooks for Claude Code: blocks destructive commands, prevents secret leaks, guards branch pushes. 300+ hooks, 46 CLI commands.
 
 ### App Automation via Composio
 


### PR DESCRIPTION
Adds [cc-safe-setup](https://github.com/yurukusa/cc-safe-setup) to the Security & Systems section.
**What it does:** One-command safety hooks for Claude Code — blocks destructive commands (`rm -rf`, `git reset --hard`), prevents secret leaks (`git add .env`), guards branch pushes to main, and 300+ other safety patterns.
**Why it fits Security & Systems:** It's a safety tool that prevents the kind of incidents reported in Claude Code issues (lost C:\Users directory, force-pushed to main, committed API keys).
**Install:** `npx cc-safe-setup --shield`
8,000+ npm downloads/week. MIT licensed.