### PR TITLE
Add Web to Markdown skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [Web to Markdown](https://github.com/aluvia-connect/aluvia-skills/tree/main/webtomd) - Scrapes webpages and saves them as clean Markdown with frontmatter, with fast (WebFetch) and precise (urllib+markdownify) modes for articles and technical docs.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis


### PR DESCRIPTION
## Summary

Added **Web to Markdown** skill to the Development & Code Tools section.

A skill that scrapes webpages and saves them as clean Markdown files with YAML frontmatter, with fast (WebFetch) and precise (urllib+markdownify) modes for articles and technical docs.

## Checklist

- [x] Based on a real use case
- [x] Well documented with clear instructions
- [x] Includes examples and use cases
- [x] Tested with Claude Code integration
- [x] Safe - no destructive operations
- [x] Portable across Claude platforms

## What Problem It Solves

Converts web pages into clean, structured Markdown for offline reading, documentation archiving, and knowledge base building — without requiring external tools or browser extensions.

## Inspiration

The need for a simple, built-in way to save and archive web content as Markdown directly from Claude, without relying on third-party APIs or browser extensions.