### PR TITLE
Add voxflow to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [voxflow](https://github.com/VoxFlowStudio/skills) - 5 skills bundled into an AI voice CLI: TTS in 200+ voices, multi-speaker podcasts, video dubbing from SRT, transcription, and short-form Remotion videos. *By [@chicogong](https://github.com/chicogong)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds [voxflow](https://github.com/VoxFlowStudio/skills) to `Skills → Creative & Media`.

VoxFlow is a 14-month solo project — an AI voice/audio CLI shipping as 5 SKILL.md files (hub, podcast, transcribe, video, paper-slide) that work cross-agent (Claude Code, Cursor, Codex CLI, Gemini CLI, Cline).

Install for any agent:
```
npx skills add VoxFlowStudio/skills
```

CLI: https://www.npmjs.com/package/voxflow
Demo: https://github.com/VoxFlowStudio/skills/raw/main/demo.gif
README: https://github.com/VoxFlowStudio/skills

Free tier: 10K quota/month. Backend uses Tencent TTS/ASR + multiple LLM providers behind a quota system, server-side Remotion rendering on Fly.io.

Per CONTRIBUTING.md: ✅ real use case, well-documented, includes examples, tested across Claude Code / Cursor / Codex / Gemini CLI, safe (no destructive ops without confirmation), portable.