### PR TITLE
Add president-skill to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [president-skill](https://github.com/realteamprinz/president-skill) - Activatable AI perspectives of US Presidents — thinking operating systems distilled from speeches, executive orders, debates, and biographies. Ships with Trump (45/47) and Lincoln (16); 43 more rolling out through Easter Week 2026. Mental models, decision patterns, expression DNA, 7-language READMEs, first-person role-play with honest boundaries. *By [@realteamprinz](https://github.com/realteamprinz)*
 
 ### Creative & Media
 


### PR DESCRIPTION
Adding **[president-skill](https://github.com/realteamprinz/president-skill)** under **Communication & Writing**.

## What it is

Activatable AI perspectives of US Presidents — thinking operating systems distilled from speeches, executive orders, debates, and biographies into Claude Code skills you can summon with a single phrase in any language.

## Currently shipping

- **01-trump** ⭐ (45 / 47) — complete: 5 mental models, 9 laws, full expression DNA
- **17-lincoln** ✅ (16) — complete: 7 mental models (House Divided, Team of Rivals, Slow Walker, Create the Future, Malice Toward None, Laugh Because I Must Not Cry, Public Sentiment Is Everything)
- 43 more presidents rolling out during **Easter Resurrection Week 2026**

## Why it fits "Communication & Writing"

Each perspective is fundamentally a communication framework — how to think, frame, and speak about a problem through a specific historical operating system. It covers:

- **Negotiation framing** (Trump's Art of the Deal)
- **Crisis communication** (Lincoln's Second Inaugural)
- **Team conflict resolution** (Team of Rivals)
- **Speech / keynote writing** (biblical cadence, parallel structure, parable-as-policy)

## Structure

Each `presidents/[XX-name]/` is self-contained:

```
presidents/17-lincoln/
├── SKILL.md              # 7 mental models + role-play rules
├── meta.json             # narrative angle, core models, trigger words
└── references/research/
    ├── 01-writings.md
    ├── 02-conversations.md
    ├── 03-expression-dna.md
    ├── 04-external-views.md
    ├── 05-decisions.md
    └── 06-timeline.md
```

## Extras

- **7-language READMEs** (English, 中文, Español, Deutsch, 日本語, Русский, Português) with dialogue demos
- Narrative angle declared in frontmatter — no "objective" pretense
- First-person role-play with explicit "what this CANNOT do" section
- MIT license

Thanks for maintaining this list! 🇺🇸