### PR TITLE
Add TokRepo Search skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [TokRepo Search](./tokrepo-search/) - Find installable skills, MCP servers, prompts, and workflows from TokRepo when users need to discover AI tools. Inspired by TokRepo's search-and-install workflow.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.

--- a/tokrepo-search/SKILL.md
+++ b/tokrepo-search/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: tokrepo-search
+description: Find installable AI skills, MCP servers, prompts, and workflows from TokRepo when a user asks to discover or install an AI tool.
+---
+
+# TokRepo Search
+
+TokRepo Search helps Claude find practical, installable AI assets from TokRepo, an open registry for skills, prompts, MCP configs, scripts, and workflows.
+
+## When to Use This Skill
+
+- The user asks to find or discover an AI tool, Claude skill, MCP server, prompt, or workflow
+- The user wants an install command instead of a long manual setup
+- The user wants options for a specific use case such as code review, database access, or content creation
+- The user mentions TokRepo directly
+
+## What This Skill Does
+
+1. **Searches TokRepo**: Finds relevant AI assets by keyword or use case.
+2. **Summarizes matches**: Explains what each asset does in plain language.
+3. **Provides install paths**: Gives the right `npx tokrepo install` command or product link.
+4. **Shows alternatives**: Offers a small shortlist when more than one asset could fit.
+
+## How to Use
+
+### Basic Usage
+
+If command execution is available, search with:
+
+```bash
+npx tokrepo search "<query>"
+```
+
+Examples:
+
+```bash
+npx tokrepo search "claude code review"
+npx tokrepo search "mcp postgres"
+npx tokrepo search "prompt writing"
+```
+
+### Advanced Usage
+
+After finding a match, install it with:
+
+```bash
+npx tokrepo install <uuid-or-name>
+```
+
+If terminal access is not available, use https://tokrepo.com to inspect the asset page and explain the setup steps clearly.
+
+## Example
+
+**User**: "Find me a Claude skill for code review and show me how to install it."
+
+**Output**:
+
+```text
+I found a few relevant TokRepo entries for code review.
+
+1. <Asset title>
+   - What it does: Reviews code changes and highlights likely issues
+   - Install: npx tokrepo install <uuid>
+
+2. <Asset title>
+   - What it does: Focuses on security-oriented code review
+   - Install: npx tokrepo install <uuid>
+```
+
+**Inspired by:** TokRepo's search-and-install workflow for AI assets.
+
+## Tips
+
+- Prefer a short shortlist over a long dump of results
+- Always include the install command when available
+- If the user is unsure, suggest the most broadly useful option first
+
+## Common Use Cases
+
+- Finding a Claude Code skill for a specific engineering task
+- Discovering an MCP server for databases, GitHub, or chat tools
+- Recommending prompts or workflows that can be installed quickly


### PR DESCRIPTION
This adds a native `tokrepo-search` Claude skill and README entry.

Why it fits:
- helps Claude users discover installable skills, MCP servers, prompts, and workflows for real tasks
- follows the repo native format with a self-contained skill folder
- gives a practical search-to-install workflow instead of a generic directory link

Happy to adjust the wording or category if you prefer a different placement.