### PR TITLE
Add bigdata-analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Data & Analysis
 
+- [bigdata-analysis](https://github.com/Oak-B/bigdata-analysis-skill) - Prevents silent data bugs in Hive/Impala/Spark ETL: control characters in GROUP BY, SELECT * column shifts, broadcast JOIN explosion, and 7 more rules from production incidents. *By [@Oak-B](https://github.com/Oak-B)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## What this PR adds

**[bigdata-analysis](https://github.com/Oak-B/bigdata-analysis-skill)** — an AI coding skill that prevents silent data bugs in Hive/Impala/Spark ETL pipelines.

### What problem it solves

When AI assistants generate Spark/Hive code, they frequently produce code with **invisible bugs** — row counts look correct, no errors thrown, but data is silently wrong. This skill encodes 10 battle-tested rules from real production incidents:

- Control characters in `GROUP BY` causing silent row explosion
- `SELECT *` in INSERT causing column position shifts
- `foreachPartition` as a no-op for cache materialization  
- Broadcast JOIN threshold causing 26k+ task explosion
- And 6 more rules covering OOM, JOIN safety, UDF type safety, metadata refresh, etc.

### Who uses this workflow

Data engineers writing Hive/Impala SQL or Spark Scala ETL jobs on HDFS/YARN, especially those using AI coding assistants.

### Real-world impact

One rule alone (Rule 4: Spark SQL vs DataFrame API) reduced a production job from **367 lines / 45 Jobs / 3 hours** to **50 lines / 1 Job / 15 minutes**.

### Category

Added to **Data & Analysis** (alphabetical order).

### Install

```bash
npx skills add Oak-B/bigdata-analysis-skill@bigdata-analysis
```
