### PR TITLE
Add agenttrace session audit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [agenttrace-session-audit](https://github.com/luoyuctl/agenttrace/tree/master/skills/agenttrace-session-audit) - Audits local AI coding agent sessions for cost, tokens, failures, latency, anomalies, health, diffs, and CI gates. *By [@luoyuctl](https://github.com/luoyuctl)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## Summary
- Add agenttrace-session-audit to Development & Code Tools.
- Link to the existing agenttrace skill for auditing local AI coding-agent sessions.

## Why
agenttrace helps Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, and similar users inspect local sessions for cost, token usage, tool failures, latency, anomalies, health, diffs, and CI gates.

## Validation
- `git diff --check`
- Local validation against this repo's ready-to-merge README rules: only README changed, external URL, alphabetical placement, no blocked keywords.