### PR TITLE
Add GitMemo to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Productivity & Organization
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
+- [GitMemo](https://github.com/sahadev/GitMemo) - Auto-sync AI conversations and notes to Git with Claude Code and Cursor support via CLI and MCP server. *By [@sahadev](https://github.com/sahadev)*
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.


### PR DESCRIPTION
## Summary

- Add [GitMemo](https://github.com/sahadev/GitMemo) to the **Productivity & Organization** section
- GitMemo is a CLI tool + MCP server that auto-syncs AI conversations and notes to Git
- Supports both Claude Code and Cursor
- Zero background process, powered by native editor hooks

## What GitMemo Does

- Auto-records AI conversations as Markdown files
- Syncs to Git (auto commit & push)
- Full-text search across conversations and notes
- MCP integration with 8 tools (search, notes, sync, etc.)
- CLI commands for notes, daily journal, manuals

## Links

- GitHub: https://github.com/sahadev/GitMemo
- skills.sh: https://skills.sh/sahadev/gitmemo