### PR TITLE
Add Strategic Partner skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
+- [Strategic Partner](https://github.com/JimmySadek/strategic-partner) - Advisory skill that separates thinking from building. Challenges premises, compares approaches, routes tasks to the right tool, and packages work into self-contained prompts for fresh sessions. *By [@JimmySadek](https://github.com/JimmySadek)*
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 
 ### Collaboration & Project Management


### PR DESCRIPTION
**What:** Add Strategic Partner, an advisory skill for Claude Code.

**Category:** Productivity & Organization

**Real-world problem:** Claude Code users with many installed skills often rush into implementation before the problem is properly framed. This leads to rework, scope drift, and wasted context windows.

**Who uses this:** Daily Claude Code users who manage multiple projects and want a thinking layer before building.

**What it does:** Separates deciding from building — challenges assumptions, presents A/B/C alternatives, routes tasks to the right skill, and crafts self-contained implementation prompts for fresh sessions. Never writes source code in its own session.

**Usage:** `/strategic-partner` in any project. Describe what you need; it thinks with you before packaging the execution.

**Attribution:** Built from daily Claude Code usage across multiple projects. MIT licensed.