### PR TITLE
Add vibe-replay skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable, interactive HTML replays with animated playback, insights, and PR integration. *By [@tuo-lei](https://github.com/tuo-lei)*
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
## Summary

Adds [vibe-replay](https://github.com/tuo-lei/vibe-replay) to the **Development & Code Tools** category.

**vibe-replay** turns AI coding sessions (Claude Code, Cursor) into shareable, interactive HTML replays with animated playback, insights, and PR integration. It generates self-contained HTML files that require zero external requests.

### What problem it solves

- Developers using AI coding tools have no easy way to review, share, or document their AI-assisted development sessions
- Code review context is lost — reviewers see the final diff but not the iterative thought process
- Team knowledge sharing of AI workflows is difficult without a replay format

### Who uses this

- Developers who use Claude Code or Cursor for AI-assisted coding
- Teams that want to share AI coding workflows for learning and review
- Anyone creating PR artifacts that show the development process

### Entry added

```markdown
- [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable, interactive HTML replays with animated playback, insights, and PR integration. *By [@tuo-lei](https://github.com/tuo-lei)*
```

Placed in alphabetical order within the Development & Code Tools section.