### PR TITLE
Add fabbo-ai-generator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Creative & Media
 
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [fabbo-ai-generator](https://github.com/fabbo-ai/fabbo-ai-generator) - Generates AI videos and images on [fabbo.ai](https://fabbo.ai) by driving a real Playwright browser session. Supports text-to-video, image-to-video, text-to-image, reference-to-video, and image editing modes. *By [@fabbo-ai](https://github.com/fabbo-ai)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
## What it does

**fabbo-ai-generator** is a Claude Code skill that generates AI videos and images on [fabbo.ai](https://fabbo.ai) by driving a real Playwright browser session with a persistent profile (sign in once, then unattended).

- **Repo:** https://github.com/fabbo-ai/fabbo-ai-generator
- **Modes supported:** text-to-video, image-to-video, text-to-image, reference-to-video, frame-to-video, image editing
- **Output:** returns both the remote URL and a local file path as a single JSON payload

## Real-world use case

When a user asks Claude to "make a video of X" or "animate this photo," this skill generates the result on fabbo.ai (which runs Veo, Sora, Kling, Wan, Luma, Runway, Midjourney, Nano Banana) and downloads it locally — no public API needed, respects the user's credit balance.

## Category

Added to **Creative & Media** — alphabetically between `Canvas Design` and `imagen`.

Single-line addition to `README.md`, no other changes.