### PR TITLE
Add smartest-tv to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
+- [smartest-tv](https://github.com/Hybirdss/smartest-tv) - Play Netflix episodes, YouTube videos, and Spotify music on your smart TV by name. Resolves content IDs and deep links to LG, Samsung, Android TV, and Roku. *By [@Hybirdss](https://github.com/Hybirdss)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
I built a CLI that lets Claude control my TV. "Play Frieren on the living room TV" → Netflix opens the right episode in 3 seconds.

Supports 30+ streaming platforms (Netflix, Disney+, Prime, Max, Hulu, Crunchyroll, etc.) and auto-detects which one has the show. Works on LG, Samsung, Roku, Android TV.

I use it every night while coding — faster than picking up the remote.

- **Repo**: https://github.com/Hybirdss/smartest-tv
- **Install**: `pip install stv && stv setup`
- **PyPI**: ~1000 downloads/month
- **Skill**: `skills/tv/SKILL.md` (auto-triggers on "play", "good night", "next episode")