### PR TITLE
Add Visual Eyes - visual testing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [Visual Eyes](https://github.com/nikolasdehor/visual-eyes) - Give Claude Code eyes to see running apps - screenshot, analyze UI issues visually, and auto-fix them with zero config.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
Adds Visual Eyes, a Claude Code skill that gives Claude the ability to see running web applications via Playwright screenshots, analyze UI issues visually, and auto-fix them. Zero config, works with any localhost app.