### PR TITLE
Add feishu-inout: Lark/Feishu docs, messaging, calendar & bitable skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Collaboration & Project Management
 
+- [feishu-inout](https://github.com/joe960913/feishu-inout) - Lark/Feishu docs, messaging, calendar & bitable integration. Read/write documents, send/search messages, create meetings, manage bitable records. Zero dependencies, official MCP. `npx skills add joe960913/feishu-inout` *By [@joe960913](https://github.com/joe960913)*
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## Summary

Adds [feishu-inout](https://github.com/joe960913/feishu-inout) to the Collaboration & Project Management section.

**feishu-inout** is a Claude Code skill for Lark/Feishu integration that provides:
- Read/write Lark documents
- Send and search messages
- Create calendar meetings
- Manage bitable records
- Zero dependencies, official MCP

Install: `npx skills add joe960913/feishu-inout`

GitHub: https://github.com/joe960913/feishu-inout