### PR TITLE
Add solo-skills under Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
+- [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.


### PR DESCRIPTION
Adding [solo-skills](https://github.com/rockscy/solo-skills) — a bilingual Claude Code skills pack for solo founders and indie developers.

### What it is

Seven Claude Code skills shaped for one specific situation: the developer shipping a product alone, with no team to delegate to. Skills cover:

- `ship-decision` — regret-minimizing call between 2-3 product options
- `launch-tweet` — draft launch tweet/thread, no marketing hype
- `changelog-from-commits` — turn raw git log into user-facing release notes
- `bug-from-user` — convert a confusing customer email into a reproducible bug report
- `standup-solo` — 5-minute personal standup
- `email-customer` — polite-but-firm reply to refunds, scope creep, complaints
- `postmortem-solo` — ≤350-word blame-free postmortem template

### Why it fits this list

- Solves a real, recurring use case for solo developers (most existing productivity skills assume team workflows).
- Bilingual: every skill has parallel English and Chinese (中文) sections in `SKILL.md`.
- Distinguishing feature: every skill has a mandatory "When NOT to use" section + a fixed output format + a worked input/output example. No vague "be helpful" output.
- One-line install: `curl -fsSL .../install.sh | bash`.
- MIT licensed.

### Where I added it

Under **Productivity & Organization**, alphabetically between "Raffle Winner Picker" and "Tailored Resume Generator".

Repo: https://github.com/rockscy/solo-skills