### PR TITLE
Add EnigmAgent MCP skill to Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 ### Security & Systems
 
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
+- [EnigmAgent](https://github.com/Agnuxo1/enigmagent-mcp) - Local encrypted vault MCP server for Claude. AES-256-GCM + Argon2id, zero cloud, zero telemetry. Run with `npx enigmagent-mcp`. *By [@Agnuxo1](https://github.com/Agnuxo1)*
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.


### PR DESCRIPTION
## What

Adds [**EnigmAgent**](https://github.com/Agnuxo1/enigmagent-mcp) to the **Security & Systems** category — a local encrypted vault MCP server for Claude.

## Real-world problem it solves

Developers and researchers using Claude Code routinely need to handle secrets, API keys, recovery phrases, and confidential notes. Pasting them into prompts leaks them into chat logs, browser history, and SaaS databases. EnigmAgent gives Claude a **local-only** vault it can read/write from via MCP — nothing ever leaves the machine.

## Highlights

- **AES-256-GCM** authenticated encryption with **Argon2id** key derivation (OWASP-recommended params)
- Zero cloud, zero telemetry — vault file lives in `~/.enigmagent/` or user-specified path
- One-line install: `npx enigmagent-mcp`
- MIT license, npm package: [`enigmagent-mcp`](https://www.npmjs.com/package/enigmagent-mcp)
- Listed on Glama with a **Security A** rating

## Who uses it

Solo devs, security-conscious researchers, and anyone running Claude Code on local workstations who refuses to pipe secrets through cloud password managers.

## Diff

A single one-line addition to the **Security & Systems** section of `README.md`, alphabetical order, format matched to existing entries.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>