### PR TITLE
Add VirtualSMS — real-SIM SMS verification skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 
 ### Communication & Writing
+- [virtualsms-skill](https://github.com/virtualsms-io/claude-skill-sms-verification) - Lets Claude request real-SIM phone numbers for SMS verification across 145+ countries and 2000+ services. Hosted MCP at mcp.virtualsms.io (zero install) or local stdio via npm. *By [@virtualsms-io](https://github.com/virtualsms-io)*
 
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.


### PR DESCRIPTION
## Summary

Adds VirtualSMS to **Communication & Writing** — a Claude Skill that lets agents request real-SIM phone numbers for SMS verification across 2000+ services (Tinder, WhatsApp, Discord, Telegram, OnlyFans, etc.) and 145+ countries.

## Why this fits

- Production MCP server (`virtualsms-mcp` on npm, v1.2.0)
- Two transports: hosted StreamableHTTP at `https://mcp.virtualsms.io/mcp` (zero install) and local stdio via npm
- 18 tools across discovery, account, and order management
- Real physical SIMs (not VoIP/eSIM) — survives carrier_lookup checks where eSIM-based competitors fail
- Listed on the official MCP registry: `io.github.virtualsms-io/sms`

## Repo

https://github.com/virtualsms-io/claude-skill-sms-verification

Includes `SKILL.md` with trigger phrases, full tool reference, and a quickstart for Claude Desktop / Claude Code.
