### PR TITLE
Add skills-hub.ai — open registry for AI coding skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If you receive the email, Claude is now connected to 500+ apps.
 Claude Skills are customizable workflows that teach Claude how to perform specific tasks according to your unique requirements. Skills enable Claude to execute tasks in a repeatable, standardized manner across all Claude platforms.
 
 ## Skills
+- [skills-hub.ai](https://skills-hub.ai) - Open platform with 2,850+ AI coding skills. Browse, install (CLI or web), publish, compose, and review skills for Claude Code, Cursor, Windsurf, Codex CLI, and any MCP-compatible tool. Features quality scoring, security scanning, collections, and organizations.
 
 ### Document Processing
 


### PR DESCRIPTION
Adding skills-hub.ai, which I found useful for AI agent skill discovery and install.

It's an open platform with 2,850+ skills across 23 categories aggregated from 62 sources
(Anthropic, Vercel, Stripe, Supabase, Google, Microsoft, and more). Skills install via CLI
(`npx @skills-hub-ai/cli install <skill>`) or via an MCP server, and work with Claude Code,
Cursor, Windsurf, Codex CLI, and any MCP-compatible tool.

Suggested entry:

```markdown
- [skills-hub.ai](https://skills-hub.ai) - Open platform with 2,850+ AI coding skills. Browse, install (CLI or web), publish, compose, and review skills for Claude Code, Cursor, Windsurf, Codex CLI, and any MCP-compatible tool. Features quality scoring, security scanning, collections, and organizations.
```

Happy to revise the wording, move it to a different section, or close this if it isn't a fit
for the list. Thanks for maintaining the list!