### PR TITLE
Add reddit-skills: Reddit automation for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
 
+### Social Media & Community
+
+- [reddit-skills](https://github.com/1146345502/reddit-skills) - Reddit automation skills for AI agents — browse, search, comment, vote, and publish using your real browser via a Chrome extension bridge. *By [@1146345502](https://github.com/1146345502)*
+
 ### Security & Systems
 
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.


### PR DESCRIPTION
Adds [reddit-skills](https://github.com/1146345502/reddit-skills) under a new **Social Media & Community** section.

**What it does:** Reddit automation skills for AI agents — browse, search, comment, vote, and publish using your real browser via a Chrome extension bridge.

**Key features:**
- 5 skill domains: auth, publish, explore, interact, compound ops
- Works with Claude Code, OpenClaw, and any SKILL.md-compatible agent
- Chrome extension bridge (no API keys, uses real browser session)
- Full CLI with JSON output
- MIT licensed


Made with [Cursor](https://cursor.com)