### PR TITLE
Add toprank to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [toprank](https://github.com/nowork-studio/toprank) - SEO + Google Ads skills for Claude Code. Audits Search Console data, finds wasted ad spend, rewrites meta tags, generates schema markup, and ships the fixes. *By [@nowork-studio](https://github.com/nowork-studio)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds **toprank** under Business & Marketing.

## What is toprank?

A Claude Code plugin that provides SEO + Google Ads skills. It gives Claude direct access to Google Search Console and Google Ads — auditing traffic, finding wasted ad spend, rewriting meta tags, generating schema markup, and shipping fixes (not just reports).

**9 skills:** ads-audit, ads, ads-copy, seo-analysis, content-writer, keyword-research, meta-tags-optimizer, schema-markup-generator, setup-cms, plus a gemini cross-model review skill.

## Fit

Slotted under Business & Marketing alphabetically (after Lead Research Assistant). toprank fits cleanly alongside Competitive Ads Extractor and Lead Research Assistant — it's a marketing automation skill focused on SEO and paid ads.

## Links
- Source: https://github.com/nowork-studio/toprank
- License: MIT
- Install: \`/plugin marketplace add nowork-studio/toprank\`