### PR TITLE
Add ADHX to Communication & Writing — X/Twitter post reader skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [ADHX](https://github.com/itsmemeworks/adhx) — Fetch any X/Twitter post as clean LLM-friendly JSON (including full X Articles) via a public API — no browser, no scraping. Install: `/plugin marketplace add itsmemeworks/adhx` or manually via curl. By [@itsmemeworks](https://github.com/itsmemeworks)
 
 ### Creative & Media
 


### PR DESCRIPTION
Adds ADHX (https://github.com/itsmemeworks/adhx) to the Communication & Writing section.

ADHX is an open-source Claude Code skill that fetches any X/Twitter post as clean LLM-friendly JSON via a public API — no browser, no scraping. Works with regular tweets and full X Articles.

Install options:
- /plugin marketplace add itsmemeworks/adhx
- Manual: curl -sL https://raw.githubusercontent.com/itsmemeworks/adhx/main/skills/adhx/SKILL.md -o ~/.claude/skills/adhx/SKILL.md