### PR TITLE
Add llm-wiki skill under Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) - Build and maintain an LLM-curated personal knowledge base in any project (Karpathy's LLM Wiki pattern). Ingest sources once into persistent, cross-referenced markdown pages; subsequent queries read the pre-synthesized wiki. Skill + 5 `/wiki:*` commands with sharded indexes, BM25 search, and a structural lint script — designed to scale to thousands of pages.
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adds [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) under **Productivity & Organization**, next to tapestry which has a similar knowledge-network framing.

## What it does

An implementation of [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) as a Claude Code plugin + skill. Ingested sources (papers, articles, transcripts, PDFs, notes) get compiled once into persistent, structured markdown pages; subsequent queries read the pre-synthesized wiki rather than re-chunking raw sources, so knowledge compounds over time.

## Surface area

- `llm-wiki` skill with progressive-disclosure references (architecture, ingest, query, lint, scaling)
- 5 slash commands: `/wiki:init`, `/wiki:ingest`, `/wiki:query`, `/wiki:lint`, `/wiki:stats`
- 4 bundled stdlib-only Python scripts: init, BM25 search with frontmatter filters, structural lint, size/shape stats
- Installable via `/plugin marketplace add praneybehl/llm-wiki-plugin` or `npx skills add praneybehl/llm-wiki-plugin`

Solves a real problem (scalable LLM-maintained research notes that avoid RAG's "nothing accumulates" failure mode). Tested locally with `claude plugin validate` and all five commands exercised.