### PR TITLE
Add Deep Research with NotebookLM skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [Deep Research with NotebookLM](https://github.com/Chris1220-cmd/deep-research-skill) - Free Perplexity/Gemini-level deep research with 20-40+ sources, domain boost (maritime, legal, academic), source credibility scoring, and post-research artifact generation (podcast, video, slides, quiz). *By [@Chris1220-cmd](https://github.com/Chris1220-cmd)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 


### PR DESCRIPTION
## New Skill: Deep Research with NotebookLM

**Repo:** https://github.com/Chris1220-cmd/deep-research-skill
**Category:** Data & Analysis

### What it does

Free alternative to Perplexity Pro / Gemini Deep Research / ChatGPT Deep Research that runs inside any agent-skills compatible tool.

- Researches any topic with 20-40+ sources via NotebookLM's Gemini-powered research engine
- Domain boost for maritime (SOLAS/IMO/STCW), legal, and academic research
- Source credibility scoring (official, academic, industry, news, blog)
- Post-research artifact generation: podcast, video, slides, quiz/flashcards
- Continue/resume previous research sessions
- Compare mode for structured X vs Y analysis
- Graceful fallback to WebSearch-only when NotebookLM is not installed

### Why it's different from existing deep-research entry

The existing deep-research by @sanjay3290 uses Gemini Deep Research API directly and focuses on market analysis. This skill:

1. Uses NotebookLM (free) instead of Gemini API (paid)
2. Adds domain-specific search routing (maritime, legal, academic)
3. Generates artifacts (podcast, video, slides, quiz) from research findings
4. Includes source credibility scoring
5. Supports continue/resume and compare modes
6. Works in fallback mode without any API keys

### Checklist

- [x] Based on a real use case
- [x] Checked for duplicates (different approach from existing deep-research)
- [x] Follows skill structure (single SKILL.md)
- [x] MIT licensed
- [x] Tested across platforms