### PR TITLE
Add unslop to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [unslop](https://github.com/MohamedAbdallah-14/unslop) - Humanizes Claude's output by stripping AI stylometric tells (sycophancy openers, stock vocab, hedging stacks, tricolon padding, em-dash pileups) while preserving code, URLs, and headings byte-exact. Six intensity modes (`subtle` / `balanced` / `full` / `voice-match` / `anti-detector`) toggle via `/unslop`. Blind LLM-judge humanness preference 21/21 on a 7-fixture suite. Works across Claude Code, Cursor, Windsurf, Cline, Gemini CLI, and Codex through a single synced plugin. *By [@MohamedAbdallah-14](https://github.com/MohamedAbdallah-14)*
 
 ### Creative & Media
 


### PR DESCRIPTION
Adds [unslop](https://github.com/MohamedAbdallah-14/unslop) to the **Communication & Writing** section in alphabetical order (after "Twitter Algorithm Optimizer").

**What it does:** Claude Code plugin + CLI that humanizes AI output by stripping the stylometric residue from RLHF — sycophancy openers, stock vocab, hedging stacks, tricolon padding, em-dash pileups — while preserving code blocks, URLs, headings, and YAML frontmatter byte-exact. Six intensity modes (`subtle` / `balanced` / `full` / `voice-match` / `anti-detector`) toggle with `/unslop`.

**Why it fits this list:** It's a real Claude Code skill (installable via `/plugin marketplace add MohamedAbdallah-14/unslop` + `/plugin install unslop`), not a general-purpose tool masquerading as one. The skill injects activation rules into Claude's context at SessionStart, re-emits reinforcement banners at turns 8/16/24 to beat persona drift (per RMTBench/HorizonBench findings), and tracks the active mode in `~/.claude/.unslop-mode`.

**Measured results:** Blind LLM-judge humanness preference 21/21 (100%) on a 7-fixture suite, 3 independent runs per fixture, randomized A/B sides. 89.1% AI-ism reduction vs baseline. Reproducible with `python3 evals/perceived_humanness.py --runs 3`.

**Use case:** Cover letters, personal statements, LinkedIn posts, blog posts, marketing copy — anywhere a human reader judges you on how the text sounds. Explicitly NOT for code, legal text, medical advice, or runbooks (see the "When it actually matters" section in the README).

MIT-licensed. Six-assistant support via a single synced plugin (Claude Code, Cursor, Windsurf, Cline, Gemini CLI, OpenAI Codex).

Repo: https://github.com/MohamedAbdallah-14/unslop
