### PR TITLE
Add openai-image-skill to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [openai-image-skill](https://github.com/dkarski/openai-image-skill) - Generate images with DALL-E 2/3 and gpt-image-1 directly from Claude. Supports quality control (`--quality=low|standard|hd`), multiple variants (`--count=N`), and self-updates via GitHub Releases. *By [@dkarski](https://github.com/dkarski)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
## Description

Adds [openai-image-skill](https://github.com/dkarski/openai-image-skill) to the **Creative & Media** section.

A Claude Code skill for AI image generation using OpenAI's API:
- Supports DALL-E 2/3, gpt-image-1, gpt-image-1.5 (auto-detects new models daily)
- `--quality=low|standard|hd` for cost vs. quality control
- `--count=N` for multiple variants in one command
- Self-updating via `generate-image.mjs update` (GitHub Releases)
- MIT license

## Checklist

- [x] Entry added in alphabetical order within the section
- [x] Format matches existing entries (`- [name](url) - Description. *By [@author](url)*`)
- [x] Link points to public GitHub repository
- [x] Repository is publicly accessible and has a clear README