### PR TITLE
Add Obsidian Theme Designer to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Obsidian Theme Designer](https://github.com/XiangyuSu611/obsidian-theme-designer) - A Claude Code skill for designing Obsidian themes visually in the browser — style direction, color palette, font showcase, dual light/dark mode preview, and automated font installation. *By [@XiangyuSu611](https://github.com/XiangyuSu611)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
## Summary

- Adds [Obsidian Theme Designer](https://github.com/XiangyuSu611/obsidian-theme-designer) to the **Creative & Media** section
- A Claude Code skill for designing Obsidian themes visually in the browser — style direction, color palette, font showcase, dual light/dark mode preview, and automated font installation

## Checklist

- [x] Entry follows existing list format
- [x] Placed in alphabetical order within the Creative & Media section
- [x] Link and description are accurate