### PR TITLE
Add agentify-cli to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Development & Code Tools
 
+- [agentify-cli](https://github.com/koriyoshi2041/agentify) - Agent Interface Compiler that transforms OpenAPI specs into 9 agent interface formats (Skills, CLAUDE.md, MCP servers, AGENTS.md, .cursorrules, llms.txt, GEMINI.md, A2A Card, CLI) with a single command. *By [@koriyoshi2041](https://github.com/koriyoshi2041)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## What problem it solves

[agentify-cli](https://github.com/koriyoshi2041/agentify) bridges the gap between traditional APIs and the agent ecosystem. Many products have OpenAPI specs but lack agent-friendly interfaces. Agentify transforms any OpenAPI spec into 9 agent interface formats with a single command:

```bash
npx agentify-cli transform <openapi-spec>
```

**Output formats:** Skills, CLAUDE.md, MCP servers, AGENTS.md, .cursorrules, llms.txt, GEMINI.md, A2A Card, CLI

## Who uses this workflow

- Developers who want to make their APIs accessible to AI agents
- Teams adopting Claude Code, Cursor, or other AI coding tools that consume CLAUDE.md / .cursorrules / AGENTS.md
- API providers looking to generate MCP servers or Skills from existing OpenAPI specs

## Details

- **npm:** [agentify-cli](https://www.npmjs.com/package/agentify-cli) (v0.4.3)
- **GitHub:** [koriyoshi2041/agentify](https://github.com/koriyoshi2041/agentify)
- **License:** MIT
- **Tech:** TypeScript, supports both Swagger 2.0 and OpenAPI 3.x

## Example

```bash
# Transform Stripe's API into agent interfaces
npx agentify-cli transform https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json

# Generate only Skills and CLAUDE.md
npx agentify-cli transform ./petstore.yaml -f skills -f claude
```