### PR TITLE
Add Immich Photo Manager to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Productivity & Organization
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
-- [Immich Photo Manager](https://github.com/drolosoft/immich-photo-manager) - Manages self-hosted Immich photo libraries through conversation with 11 skills covering natural language search, geographic album curation, duplicate detection via perceptual hashing, library health audits, metadata repair, and interactive HTML galleries. *By [@drolosoft](https://github.com/drolosoft)*
+- [Immich Photo Manager](https://github.com/drolosoft/immich-photo-manager) - Manages self-hosted Immich photo libraries through conversation with 36 MCP tools and 11 skills covering natural language search, geographic album curation, duplicate detection, people and face management, trash cleanup, library health audits, metadata repair, and interactive HTML galleries. *By [@drolosoft](https://github.com/drolosoft)*
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Productivity & Organization
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
+- [Immich Photo Manager](https://github.com/drolosoft/immich-photo-manager) - Manages self-hosted Immich photo libraries through conversation with 11 skills covering natural language search, geographic album curation, duplicate detection via perceptual hashing, library health audits, metadata repair, and interactive HTML galleries. *By [@drolosoft](https://github.com/drolosoft)*
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Productivity & Organization
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
+- [Immich Photo Manager](https://github.com/drolosoft/immich-photo-manager) - 13 skills over an MCP server for self-hosted Immich photo libraries: natural language and OCR search, geographic album curation, duplicate detection, people and faces, metadata repair, library health, PDF album reports; 94 tools, tested live on Immich 2.x and 3.x. *By [@drolosoft](https://github.com/drolosoft)*
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.


### PR DESCRIPTION
Adds Immich Photo Manager to Productivity & Organization.

It is a set of 13 skills for managing a self-hosted Immich photo library from Claude Code, over an MCP server with 94 tools. The skills are the workflows: photo-search, photo-cleanup, duplicate-report, auto-album-curator, album-manager, album-report (PDF), travel-map, metadata-fixer, storage-optimizer, library-health-report, people-report, rotate-photos and timeline-gaps. Each one says which tools it calls, when it asks before writing, and what it hands back (a gallery, a PDF, a table).

What that looks like in use: "find duplicates and keep the best one of each group", "create albums for everywhere I have traveled", "which months have no photos", "make me a PDF of the Sintra trip". The cleanup skills store their verdict as a note on each asset, so a second pass skips what the first one already reviewed.

Every release runs live against real Immich 2.7.5 and 3.1.0 (Docker, all tools over MCP) before it is tagged; the kit is in the repo. MIT, Python 3.10+, install is `claude plugin marketplace add ./` + `claude plugin install immich-photo-manager` from the clone, or `uvx immich-photo-manager` for any MCP client.
