### PR TITLE
Add google-sites-architect skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [Google Sites Architect](google-sites-architect/) | Design, plan, and build Google Sites with step-by-step build guides, ASCII mockups,
+  component mapping, style guides, and QA checklists
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adds Google Sites Architect — a planning and build guidance skill for Google Sites.

I built this while redesigning a 24-page organization website on Google Sites. Google Sites has no API or CLI, so the only way to get AI assistance is through detailed build guides that reference actual platform components and menus. I couldn't find anything like this in any skill collection, so I packaged what I'd built into a reusable skill.

The skill runs an 8-phase workflow: requirements gathering, site architecture, page blueprints, copywriting, component mapping to Google Sites UI elements, style guide, numbered build steps with ASCII mockups, and a QA checklist. Every recommendation is specific to what Google Sites can actually do — including its limitations like no images inside collapsible text and no custom CSS.

Includes a full reference doc covering all 10 Google Sites components with usage tips, dimensions, and mobile considerations.

Repo: https://github.com/jpmalich/google-sites-architect