### PR TITLE
Add Deep Research skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [Deep Research](https://github.com/robertnowell/deep-research) - Multi-source deep research with source quality gates, 4-tier source classification, confidence labels, and parallel agents. *By [@robertnowell](https://github.com/robertnowell)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 


### PR DESCRIPTION
## What problem does it solve?

Engineers and decision-makers need trustworthy multi-source research within Claude Code, but built-in WebSearch only returns titles/URLs and has no source quality evaluation. Existing research skills either delegate to external APIs (Gemini) or lack source verification.

Deep Research runs a 5-phase parallel pipeline entirely within Claude Code — no API keys, no external dependencies — with hard quality gates that block output unless every claim cites a classified source.

## Who uses this workflow?

Software engineers evaluating technical decisions (e.g., "should we migrate from Redis to Valkey?"), teams doing competitive analysis, and anyone who needs a well-sourced answer in minutes rather than hours.

## What makes it different?

- **4-tier source classification** — every source labeled as Primary, Curated Secondary, Community, or Unverifiable
- **5 hard quality gates** — no fabricated URLs, no uncited findings, failed angles disclosed
- **Confidence labels** — Established / Likely / Emerging / Contested / Speculative
- **3 scope modes** — quick (~2 min), standard (~5 min), thorough (~10 min)
- **Codebase-aware** — spawns Explore agents for project-related questions
- **No external API keys required** — uses built-in WebSearch + WebFetch

## Usage example

```
/deep-research what are the tradeoffs between SQLite and PostgreSQL for new web apps?
/deep-research quick what is WebTransport?
/deep-research thorough should we migrate from Redis to Valkey?
```

## Attribution

Created by [@robertnowell](https://github.com/robertnowell). MIT licensed.