### PR TITLE
Add claude-report-skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [claude-report-skill](https://github.com/MarcinDudekDev/claude-report-skill) - Generate beautiful, self-contained HTML reports instead of long terminal output. 5 report types (task-completion, research, audit, error-blocker, comparison), zero dependencies, cross-platform.
 
 ### Data & Analysis
 


### PR DESCRIPTION
## Summary

Adds [claude-report-skill](https://github.com/MarcinDudekDev/claude-report-skill) to the Development & Code Tools section.

**Description:** Generate beautiful, self-contained HTML reports instead of long terminal output. 5 report types (task-completion, research, audit, error-blocker, comparison), zero dependencies, cross-platform.

The skill helps Claude Code produce structured HTML output for longer task summaries, research findings, audits, and comparisons — keeping the terminal clean for short answers while delivering rich reports for complex outputs.