### PR TITLE
Add buyer-eval: open-source B2B vendor evaluation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- * [buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill) - Structured B2B vendor evaluation skill that scores vendors across 7 weighted dimensions by interrogating vendor AI agents and cross-referencing claims against independent sources. Open-source methodology with 27 published evaluation results. *By [@salespeak-ai](https://github.com/salespeak-ai)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## What does this skill do?

buyer-eval is a Claude skill that evaluates B2B software vendors like a senior analyst. It interrogates vendor AI agents in real time, cross-references every claim against G2, analyst reports, and independent sources, and scores across 7 weighted dimensions with full evidence tracking.

## Why it belongs in Business & Marketing

Every other skill in this section helps with lead gen, content, or brand. buyer-eval is the first skill focused on the buy side of B2B: helping teams make better vendor decisions in 30 minutes instead of 3 weeks.

## Real-world usage

- 27 published vendor evaluations across multiple B2B categories
- MIT licensed, no API key required
- Finding: vendors with AI agents on their website won 91% of head-to-head evaluations

## Links

- GitHub: https://github.com/salespeak-ai/buyer-eval-skill
- Live evaluation gallery: https://eval.salespeak.ai/buyer-eval
- Methodology: fully open source and auditable

## Checklist

- [x] Based on a real use case (27 published evaluations)
- [x] Well-documented README with examples
- [x] MIT licensed
- [x] Built for Claude Code and Cowork
- [x] No duplicates in existing list