### PR TITLE
Add ru-text: Russian text quality skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence. Cross-platform. *By [@talkstream](https://github.com/talkstream)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 
 ### Creative & Media


### PR DESCRIPTION
## Summary

- Adds [ru-text](https://github.com/talkstream/ru-text) to the **Communication & Writing** section
- ~1,040 rules covering typography, info-style, editorial standards, UX writing, and business correspondence
- Cross-platform skill (Claude Code, Claude.ai, API)

## What problem it solves

Russian-language text has strict typography and style conventions (e.g., proper dashes, quotes, spacing, info-style clarity rules). ru-text provides ~1,040 curated rules so Claude produces publication-ready Russian text without manual post-editing.

## Who uses this

Anyone writing or editing Russian-language content: technical writers, editors, UX writers, marketers, business correspondents.

## Example

```
/ru-check

> Checks the last Russian text output against typography, info-style, editorial, UX writing, and correspondence rules, returning specific fixes.
```