### PR TITLE
Add cera-reasoning-harness to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
+- [cera-reasoning-harness](https://github.com/miketepUR/cera-reasoning-harness) - Reasoning harness for Claude Projects. Preserves logical provenance, strategic posture, and collaborative state across sessions — not just facts. Two-tier architecture with per-session reasoning maps + cross-session CERA Index. Apache 2.0, patent pending. *By [@miketepUR](https://github.com/miketepUR)*
 
 ### Security & Systems
 


### PR DESCRIPTION
Adds [cera-reasoning-harness](https://github.com/miketepUR/cera-reasoning-harness) to the Collaboration & Project Management section.

## About the skill

CERA (Co-Emergent Reasoning Architecture) is a reasoning harness for Claude Projects that preserves logical provenance, strategic posture, and collaborative state across sessions — not just facts. Two-tier architecture: per-session reasoning maps plus a cross-session CERA Index managed by a dedicated integrator.

- **License:** Apache 2.0
- **Repo:** https://github.com/miketepUR/cera-reasoning-harness
- **Paradigm essay:** https://michael124.substack.com/p/the-reasoning-harness-preserving
- **Patent:** provisional filed February 2026

It's free, open source, non-promotional, and provides standalone value (no SaaS/API dependency). Happy to adjust placement or wording per reviewer feedback.