### PR TITLE
Add Brand Build Skills (59-skill library covering the full website lifecycle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 
 ### Business & Marketing
 
+- [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.


### PR DESCRIPTION
Adds [rampstackco/claude-skills](https://github.com/rampstackco/claude-skills), a 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research.

## Highlights

- 59 skills across 13 categories, every one with a complete `SKILL.md` and at least one reference file
- 95 reference files total (templates, checklists, decision matrices, worked examples)
- Uniform structure across every skill so they compose cleanly
- Stack-agnostic (Next.js, WordPress, Shopify, Webflow, plain HTML, etc.)
- Includes an Ahrefs MCP-powered SEO audit suite (7 dedicated audit skills)
- Includes a meta-skill (`skill-creation-walkthrough`) that teaches users to write their own skills using the same conventions
- CI lint validates structure on every PR (frontmatter, references, em dashes, broken cross-skill refs)

MIT licensed. Released as v1.1.0 with full release notes.

Placed under Business & Marketing as the dominant category, alphabetically positioned before Brand Guidelines.