### PR TITLE
Add firewall-review and claude-logger to Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,10 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Security & Systems
 
+- [claude-logger](https://github.com/ipunithgowda/claude-logger/tree/main/skills/claude-logger) - Query and verify tamper-proof audit logs for Claude Code sessions. SHA-256 hash chains over append-only JSONL, with helpers for cost rollups, error grep, and integrity checks. *By [@ipunithgowda](https://github.com/ipunithgowda)*
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
+- [firewall-review](https://github.com/transilienceai/communitytools/tree/main/skills/firewall-review) - Static firewall ruleset audit playbook. 17 vendor-agnostic detectors across FortiGate, PAN-OS, Cisco ASA/IOS, Azure NSG, AWS SG, iptables. Findings carry source file, byte offset, quoted rule, and version-pinned framework citations (NIST CSF 2.0, PCI DSS v4.0.1, ISO/IEC 27001:2022, CIS Controls v8.1, HIPAA). *By [@ipunithgowda](https://github.com/ipunithgowda)*
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 


### PR DESCRIPTION
Adds two skills to the **Security & Systems** section.

### firewall-review
Static firewall ruleset audit playbook shipped to `transilienceai/communitytools` (PR #22, merged 2026-04-28). 17 vendor-agnostic detectors across FortiGate, PAN-OS, Cisco ASA/IOS, Azure NSG, AWS SG, and iptables. Every finding carries source file + byte offset + quoted rule, plus version-pinned framework citations (NIST CSF 2.0, PCI DSS v4.0.1, ISO/IEC 27001:2022, CIS Controls v8.1, HIPAA).

**Real-world use case:** used in audit engagements at Network Intelligence to produce client-grade PDF + Excel deliverables from raw vendor configs.

### claude-logger
Tamper-proof audit-log query skill for Claude Code sessions. SHA-256 hash chains over append-only JSONL, with helpers for cost rollups, error grep, and integrity checks.

**Real-world use case:** dropped into a daily Claude Code workflow to surface session costs and verify log integrity without leaving the terminal.

### Format check
Both rows added to the existing **Security & Systems** section in alphabetical order, matching the surrounding `[name](url) - description. *By [@handle]*` pattern. No changes elsewhere.