### PR TITLE
Add topic-pause-recall: Pause/resume agent tasks by keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [topic-pause-recall](https://github.com/carterusedulm2-maker/topic-skill-topic-pause-recall) - Pause any long-running agent task and seamlessly resume it later by keyword. Supports pause, recall, list, and forget with optional workspace/memory cleanup. *By [@carterusedulm2-maker](https://github.com/carterusedulm2-maker)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
## topic-pause-recall

Pause any long-running agent task and seamlessly resume it later by keyword. Supports pause, recall, list, and forget with optional workspace/memory cleanup.

### Features
- **Pause** — Save current task state to disk by keyword
- **Recall** — Resume any paused task by keyword
- **List** — View all paused tasks with status and timestamps
- **Forget** — Remove a paused task, optionally cleaning up workspace dirs and memory files

### Use Case
When you are mid-task with an agent and need to step away, say "先這樣" (thats all for now). When ready to continue, just say "continue [keyword]" and the agent picks up right where it left off.

---

Repo: https://github.com/carterusedulm2-maker/topic-skill-topic-pause-recall