### PR TITLE
Add HubSpot Admin Skills — 32 skills for HubSpot CRM administration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
+- [HubSpot Admin Skills](https://github.com/TomGranot/hubspot-admin-skills) - 32 Claude Code skills for auditing, cleaning, enriching, and automating HubSpot CRM. Includes full audit, plan, execute, and maintain workflow with Python scripts. *By [@TomGranot](https://github.com/TomGranot)*
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 
 ### Communication & Writing


### PR DESCRIPTION
## Summary

Adds [HubSpot Admin Skills](https://github.com/TomGranot/hubspot-admin-skills) to the Business & Marketing section.

This is a collection of 32 Claude Code skills for HubSpot CRM administration, covering the full lifecycle from audit through cleanup, enrichment, and ongoing maintenance. Each skill includes process documentation and companion Python scripts that use the `hubspot-api-client` SDK.

**What's included:**

- Database audit and reporting skills
- Contact hygiene (duplicates, bounces, unsubscribes, free email domains)
- Data enrichment (company names, industries, country/state standardization)
- Lifecycle stage management and lead scoring setup
- Engagement-based suppression and re-engagement workflows
- Quarterly cleanup routines

Built and tested against a production HubSpot instance with ~96K contacts and ~46K companies.