### PR TITLE
Add 6 business & sales skills by koinod

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Client Acquisition](https://github.com/koinod/koino-skills/tree/main/client-acquisition) - Full-funnel B2B client acquisition with ICP scoring, personalized outreach sequences, and pipeline management. *By [@koinod](https://github.com/koinod)*
+- [Cold Email Writer](https://github.com/koinod/koino-skills/tree/main/cold-email-writer) - Personalized cold email sequences using P.A.S. framework with A/B variants. *By [@koinod](https://github.com/koinod)*
+- [Lead Scorer](https://github.com/koinod/koino-skills/tree/main/lead-scorer) - Score prospects 0-100 on BANT/MEDDIC criteria — HOT / WARM / COLD / DISQUALIFIED. *By [@koinod](https://github.com/koinod)*
+- [Proposal Generator](https://github.com/koinod/koino-skills/tree/main/proposal-generator) - Generate service proposals in 60 seconds with ROI projections and pricing tiers. *By [@koinod](https://github.com/koinod)*
+- [Sales Objection Coach](https://github.com/koinod/koino-skills/tree/main/sales-objection-coach) - Practice handling objections with 7 frameworks including LAER, Feel-Felt-Found, and Boomerang. *By [@koinod](https://github.com/koinod)*
+- [Competitor Analyzer](https://github.com/koinod/koino-skills/tree/main/competitor-analyzer) - Deep competitive analysis with pricing intelligence, feature gaps, and positioning insights. *By [@koinod](https://github.com/koinod)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Summary
Adds 6 business and sales skills to the Business & Marketing section from [koinod/koino-skills](https://github.com/koinod/koino-skills).

## Skills Added
- **client-acquisition** — Full-funnel B2B acquisition with ICP scoring and outreach sequences
- **cold-email-writer** — Personalized cold emails using P.A.S. framework
- **lead-scorer** — BANT/MEDDIC automated lead scoring (0-100)
- **proposal-generator** — Service proposals in 60 seconds with ROI projections
- **sales-objection-coach** — 7 objection handling frameworks with drill mode
- **competitor-analyzer** — Competitive intelligence with pricing and positioning analysis

All follow the SKILL.md standard. Production-tested in real client deployments.