### PR TITLE
Refactor project into task-first multi-tool diagnosis architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [skill-doctor](https://github.com/LpcPaul/skill-doctor) - AI agent tool-path ER — diagnoses failures, conflicts, and mis-selection across skills, MCPs, plugins, and built-in tools. *By [@LpcPaul](https://github.com/LpcPaul)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
## What changed

This PR rewrites the project from a skill-first troubleshooting library into a
task-first diagnosis and navigation system.

### Major changes
- Rename project direction to Skill-Agent-MCP Docter
- Introduce local self-diagnosis intake before retrieval
- Reorganize knowledge architecture around:
  - task
  - journey stage
  - problem family
  - next action
  - candidate tools/cases
- Expand supported tool types:
  - skill
  - mcp
  - plugin
  - builtin
  - agent
  - workflow
  - hook
- Rewrite README, SKILL.md, contributing docs, taxonomy, schema, issue template, and docs

### Notes
- Old cases are not migrated in this PR
- Scripts are not yet rewritten in this PR
- This PR focuses on information architecture, documentation, and schema redesign
