### PR TITLE
Add idea-os to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [idea-os](https://github.com/Slashworks-biz/idea-os) - Five-phase pipeline that turns a raw product idea into four linked files: clarifying questions, deep research (TAM/SAM/SOM, SWOT, JTBD, competitor map, distribution), a PRD with non-goals + metrics, and a phased execution plan with mermaid user journey, stack matrix, and kill criteria per phase.
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.


### PR DESCRIPTION
### idea-os
**Category:** Collaboration & Project Management
**Repo:** https://github.com/Slashworks-biz/idea-os
**License:** MIT

Five-phase pipeline (triage → clarify → research → PRD → plan) that writes four linked files. Covers TAM/SAM/SOM (top-down + bottom-up), SWOT, JTBD, competitor positioning, distribution first-100-users playbook, platform/stack recommendations, and a mermaid user-journey diagram.

Adapts depth to idea complexity (T1/T2/T3) and builder sophistication (S1/S2/S3) so a first-time builder isn't drowning in jargon and a founder gets full rigor. Works across Claude.ai, Claude Code, and the API.

**Checks:**
- [x] Addresses a real use case (pre-build idea validation — non-dev founders / PMs)
- [x] SKILL.md with YAML frontmatter (name + description)
- [x] Lowercase-hyphen folder name
- [x] Tested end-to-end (`examples/example-notion-for-dog-trainers.md` in upstream, 590 lines; `examples/jee-prep/` real dog-food run, 778 lines)
- [x] Works across Claude.ai, Claude Code, and Claude API