### PR TITLE
docs: add AgentSkillsHub to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 
 ### Community Resources
 
+- [AgentSkillsHub](https://agentskillshub.top) - Searchable directory of 67,000+ Claude Skills + MCP servers + Codex Skills + agent tools indexed from GitHub, quality-scored on 10 dimensions, refreshed every 8 hours. Free + open source ([source](https://github.com/zhuyansen/agent-skills-hub))
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 
 ### Community Resources
 
-- [AgentSkillsHub](https://agentskillshub.top) - Searchable directory of 67,000+ Claude Skills + MCP servers + Codex Skills + agent tools indexed from GitHub, quality-scored on 10 dimensions, refreshed every 8 hours. Free + open source ([source](https://github.com/zhuyansen/agent-skills-hub))
+- [AgentSkillsHub](https://agentskillshub.top) - Security-graded directory of 130,000+ Claude Skills + MCP servers indexed from GitHub — every entry carries a SAFE/CAUTION/UNSAFE grade and a quality score, refreshed every 8 hours. Free + open source ([source](https://github.com/zhuyansen/agent-skills-hub))
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills


### PR DESCRIPTION
## Summary
Adds [AgentSkillsHub](https://agentskillshub.top), a security-graded directory of 130,000+ Claude Skills and MCP servers indexed from GitHub.

## Why it fits the Community Resources section
Complements the existing entries (Anthropic Skills Repository, Claude Community, Skills Marketplace) by providing much wider open-source coverage:

- **Indexes 130,000+ projects** continuously (vs the curated awesome-* approach)
- **Security grade per entry** — SAFE/CAUTION/UNSAFE, so users can vet a skill before installing; full graded dataset is open (CC-BY-4.0 on [Hugging Face](https://huggingface.co/datasets/jasonzhuyansen/agent-skills-security-grades))
- **Quality-scored on 10 weighted dimensions** — methodology open-source at [quality_analyzer.py](https://github.com/zhuyansen/agent-skills-hub/blob/main/backend/app/services/quality_analyzer.py)
- **Refreshed every 8 hours** via GitHub Actions
- **Free + open source** (MIT code) — no signup, no paywall

Inserted alphabetically (A before Anthropic). Happy to adjust placement / wording per maintainer preference.