### PR TITLE
Add framecraft — demo video generation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Creative & Media
 
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [framecraft](https://github.com/vaddisrinivas/framecraft) - Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations. *By [@vaddisrinivas](https://github.com/vaddisrinivas)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
Adds [framecraft](https://github.com/vaddisrinivas/framecraft) to the **Creative & Media** section.

**What it does:** Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.

**Install:** `claude plugin install framecraft` or `npx skills add vaddisrinivas/framecraft`

- Real use case: creating product demo videos, feature showcases, and launch videos
- Includes a full Python pipeline, HTML templates, MCP server, and CLI — not just a SKILL.md
- Tested with Claude Code
- MIT licensed