### PR TITLE
Add swiftui-design-skill to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
+- [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
## What does this PR add?

Adds [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) to the Creative & Media section.

## What it does

SwiftUI frontend design skill that helps AI agents create beautiful, distinctive iOS/macOS interfaces. Features:
- 6 Anti-AI-Slop Rules — eliminate generic patterns
- Design Direction Advisor — 5 schools × 20 philosophies
- Brand Asset Protocol — systematic brand integration
- 5-Dimension Design Review — structured quality assessment
- Layout Patterns, Typography & Color, Swift Extensions

## Install

```bash
npx skills add wholiver/swiftui-design-skill
```

## Platform Support

Claude Code, Cursor, Codex, OpenCode, Amp, Gemini CLI, GitHub Copilot, and 50+ more agents.