### PR TITLE
Add ctxlint — AI context file linter with MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
+- [**ctxlint**](https://github.com/YawLabs/ctxlint) - Lints AI context files (CLAUDE.md, .cursorrules, copilot-instructions.md) against your codebase. Built-in MCP server for agent self-auditing.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*
 - [FFUF Web Fuzzing](https://github.com/jthack/ffuf_claude_skill) - Integrates the ffuf web fuzzer so Claude can run fuzzing tasks and analyze results for vulnerabilities. *By [@jthack](https://github.com/jthack)*
 - [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.


### PR DESCRIPTION
## Summary

[ctxlint](https://github.com/YawLabs/ctxlint) is an open-source linter for AI context files (CLAUDE.md, .cursorrules, copilot-instructions.md). It validates file paths, shell commands, and references against your actual codebase. Includes a built-in MCP server so agents can self-audit their own context files.

- **GitHub**: https://github.com/YawLabs/ctxlint
- **npm**: [@yawlabs/ctxlint](https://www.npmjs.com/package/@yawlabs/ctxlint)
- **License**: MIT

Added to the **Development & Code Tools** section in alphabetical order.