### PR TITLE
Add Claude Starter Kit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Productivity & Organization
 
+- [Claude Starter Kit](https://github.com/awrshift/claude-starter-kit) - Ready-to-use project structure for Claude Code agents with persistent memory, session continuity, pre-compact hooks, and bundled skills (Gemini, Brainstorm, Design). *By [@awrshift](https://github.com/awrshift)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
## Add Claude Starter Kit

**Category:** Productivity & Organization

**Entry:**
- [Claude Starter Kit](https://github.com/awrshift/claude-starter-kit) - Ready-to-use project structure for Claude Code agents with persistent memory, session continuity, pre-compact hooks, and bundled skills (Gemini, Brainstorm, Design). *By [@awrshift](https://github.com/awrshift)*

### What it does
A complete starter kit for Claude Code projects that includes:
- **Memory system** — MEMORY.md, CONTEXT.md, snapshots for cross-session persistence
- **Session continuity** — next-session-prompt with `<!-- PROJECT:name -->` tags for parallel multi-project work
- **Hooks** — session-start (context injection) + pre-compact (prevents context loss)
- **Bundled skills** — Gemini (second opinions), Brainstorm (Claude x Gemini dialogue), Design (token pipeline)
- **Auto-setup** — agent configures everything on first run

### Checklist
- [x] Skill has a SKILL.md file with proper frontmatter
- [x] Tested on Claude Code
- [x] Entry placed in alphabetical order
- [x] No emoji in description
- [x] MIT licensed