### PR TITLE
Add great_cto: Claude Code SDLC plugin with 7 subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
+- [great_cto](https://github.com/avelikiy/great_cto) - Claude Code plugin: 7 specialised subagents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor) orchestrating a full SDLC pipeline — architecture, TDD, 12-angle code review, QA, security audit, deploy. 11 project archetypes auto-detected, 13 compliance frameworks (GDPR/PCI-DSS/HIPAA/SOC2/ISO 27001), self-improving knowledge layer that learns from every incident. *By [@avelikiy](https://github.com/avelikiy)*
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis


### PR DESCRIPTION
## What is great_cto?

A [Claude Code plugin](https://github.com/avelikiy/great_cto) that orchestrates a full SDLC pipeline through 7 specialised subagents.

**Real use case:** Solo founders and small teams (up to 50 engineers) lose weeks per feature on the same questions — *Is the architecture right? Did we miss a security issue? Will this break in production?* great_cto runs the architect → developer → QA → security → DevOps loop with 2 explicit approval gates per feature.

## What it includes

- **7 Claude Code subagents** with tuned models per role (tech-lead on Opus, senior-dev on Sonnet, qa-engineer on Haiku, etc.)
- **16 slash commands** covering the full SDLC lifecycle (`/start`, `/audit`, `/review`, `/sec`, `/inbox`, `/digest`, `/poc`, `/crystallize`, …)
- **11 project archetypes** auto-detected from the repo (web-service, agent-product, commerce, regulated, web3, iot-embedded, etc.)
- **13 compliance frameworks** (GDPR, PCI-DSS, HIPAA, SOC2, ISO 27001, FedRAMP, …) with archetype-aware security tier
- **12-angle code review** running each angle as a separate pass with its own rubric
- **Self-improving knowledge layer** — every P0 incident triggers structured Knowledge Extraction; \`/crystallize\` promotes patterns to global library, surfaced in every agent's Step 0 next session
- **MCP-native** — Grafana monitoring (l3-support), LLM router (Kimi fallback for cost optimization)

## Why it fits "Development & Code Tools"

It is a development/code tool that operates across the full software lifecycle, not just one phase. The plugin is installable directly via \`npx great-cto init\`.

## Installation

\`\`\`bash
npx great-cto init
\`\`\`

Then in Claude Code: \`/start "describe what you're building"\`

## Links

- Repo: https://github.com/avelikiy/great_cto
- npm: https://www.npmjs.com/package/great-cto