### PR TITLE
Add Imprint: portable AI collaboration profile (1 skill → 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
+- [Imprint](https://github.com/ilang-ai/Imprint) - Your habits, imprinted on AI. One skill replaces eleven: memory, compression, onboarding, code review, debugging, planning, progress tracking, testing, git workflow, SEO, and copywriting. Creates a portable profile across 19 agents.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.


### PR DESCRIPTION
Adds Imprint, a single skill that replaces 11 specialized skills by creating a portable user profile.

- MIT licensed, no external API calls, no SaaS dependency
- Works across Claude Code, Codex, Cursor, Copilot, Gemini, Windsurf, Trae, Cline, Roo + 10 more
- Profile stored as plain text under 500 tokens
- Live on skills.sh, VS Code Marketplace, Open VSX, Gemini CLI Gallery
- GitHub: https://github.com/ilang-ai/Imprint