### PR TITLE
Add Capsulate Gmail dashboard skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Productivity & Organization
 
+- [Capsulate](https://github.com/imekenni/capsulate-skill) - Turn Gmail into structured dashboards — extract and track subscriptions, packages, invoices, job applications, and more. No backend required.
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
## Description

Adds [Capsulate](https://github.com/imekenni/capsulate-skill) to the Productivity & Organization section.

Capsulate is a Claude Code skill that turns Gmail into structured, queryable dashboards. You describe what you want to track (subscriptions, packages, invoices, job applications, etc.), and Claude searches your email, extracts the data in parallel, and generates a self-contained HTML dashboard — all locally, no backend required.

## Checklist

- [x] Skill is publicly available on GitHub
- [x] Added in alphabetical order within the category
- [x] One-sentence description following existing format
- [x] No backend or paid account required to use