### PR TITLE
Add AIRIS MCP Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) - Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools, reducing context token usage by 97%. One command to start, auto-enables servers on demand. *By [@agiletec-inc](https://github.com/agiletec-inc)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## Summary

- Adds [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) to the **Development & Code Tools** section
- Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools, reducing context token usage by 97%
- One `docker compose up -d` to start; servers auto-enable on demand via lazy loading and idle-kill

## What problem it solves

Claude Code users connecting many MCP servers face massive context token overhead (40k+ tokens just for tool definitions). AIRIS MCP Gateway solves this by exposing only 7 meta-tools (`airis-find`, `airis-exec`, `airis-schema`, etc.) that dynamically route to 60+ underlying tools, cutting token usage by ~97%.

## Who uses this workflow

Developers using Claude Code with multiple MCP servers (Stripe, Supabase, Playwright, memory, etc.) who want a single gateway instead of registering each server individually.

## Attribution

Built by [Agiletec Inc.](https://github.com/agiletec-inc)