### PR TITLE
Add agent-handoff to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [agent-handoff](https://github.com/WillowRyu/agent-handoff) - Strict 3-stage handoff workflow (plan → execute → verify) for coding agents with disk-backed state for cross-context handoff, monorepo-aware, multi-language. *By [@WillowRyu](https://github.com/WillowRyu)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
Adds [agent-handoff](https://github.com/WillowRyu/agent-handoff) — a Claude Code plugin (MIT) that splits coding work into a strict three-stage workflow with disk-backed state, so each stage can run in a fresh chat without losing context.

## What it does

Bundle of four skills:

- `/setup-handoff` — once per project; auto-scans manifests and writes `.handoff/config.md` (monorepo-aware: pnpm/turbo/lerna/nx/cargo/go workspaces).
- `/plan` — writes `.handoff/plan.md` with change list, parallelization groups, and verification plan.
- `/execute` — applies the plan, tracks progress in `.handoff/task.md`. Forbidden from running tests/lint.
- `/verify` — runs in a fresh chat. Reads only the plan and the diff (not the reasoning that produced the code) to catch missed requirements and out-of-scope changes.

## Why it solves a real problem

Agents working in a single context tend to rationalize their own bugs. The plan/execute/verify split forces independent verification, and the disk-backed state means each step survives a chat restart — important for longer features or context-window-heavy work.

## Bilingual / multi-language

Response language is the first interview question (any ISO code: en, ko, ja, zh, fr, ...). Every artifact is written in that language. Code, file paths, and command syntax stay native.

## License

MIT. No telemetry — see [PRIVACY.md](https://github.com/WillowRyu/agent-handoff/blob/main/PRIVACY.md).