### PR TITLE
Add /cht — Chat Persistence for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Productivity & Organization
 
+- [cht-cli](https://github.com/kosoukhov/cht-cli) - Chat persistence for Claude Code: 13 slash commands + hooks for saving conversations as local markdown files with crash-proof auto-save and project-based organization. *By [@kosoukhov](https://github.com/kosoukhov)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
## Add /cht — Chat Persistence for Claude Code

[/cht](https://github.com/kosoukhov/cht-cli) provides 13 slash commands + hooks for persisting Claude Code conversations as local markdown files.

**Key features:**
- Crash-proof auto-save via hooks
- Project-based chat organization
- Full conversation context loading
- Offline-readable markdown

**Links:**
- GitHub: https://github.com/kosoukhov/cht-cli
- npm: https://www.npmjs.com/package/@kosoukhov/cht-cli