### PR TITLE
Add trading-skills skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [trading-skills](https://github.com/VictorVVedtion/trading-skills) - 68 trading legends as Claude Code skills. Warren Buffett reviews your trades. Jim Simons asks if you backtested. Pre-trade risk gate with ghost warnings from SBF, Do Kwon, 3AC. *By [@VictorVVedtion](https://github.com/VictorVVedtion)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
## What

Adds [trading-skills](https://github.com/VictorVVedtion/trading-skills) — 68 trading legends as Claude Code skills.

## Problem it solves

Traders make emotional, undisciplined decisions. This skill set channels specific trading philosophies (Buffett's value investing, Simons' quant discipline, Livermore's trend following) as Claude Code advisors that activate whenever you discuss trades.

## Target workflow

Any developer or trader using Claude Code who discusses trading decisions, portfolio management, or investment analysis.

## What's included

- 8 legendary master trading advisors (standalone SKILL.md files)
- Pre-trade risk gate (9 checks + 10 ghost warnings from SBF, Do Kwon, 3AC, LTCM, Lehman)
- Tilt detector (revenge trading, FOMO, panic selling prevention)
- One-liner installer, MIT licensed

## Usage example

```bash
# Install all 10 skills
curl -fsSL https://raw.githubusercontent.com/VictorVVedtion/trading-skills/main/install.sh | bash
```

Then in any Claude Code session:
> "Should I buy ETH here?"
> Warren Buffett: "What is ETH worth intrinsically? Would you hold this if the exchange closed for 5 years?"

## Attribution

Extracted from [Vibe Sensei](https://github.com/VictorVVedtion/vibe-sensei) — AI trading terminal with 68 master guardians.

🤖 Generated with [Claude Code](https://claude.com/claude-code)