### PR TITLE
Add vara-skills to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [vara-skills](https://github.com/gear-foundation/vara-skills) - 21 skills for shipping Rust smart contracts on Vara Network with the Gear/Sails framework. Full pipeline: spec → Sails impl → gtest → on-chain deploy via `vara-wallet`. Covers IDL codegen, React frontend, and event-driven indexer. *By [@gear-foundation](https://github.com/gear-foundation)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds [vara-skills](https://github.com/gear-foundation/vara-skills) to the Development & Code Tools section.

**What it is:** 21 skills teaching Claude how to build and ship Rust smart contracts on Vara Network with the Gear/Sails framework. Covers spec → architecture → Rust implementation → IDL/client codegen → deterministic gtest → React frontend → event-driven indexer → on-chain deploy via `vara-wallet`.

**Why it fits here:** Similar scope to `aws-skills` (AWS development patterns), `move-code-quality-skill` (Move language quality), and `iOS Simulator` (iOS testing workflow) — domain-specific dev tooling that teaches an agent a specific framework end-to-end.

Works across Claude.ai, Claude Code, Codex, and OpenClaw. Apache-2.0-compatible (MIT licensed). Published by Gear Foundation.