### PR TITLE
Add cclint (Claude Config Linter) to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
+- [cclint](https://github.com/SingggggYee/cclint) - Lints your Claude Code configuration files (CLAUDE.md, .claude/settings.json). Checks for common mistakes and suggests fixes. *By [@SingggggYee](https://github.com/SingggggYee)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*


### PR DESCRIPTION
## Summary

- Adds [cclint](https://github.com/SingggggYee/cclint) to the Development & Code Tools section.
- Lints your Claude Code configuration files (CLAUDE.md, .claude/settings.json). Checks for common mistakes and suggests fixes.