### PR TITLE
Add claude-ecom skill to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Data & Analysis
 
+- [claude-ecom](https://github.com/takechanman1228/claude-ecom) - Ecommerce business review for D2C stores: turns order CSVs into structured monthly reviews with multi-horizon KPI decomposition (30d/90d/365d), ~30 health checks across revenue/customer/product, RFM cohorts, and a prioritized action plan with revenue impact estimates. *By [@takechanman1228](https://github.com/takechanman1228)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
Hi — adding `claude-ecom` to the **Data & Analysis** section, as a peer to `CSV Data Summarizer`.

**What it does**: An ecommerce business-review skill for D2C stores. Given an order CSV, it produces a structured monthly business review:
- Multi-horizon KPI decomposition (30d / 90d / 365d)
- ~30 automated health checks across revenue / customer / product
- RFM cohort segmentation (Champions / Loyal / At-Risk / Lost)
- Prioritized action plan with estimated revenue impact per finding

Hybrid architecture: Python backend handles deterministic KPI computation, Claude handles narrative and recommendations.

**Why Data & Analysis over E-commerce & Payments**: The E-commerce & Payments subsection groups Shopify / Square / Stripe *automation* skills (CRUD via Rube MCP). `claude-ecom` is an *analytics* skill that reads CSVs and writes reviews — no external API calls, no automation. It sits more naturally next to `CSV Data Summarizer`. Happy to relocate if you'd prefer it elsewhere.

**Compliance**:
- Real-world use case: monthly D2C business reviews, replacing manual KPI/cohort analysis for store operators
- Safety: read-only (pandas analysis of CSVs, no destructive ops)
- Attribution: included inline (`*By [@takechanman1228](https://github.com/takechanman1228)*`)
- License: MIT
- Latest release: v0.1.3
- SKILL.md with YAML frontmatter at `skills/ecom/SKILL.md`
- Active: yes, recent commits

Alphabetical within section (`claude-ecom` → `CSV Data Summarizer` → `deep-research` → `postgres` → `root-cause-tracing`).