### PR TITLE
Add Marketing AI Toolkit skill directory to Business & Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Marketing AI Toolkit](https://ccromp.github.io/marketing-ai-toolkit/) by [MarketCore Labs](https://github.com/ccromp/marketing-ai-toolkit) - Quality-scored directory of 230+ Claude Code skills and MCP servers for marketing professionals. Covers SEO, content creation, email marketing, social media, analytics, and ad copy with MarketCore Scores for each tool.
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Add: Marketing AI Toolkit

Adding a curated directory of Claude Code skills and MCP servers specifically reviewed and scored for marketing workflows.

### What it is
A quality-scored catalog of 230+ tools for marketing teams — covering SEO, content creation, email marketing, social media, paid ads, CRM, and analytics. Each tool has a MarketCore Score based on real installation testing.

**URL:** https://ccromp.github.io/marketing-ai-toolkit/  
**Repo:** https://github.com/ccromp/marketing-ai-toolkit

### Why it belongs
The Business & Marketing category is the natural home for a resource that specifically helps marketing professionals find, evaluate, and install AI tools for Claude Code. No other resource in this list is focused exclusively on marketing use cases — this fills a real gap.

### What was added
One line in the Business & Marketing section linking to the directory.