### PR TITLE
Add brandvoice skill to Business & Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [brandvoice](https://github.com/jaimeschwarz/brandvoice) - A governed brand voice skill built on the Brand Therapy discipline. Eight stages (Purpose through Personification), governance framework, birth ritual, and child-skill generation. *By [@jaimeschwarz](https://github.com/jaimeschwarz)*
-- - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
+- [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Business & Marketing
 
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
-- [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
+- [brandvoice](https://github.com/jaimeschwarz/brandvoice) - A governed brand voice skill built on the Brand Therapy discipline. Eight stages (Purpose through Personification), governance framework, birth ritual, and child-skill generation. *By [@jaimeschwarz](https://github.com/jaimeschwarz)*
+- - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.


### PR DESCRIPTION
Adds `brandvoice` to the Business & Marketing section — a free Claude skill that walks users through the Brand Therapy discipline to build a governed brand voice. Eight stages (Purpose through Personification), governance framework (hard guardrails, soft guardrails, escalation protocol), birth ritual, and the skill generates a second brand-specific skill file the user installs and stewards.

Placed alphabetically between "Brand Guidelines" and "Competitive Ads Extractor". Formatted to match the house style for external entries (italic *By* attribution with linked GitHub handle).

**Repo:** https://github.com/jaimeschwarz/brandvoice
**Author:** Jaime Schwarz — https://brandtherapy.coach
**License:** CC BY-NC 4.0