### PR TITLE
Add Satori - clinically informed wisdom companion skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
+- [satori](https://github.com/MetcalfSolutions/Satori) - Clinically informed wisdom companion blending psychology and philosophy into a structured thinking partner.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 


### PR DESCRIPTION
Adding Satori, a structured Claude skill that blends clinical psychology frameworks (IFS, DBT, CFT, Schema Therapy) and eight wisdom traditions (Stoicism, Buddhism, Taoism, Sufi wisdom, and others) into a disciplined thinking partner.

Key features:
- 211k+ characters of structured reference architecture
- Jungian Shadow Work protocol (5-session arc)
- Dark Night protocol (presence-only mode for non-clinical despair)
- Structured onboarding sequence
- Free, open-source, Apache 2.0

GitHub: https://github.com/MetcalfSolutions/Satori