### PR TITLE
Add Tap — browser automation MCP server (81 skills, forge once run forever)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
+- [Tap](https://github.com/LeonTing1010/tap) - Universal browser automation protocol as Claude Code MCP server. 35+ tools for AI agents to operate any web interface — forge deterministic taps, run with zero AI at runtime. *By [@LeonTing1010](https://github.com/LeonTing1010)*
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis


### PR DESCRIPTION
Adds [Tap](https://github.com/LeonTing1010/tap) — the interface protocol for AI agents to operate any website.

- 81 pre-built skills across 41 sites
- 38 MCP tools (tap, forge, page, inspect, tab, intercept)
- Forge once, run forever — zero AI at runtime
- Works with Claude Code, Cursor, Windsurf, OpenClaw

```json
{
  "mcpServers": {
    "tap": {
      "command": "tap",
      "args": ["mcp"]
    }
  }
}
```