### PR TITLE
Add The Pragmatic PM — PM leadership toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
+- [The Pragmatic PM](https://github.com/marfoerst/the-pragmatic-pm) - PM leadership toolkit with 43 skills, 5 orchestrator agents, 4 multi-stage workflows, and 4 hooks. Covers PRD generation, OKR lifecycle, pricing, positioning, sales enablement, and quarterly planning. *By [@marfoerst](https://github.com/marfoerst)*
 
 ### Security & Systems
 


### PR DESCRIPTION
## Summary

- Adds [The Pragmatic PM](https://github.com/marfoerst/the-pragmatic-pm) to the Collaboration & Project Management section
- PM leadership toolkit with 43 skills, 5 orchestrator agents, 4 multi-stage workflows, and 4 automation hooks
- Covers PRD generation, OKR lifecycle, pricing, AI pricing, positioning, sales enablement, and quarterly planning
- Built on proven PM frameworks: April Dunford (positioning), Simon-Kucher (pricing), Teresa Torres (discovery), John Doerr (OKRs)
- Domain-agnostic via `domain-context.md` + `personal-context.md`
- MIT licensed

## Install

```
/plugin install pm-toolkit@the-pragmatic-pm
```