### PR TITLE
Add production-audit skill (Security & Systems)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [production-audit](https://github.com/commitshow/production-audit) - Audit a shipped repo for the production-readiness gaps that ~70% of AI-coded projects miss (RLS gaps, webhook idempotency, secret exposure, column GRANT mismatches, Stripe API idempotency, etc.). Companion to in-session security skills — scans deployed product, not editor buffer. *By [@commitshow](https://github.com/commitshow)*
 
 ### Assistive Technology
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
-- [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 - [production-audit](https://github.com/commitshow/production-audit) - Audit a shipped repo for the production-readiness gaps that ~70% of AI-coded projects miss (RLS gaps, webhook idempotency, secret exposure, column GRANT mismatches, Stripe API idempotency, etc.). Companion to in-session security skills — scans deployed product, not editor buffer. *By [@commitshow](https://github.com/commitshow)*
+- [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 
 ### Assistive Technology
 


### PR DESCRIPTION
Adds [`production-audit`](https://github.com/commitshow/production-audit) under **Security & Systems**.

## What it does

A Claude Code skill that audits a shipped repo for the 14 production-readiness gaps ~70% of AI-coded projects miss — RLS coverage, webhook idempotency, secret-in-bundle, column GRANT mismatches (Postgres column-level grant pattern + new column without grant = silent 42501), Stripe API idempotency, mobile input zoom, and ten others.

## Why it complements existing entries

The current Security & Systems entries (computer-forensics, threat-hunting-with-sigma-rules, etc.) and most security skills across the list are **in-session lenses** — they scan the editor buffer at write-time. `production-audit` scans the **deployed product** post-merge: live URL, GitHub signals, repo structure, Lighthouse, secrets in shipped bundle. Different timing, different inputs, different findings. The two run side-by-side without overlap.

## Install

```
npx skills add commitshow/production-audit
```

or in Claude Code:

```
/plugin marketplace add https://github.com/commitshow/production-audit
```

## Verifications

- ✅ Frontmatter valid (`name` + `description`, ~390 chars)
- ✅ Canonical layout `.claude/skills/production-audit/SKILL.md`
- ✅ Plugin manifest at `.claude-plugin/marketplace.json`
- ✅ Install via `npx skills add` confirmed working
- ✅ MIT licensed
- ✅ README has install + usage + companion-skills sections