### PR TITLE
Add linear-cli skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [linear-cli](./linear-cli/) - Query your Linear work queue, pick up tasks, drop progress comments, and close issues with proof of completion. Wraps the linear-cli binary (single-file Python, zero dependencies). *By [@phnx-labs](https://github.com/phnx-labs)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.

--- a/linear-cli/SKILL.md
+++ b/linear-cli/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: linear
+description: Interact with Linear via the linear-cli. Query your work queue, pick up tasks, report progress, close issues with proof.
+---
+
+# linear-cli skill
+
+You have access to the `linear` CLI — a Linear task manager built for AI agents. Config lives at `~/.linear-cli/config.json`. Team and API key are pre-configured via `linear setup`.
+
+## When to Use This Skill
+
+- User asks what tasks are assigned to them
+- User wants to pick up, update, or close a Linear issue
+- User wants to drop a progress comment on an issue
+- User wants to create a new issue
+- User wants to view team or cycle boards
+
+## Prerequisites
+
+### Install linear-cli
+
+```bash
+curl -sSL https://raw.githubusercontent.com/phnx-labs/linear-cli/main/install.sh | bash
+```
+
+### Configure
+
+```bash
+linear setup
+```
+
+Provide your Linear API key (Full access) and team identifier when prompted.
+
+## Core workflow
+
+```
+linear tasks                        # your assigned queue in the active cycle
+linear tasks --board                # whole team board, grouped by assignee/agent
+linear tasks ANT-42                  # detail view for one issue
+linear update ANT-42 --pickup        # move to In Progress
+linear update ANT-42 --comment "..."  # drop a progress note
+linear update ANT-42 --done --proof <url-or-file> --proof "deployed at X"
+linear create "Title" --label foo --priority high --description "..."
+linear cycles                       # list cycles
+```
+
+## Filters
+
+```
+linear tasks --status todo         # backlog | todo | progress | done | open
+linear tasks --label security      # by any label
+linear tasks --cycle next          # active | next
+linear tasks --json                # machine-readable
+linear tasks --all                 # ignore default agent filter
+```
+
+## Output mode for agent use
+
+Always prefer `--json` when parsing output programmatically:
+
+```
+linear tasks --json | jq '.issues[] | {id: .identifier, title, state: .state.name}'
+```
+
+## Assignee-as-queue model
+
+- `linear tasks` without flags returns issues assigned to the identity that owns the API key.
+- If `cfg.agent` is set at setup time (e.g. `claude`, `codex`), `linear tasks` additionally filters by a matching label — the "agent lane" pattern. Override with `--all`.
+- `linear update <id> --pickup` = claim the task. Follow with `--done --proof` when shipped.
+
+## Proof-of-completion
+
+`--proof` is repeatable and accepts:
+- File paths (uploaded to Linear as attachments)
+- URLs (rendered as links)
+- Plain text (appended as a line)
+
+Use it on `update --done` so reviewers see evidence without digging.
+
+## Common mistakes
+
+- Don't call the Linear GraphQL API directly — the CLI handles auth, uploads, cycle math, and state resolution.
+- Don't hand-edit `~/.linear-cli/config.json` — use `linear setup` to re-configure.
+- If you see `Error: Invalid scope: read required`, the API key was created write-only. Regenerate it with Full access at linear.app/settings/account/security.


### PR DESCRIPTION
## What this adds

A new skill for interacting with Linear via the [linear-cli](https://github.com/phnx-labs/linear-cli) binary.

## The skill

- **Name**: `linear`
- **Folder**: `linear-cli/SKILL.md`
- **Category**: Collaboration & Project Management

## What problem it solves

AI agents working on codebases need to pick up tasks from Linear, mark them in-progress, drop progress comments, and close issues with proof of completion — all without switching context to a browser. This skill wraps the `linear` binary which handles auth, uploads, cycle math, and state resolution so agents can call it directly.

## Who uses this workflow

Coding agents (Claude Code, Codex, Gemini) running inside a terminal alongside their codebase. The `--pickup` / `--done --proof` workflow is specifically designed for agent-driven task completion.

## Installation

```bash
curl -sSL https://raw.githubusercontent.com/phnx-labs/linear-cli/main/install.sh | bash
linear setup
```

## Upstream

- Repository: https://github.com/phnx-labs/linear-cli
- License: MIT
- Version: v0.1.1
- Single-file Python CLI, zero dependencies