### PR TITLE
Add ChatGPT Plus Guide to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [ChatGPT Plus Guide](https://github.com/xyzm6/chatgpt-plus-guide) - Practical guide for ChatGPT Plus/Pro subscribers — regional pricing, payment methods for blocked regions, account safety checklist. *By [@xyzm6](https://github.com/xyzm6)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
## Summary

- Adds [chatgpt-plus-guide](https://github.com/xyzm6/chatgpt-plus-guide) to the **Productivity & Organization** section
- A practical guide for ChatGPT Plus/Pro subscribers covering regional pricing, payment methods for blocked regions, and account safety checklist

## Test plan

- [ ] Verify the link resolves correctly
- [ ] Confirm entry follows the existing list format

🤖 Generated with [Claude Code](https://claude.com/claude-code)