### PR TITLE
Add zkproofport-mcp to Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [zkproofport-mcp](https://github.com/zkproofport/proofport-ai) - Zero-knowledge identity proofs for AI agents. Prove Coinbase KYC, Country, Google OIDC, Workspace, MS 365 affiliation without revealing personal data. AWS Nitro Enclave TEE proving, x402 USDC on Base.
 
 ### App Automation via Composio
 


### PR DESCRIPTION
Adds **zkproofport-mcp** to the Security & Systems section. ZKProofport is a zero-knowledge proof generation MCP server that lets Claude (and any AI agent) prove identity claims (Coinbase KYC, Country, Google OIDC, Workspace, MS 365) without revealing personal information.

**Use cases for Claude users:**
- Privacy-preserving authentication in Claude-powered apps
- KYC compliance verification without storing user data
- Country residency proofs for regulated services
- Domain-gated communities

**Key features:**
- AWS Nitro Enclave TEE for trusted server-side proving
- Noir circuits (Aztec) for the ZK layer
- x402 USDC payments on Base
- ERC-8004 registered (token #25331)
- Open source MIT

Install: `npm install -g @zkproofport-ai/mcp@latest`

**Production validation**: Reference app [OpenStoa](https://github.com/zkproofport/openstoa) won 1st place at The Synthesis Hackathon (April 2026, 506 projects).