### PR TITLE
Add ProxyClaw — residential proxy skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [ProxyClaw](https://github.com/Iploop/proxyclaw) - Route web requests through 2M+ residential IPs across 195+ countries. Built-in anti-detection with TLS fingerprinting and Chrome headers. 66 site presets. `pip install iploop-sdk`
 
 ### App Automation via Composio
 


### PR DESCRIPTION
Adds [ProxyClaw](https://github.com/Iploop/proxyclaw) to the Security & Systems section.

**ProxyClaw** enables Claude to route web requests through 2M+ residential IPs across 195+ countries:
- Built-in anti-detection (TLS/JA3 fingerprinting + Chrome headers)
- 66 site-specific presets (Amazon, Google, Reddit, etc.)
- Python SDK: `pip install iploop-sdk`
- Works as a Claude Code skill via `clawhub install proxyclaw`

Useful for web research, OSINT, data collection, and accessing geo-restricted content through real residential IPs.