### PR TITLE
Add Blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
+- [Blueprint](https://github.com/JuliusBrussee/blueprint) - A Claude Code plugin for specification-driven development that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration and dual-model adversarial review. *By [@JuliusBrussee](https://github.com/JuliusBrussee)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*


### PR DESCRIPTION
## What is Blueprint?

[Blueprint](https://github.com/JuliusBrussee/blueprint) is a Claude Code plugin for specification-driven development by [@JuliusBrussee](https://github.com/JuliusBrussee).

It turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software — with automated iteration and dual-model adversarial review built in.

## Why it fits

Blueprint is a Claude Code-native skill that extends Claude's development workflow with a structured, spec-first approach. It fits naturally in the **Development & Code Tools** section alongside other workflow and architecture skills like `subagent-driven-development`, `test-driven-development`, and `software-architecture`.

Added alphabetically between `aws-skills` and `Changelog Generator`.