### PR TITLE
Add no-slop prose linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
+- [no-slop](https://github.com/Byk3y/no-slop) - A prose linter that catches AI writing patterns. 13 rules with 40+ banned words, annotated before/after examples, sourced from Wikipedia's Signs of AI Writing. Works with Claude Code, Cursor, and Codex CLI. *By [@Byk3y](https://github.com/Byk3y)*
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 


### PR DESCRIPTION
## Summary

- Adds [no-slop](https://github.com/Byk3y/no-slop) to the **Communication & Writing** section
- A prose linter that catches AI writing patterns before they happen
- 13 rules with 40+ banned words, sourced from [Wikipedia's Signs of AI Writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)
- Includes annotated before/after examples for every rule
- Works with Claude Code, Cursor, and Codex CLI

## Why this belongs here

no-slop is a constraint skill that prevents AI writing patterns during generation rather than fixing them after. It teaches AI agents what to avoid based on Wikipedia's collaboratively maintained, evidence-based list of AI writing tells. It fits the Communication & Writing category as it directly improves the quality of any prose output.