### PR TITLE
Add agent-lsp skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [agent-lsp](https://github.com/blackwell-systems/agent-lsp) - 22 code intelligence skills backed by real language servers across 30 languages. Skills like /lsp-refactor, /lsp-inspect, /lsp-understand, and /lsp-verify encode multi-step LSP workflows so agents complete them correctly. Ships as an MCP server with 56 tools; single Go binary. *By [@blackwell-systems](https://github.com/blackwell-systems)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## Summary

Adds [agent-lsp](https://github.com/blackwell-systems/agent-lsp) to the Development & Code Tools section.

agent-lsp ships 22 code intelligence skills (lsp-refactor, lsp-inspect, lsp-understand, lsp-verify, lsp-impact, etc.) backed by real language servers across 30 languages. Each skill encodes a multi-step LSP workflow so coding agents complete them correctly without manual orchestration. Ships as a single Go binary MCP server with 56 tools.

## Checklist

- [x] Real use case (production MCP server powering Claude Code workflows)
- [x] Added in alphabetical order within Development & Code Tools
- [x] Follows existing entry format
- [x] No duplicates in the list