### PR TITLE
Add WhatsApp Channel Plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [WhatsApp Channel Plugin](https://github.com/Rich627/whatsapp-claude-plugin) - Connect Claude Code to WhatsApp as a channel plugin with two-way messaging, voice transcription, group chat with AI personalities, permission relay, and cron scheduling. Runs 24/7 on headless setups. *By [@Rich627](https://github.com/Rich627)*
 
 ### Creative & Media
 


### PR DESCRIPTION
## Summary

- Adds [WhatsApp Channel Plugin](https://github.com/Rich627/whatsapp-claude-plugin) to the **Communication & Writing** section
- Open-source MCP plugin that connects Claude Code to WhatsApp as a channel
- Features: two-way messaging, voice transcription (mlx-whisper), group chat with per-group AI personalities, permission relay via DM, access control, and cron scheduling
- Built with TypeScript + Bun, Baileys 7 (WhatsApp Web multi-device protocol)
- Runs 24/7 on headless setups (macOS LaunchAgent + tmux)

## Checklist

- [x] Based on a real use case (running 24/7 on a headless Mac Mini)
- [x] Well-documented with README and ACCESS.md
- [x] Open-source (MIT license)
- [x] Tested and working
- [x] No duplicate entry in the list