### PR TITLE
Add Master-skill: Chinese Buddhist master AI teaching personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Creative & Media
 
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [Master-skill](https://github.com/xr843/Master-skill) - Chinese Buddhist master AI teaching personas powered by FoJin. 8 pre-built masters across Chan, Tiantai, Huayan, Pure Land, Yogācāra, Mādhyamaka traditions with CBETA source citations. *By [@xr843](https://github.com/xr843)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
## Summary

- Adds [Master-skill](https://github.com/xr843/Master-skill) to the **Creative & Media** section
- 8 pre-built Chinese Buddhist master AI teaching personas (Chan, Tiantai, Huayan, Pure Land, Yogācāra, Mādhyamaka)
- Powered by [FoJin](https://github.com/xr843/fojin) with CBETA source citations

## Checklist

- [x] Entry follows existing format with project name, link, and description
- [x] Placed alphabetically within the Creative & Media section
- [x] Author attribution included