### PR TITLE
Add claude-skills and swe-skills under Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [claude-skills](https://github.com/ckorhonen/claude-skills) - A broader collection of 45+ Claude Code skills spanning engineering strategy, code hygiene, design, and workflow automation. Hub at cdd.dev/skills with pack pages and example prompts. *By [@ckorhonen](https://github.com/ckorhonen)*
+- [swe-skills](https://github.com/ckorhonen/swe-skills) - 15 strategic engineering skills for Claude Code: PR risk review, test gap hunting, performance profiling, ownership mapping, architectural auditing. *By [@ckorhonen](https://github.com/ckorhonen)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Two community skill packs under `### Development & Code Tools`:

### claude-skills
A broader collection of 45+ Claude Code skills spanning engineering strategy, code hygiene, design, marketing, AI, security, and infrastructure. ~4 months old, MIT licensed. Active install usage via skills.sh (~625 installs at submission). Hub: https://cdd.dev/skills/.

### swe-skills
15 skills under the `swe:` namespace for engineering analysis and judgment — PR risk review, repo introspection, performance/security audits, incident follow-up, ownership maps, refactor opportunities, test gap hunts. MIT licensed. Hub: https://cdd.dev/skills/swe/.

Both follow the Agent Skills standard and include `SKILL.md` frontmatter plus a root `.claude-plugin/plugin.json` manifest. Install:

```sh
npx skills add ckorhonen/claude-skills
npx skills add ckorhonen/swe-skills
```

Entries follow the existing format in the section (external link, brief description, `*By [@author]*` attribution).

A companion pack, `ckorhonen/hone-skills` (8 scheduled code-hygiene skills), was just renamed/published this week and will be worth a follow-up PR once it matures.