### PR TITLE
Add CoinPaprika and DexPaprika API skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Data & Analysis
 
+- [CoinPaprika API](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Query crypto market data for 12,000+ coins and 350+ exchanges. Tickers, OHLCV, historical prices, contract lookups. Free tier, no API key needed. *By [@coinpaprika](https://github.com/coinpaprika)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
+- [DexPaprika API](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 blockchains. 30M+ pools, 27M+ tokens, real-time streaming, OHLCV, search. No API key, no rate limits. *By [@coinpaprika](https://github.com/coinpaprika)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Data & Analysis
 
-- [CoinPaprika API](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Query crypto market data for 12,000+ coins and 350+ exchanges. Tickers, OHLCV, historical prices, contract lookups. Free tier, no API key needed. *By [@coinpaprika](https://github.com/coinpaprika)*
+- [CoinPaprika API](https://github.com/coinpaprika/skills/tree/main/coinpaprika-api) - Query crypto market data for 12,000+ coins and 350+ exchanges. Tickers, OHLCV, historical prices, contract lookups. Free tier, no API key required. *By [@coinpaprika](https://github.com/coinpaprika)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
-- [DexPaprika API](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Free DEX data across 34 blockchains. 30M+ pools, 27M+ tokens, real-time streaming, OHLCV, search. No API key, no rate limits. *By [@coinpaprika](https://github.com/coinpaprika)*
+- [DexPaprika API](https://github.com/coinpaprika/skills/tree/main/dexpaprika-api) - Query DEX data across 36 blockchains. 36M+ pools, 33M+ tokens, 230+ DEXes, SSE streaming, OHLCV, search. Free tier, no API key required. *By [@coinpaprika](https://github.com/coinpaprika)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.


### PR DESCRIPTION
Adds two crypto data skills to the list:

- **CoinPaprika API**: market data for 12,000+ coins and 350+ exchanges (tickers, OHLCV, historical prices, contract lookups). Free tier, no API key required.
- **DexPaprika API**: DEX data across 36 blockchains, pools, token prices, OHLCV, trades and SSE streaming. Free tier, no API key required. Limits and pricing: https://dexpaprika.com/api/pricing

Both are installable Claude Code skills from [github.com/coinpaprika/skills](https://github.com/coinpaprika/skills). Install via `npx skills add github.com/coinpaprika/skills`.

Closed: the repo's validator blocks crypto keywords in added lines by design, so these entries cannot pass it. See the closing comment.
