### PR TITLE
Add Master-skill skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Master-skill](https://github.com/xr843/Master-skill) - Chinese Buddhist master teaching personas (Xuanzang, Kumārajīva, Huineng, Zhiyi, Fazang, Yinguang, Ouyi, Xuyun) grounded in real CBETA canonical texts — chat with a patriarch instead of picking a book. *By [@xr843](https://github.com/xr843)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
## Add Master-skill skill

**What it does**: Eight pre-built Chinese Buddhist master personas (Xuanzang, Kumārajīva, Huineng, Zhiyi, Fazang, Yinguang, Ouyi, Xuyun) that teach in-voice while staying grounded in real CBETA canonical citations. Ships as a Claude Code / Cursor / Codex / OpenCode / Gemini CLI plugin, and is also runnable in-browser at https://fojin.app/chat (左下角「法师模式」).

**Problem solved**: Newcomers to Chinese Buddhism face a "which sutra first?" wall — 《瑜伽师地论》 is 100 juan, 《印光文钞》 is three volumes, 《坛经》 has a dozen recensions. Master-skill lowers that bar to "pick a patriarch and ask a question." Every answer cites real canonical text via a HARD-GATE: **no CBETA hit = no answer**. Offline sutra fragments and per-master fidelity tests ship in the repo, so the grounding claim is verifiable, not aspirational.

**Who uses it**: Students of Chinese Mahāyāna, translators, dharma teachers, and anyone curious about Huayan / Chan / Pure Land / Tiantai / Yogācāra / Madhyamaka traditions. Also useful for digital-humanities researchers evaluating RAG fidelity on classical Chinese corpora.

**Status**: v0.3.0, MIT, 204 stars / 44 forks, ethics + contributing + security policies in place, CI fidelity smoke on every PR.

**Example**:

> "How does 六祖慧能 explain 顿悟?"
> → Huineng persona replies in-voice, cites 《坛经·般若品》 (T48n2008), and refuses to fabricate passages not present in CBETA.

**Attribution**: Powered by [FoJin](https://fojin.app), an open-source Buddhist digital-humanities platform (503 data sources, 678K+ semantic vectors) by the same author.

**Alphabetical placement**: inserted in `### Creative & Media` between "Image Enhancer" (I) and "Slack GIF Creator" (S). One-line entry only, no other files touched.