### PR TITLE
Add Master Claude for Legal skill pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
+- [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 
 ### Development & Code Tools
 


### PR DESCRIPTION
Adds [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) under **Document Processing**.

A community skill pack for legal teams using Claude. Includes:

- **5 starter skills** — NDA triage, multi-party version diff, meeting brief, citation verifier, status synthesis (Friday-newsletter pattern)
- **10 reference docs** — privilege configuration (4-layer framework), four-pillar architecture, vocabulary glossary, MCP hardening, citation verification workflow, long-document patterns, practice-area patterns (transactional / litigation / IP / regulatory / in-house), 4-hour setup checklist, skill-authoring guide, anti-patterns
- **3 firm templates** — AI policy, client data explainer, vendor security questionnaire
- **Public dataset** — full transcript and structured 51-question dataset from the April 2026 Anthropic Claude for Legal Teams webinar

Released MIT in April 2026. Composes with the Anthropic legal plugin rather than replacing it.

Placement: Document Processing seemed the closest fit since most legal-AI work is doc-heavy (NDA review, contract redlines, version comparison, citation verification). Happy to move to Productivity & Organization or to a new "Legal" subsection if you'd prefer.

I maintain the linked repository.