### PR TITLE
Add voice-to-instrument-guide to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
+- [voice-to-instrument-guide](https://github.com/stark-ydq/voice-to-instrument-skills) - Expert guidance for converting voice recordings into realistic instrument sounds using AI tools, with recording best practices and instrument-specific tips for piano, guitar, violin, drums, saxophone, flute, cello, trumpet, bass, and clarinet.
 
 ### Productivity & Organization
 


### PR DESCRIPTION
## Summary

Adds [voice-to-instrument-guide](https://github.com/stark-ydq/voice-to-instrument-skills) to the **Creative & Media** section.

## What the skill does

A focused, MIT-licensed Agent Skill that helps AI assistants give high-quality advice on voice-to-instrument AI music production:

- **Recording best practices** — microphone setup, environment, vocal technique, file formats
- **Instrument-specific tips** — tailored guidance for piano, guitar, violin, drums, saxophone, flute, cello, trumpet, bass, and clarinet
- **Prompt engineering** — how to write effective prompts for text-to-music and voice-conversion AI tools
- **Troubleshooting** — diagnosing muddy, robotic, off-rhythm, or clipped outputs

## Why it fits

- Pure markdown (no code execution, no telemetry, no network calls)
- 100% open source under MIT license
- Creative/media-focused — matches other entries in the section
- Follows the existing bullet format with external GitHub link (same as ``imagen`` and ``youtube-transcript``)

Repository: https://github.com/stark-ydq/voice-to-instrument-skills