### PR TITLE
Add tldr skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [tldr](https://github.com/shihyuho/skills/tree/main/skills/tldr) - Produce a concise TL;DR summary of any target including files, PRs, diffs, or URLs.
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
A 4-sentence minimalist skill that produces TL;DR digests of any target (files, directories, PRs, diffs, URLs) in roughly 2 minutes, and suggests follow-up tldr targets when something stands out. Works with any agent that supports skills.