### PR TITLE
Add claude-operator-stack/skills (6 skills for solo founders)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
+- [claude-operator-stack/skills](https://github.com/mccarthy606/claude-operator-stack/tree/main/skills) - 6 SKILL.md packages for solo founders running multiple AI products: weekly-monday-review (triage of 7 projects), multi-project-context-bridge (cross-project decisions via graphify), case-study-anonymiser (sanitisation playbook), ship-day-planner (one-line idea → 8 ship-day blocks), solo-billing-monitor (cost rollup across cloud + AI APIs), obsidian-sync-helper (Brain notes vs git state).
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 
 ### Collaboration & Project Management


### PR DESCRIPTION
Adding **claude-operator-stack/skills** to the Productivity & Organization section — 6 SKILL.md packages targeting solo founders running multiple AI products in parallel.

## The 6 skills

| Skill | Use case |
|---|---|
| [`weekly-monday-review`](https://github.com/mccarthy606/claude-operator-stack/blob/main/skills/weekly-monday-review/SKILL.md) | Monday review → 2-of-N project focus pick |
| [`multi-project-context-bridge`](https://github.com/mccarthy606/claude-operator-stack/blob/main/skills/multi-project-context-bridge/SKILL.md) | Bridge cross-project decisions via graphify queries with anonymisation |
| [`case-study-anonymiser`](https://github.com/mccarthy606/claude-operator-stack/blob/main/skills/case-study-anonymiser/SKILL.md) | Apply the redaction playbook to a draft case study |
| [`ship-day-planner`](https://github.com/mccarthy606/claude-operator-stack/blob/main/skills/ship-day-planner/SKILL.md) | Turn a one-line product idea into 8 ship-day blocks |
| [`solo-billing-monitor`](https://github.com/mccarthy606/claude-operator-stack/blob/main/skills/solo-billing-monitor/SKILL.md) | Weekly cost rollup across cloud + AI APIs |
| [`obsidian-sync-helper`](https://github.com/mccarthy606/claude-operator-stack/blob/main/skills/obsidian-sync-helper/SKILL.md) | Verify Brain notes vs git state |

## Discipline

- All 6 names cross-checked against ECC's 182-skill catalog at ship time — zero collisions
- Each SKILL.md is invocable (not just descriptive), follows fixed template (When to Use → Inputs → How It Works → Output → Anti-patterns → Related), 80-200 lines
- Each links to at least one repo workflow / cookbook recipe
- `origin: claude-operator-stack` frontmatter for discoverability

## Links

- Source folder: https://github.com/mccarthy606/claude-operator-stack/tree/main/skills
- Parent repo (operator playbook + curator-toolkit): https://github.com/mccarthy606/claude-operator-stack
- npm: https://www.npmjs.com/package/claude-operator-stack
- v1.0.0 (2026-05-05). MIT.