### PR TITLE
Add OpenAccountants skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [OpenAccountants](https://github.com/openaccountants/openaccountants) - Classifies bank transactions by VAT category across 134 countries and prepares tax return working papers from bank statements. *By [@openaccountants](https://github.com/openaccountants)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## What problem does this solve?

Developers working in the tax ecosystem or managing their own VAT obligations currently have no skill for transaction classification or tax return preparation. OpenAccountants fills this gap with country-specific tax computation skills.

## Who uses it?

- Developers handling their own VAT obligations
- Developers building within the tax/accounting ecosystem
- Accountants using Claude to process client bank statements

## What it does

[OpenAccountants](https://github.com/openaccountants/openaccountants) is an open-source library of 371 tax computation skills covering 134 countries. Users upload country-specific markdown files alongside bank statements — the skills classify transactions by VAT category, apply local tax rules, and produce working papers ready for accountant review.

Coverage: 8 countries with the full guided experience (VAT + income tax + SSC + guided intake), 27 with multi-skill coverage, 99 with VAT/GST classification.

Platform-agnostic — works with Claude, ChatGPT, or any LLM that accepts markdown files.

## Changes

Single README entry added to **Business & Marketing** section in alphabetical order.