### PR TITLE
Add CLIRank MCP Server to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
+- [CLIRank MCP Server](https://clirank.dev) - MCP server giving Claude Code access to 387 APIs scored on agent-friendliness. Install via `npm install clirank-mcp-server`.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*
 - [FFUF Web Fuzzing](https://github.com/jthack/ffuf_claude_skill) - Integrates the ffuf web fuzzer so Claude can run fuzzing tasks and analyze results for vulnerabilities. *By [@jthack](https://github.com/jthack)*
 - [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.


### PR DESCRIPTION
## Summary
- Adds [CLIRank MCP Server](https://clirank.dev) to the Development & Code Tools section
- CLIRank is an MCP server that gives Claude Code access to 387 APIs scored on agent-friendliness
- Available via npm: `npm install clirank-mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)