### PR TITLE
Add SuperSEO Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [SuperSEO Skills](https://github.com/inhouseseo/superseo-skills) - 11 SEO skills covering page audits, content briefs, article writing, E-E-A-T audits, and link building, where each skill fetches pages and reads top-ranking competitors directly instead of requiring keyword exports. *By [@inhouseseo](https://github.com/inhouseseo)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [SuperSEO Skills](https://github.com/inhouseseo/superseo-skills) to the **Business & Marketing** category.

## What problem it solves

Most "Claude SEO" workflows ask you to paste in keyword data, traffic exports, crawl reports, and backlink profiles — then the prompt does spreadsheet-style analysis on whatever you fed it. SuperSEO Skills flips that: each skill fetches the page and reads the top-ranking competitors itself, so you give it a URL or a keyword and it does the work.

## Who uses this workflow

In-house SEOs, content marketers, and agency teams who want to run page audits, write briefs, draft articles, score E-E-A-T, find semantic gaps, and plan link building inside Claude — without first preparing data exports.

## What's in the bundle

11 skills, all with valid SKILL.md + YAML frontmatter:
- page-audit
- content-brief
- write-content
- improve-content
- keyword-deep-dive
- semantic-gap-analysis
- eeat-audit
- topic-cluster-planning
- featured-snippet-optimizer
- linkbuilding
- expert-interview

Apache 2.0. Plugin marketplace install (`/plugin marketplace add inhouseseo/superseo-skills`). Tested in Claude Code, Claude Desktop, Claude.ai web Skills tab, and Cursor.

## Example use

User: "Run a page audit on https://example.com/blog/seo-tips."

The agent fetches the page, identifies the primary keyword, runs a Google search, reads the top 3 ranking competitors, and returns a 7-dimension audit with specific fixes.

## Attribution

Built by InhouseSEO ([github.com/inhouseseo](https://github.com/inhouseseo)). Methodology drawn from public work by Koray Tuğberk GÜBÜR (semantic networks), Kyle Roof (POP test priorities), Lily Ray (E-E-A-T), and the Information Gain patent research.