### PR TITLE
Add buy-me-a-car skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
+- [buy-me-a-car](https://github.com/DaizeDong/buy-me-a-car) - End-to-end used-car pre-purchase workflow: multi-site inventory research, mass dealer email outreach, Gmail cron monitoring, OTD negotiation with market-data anchors, CARFAX analysis, and dossier PDF generation. Covers all 50 US states + DC; bilingual English/Chinese. *By [@DaizeDong](https://github.com/DaizeDong)*
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.


### PR DESCRIPTION
## Summary

Adds **buy-me-a-car** — an end-to-end used-car pre-purchase workflow skill for Claude Code — to the **Business & Marketing** category.

## What it does

Helps a buyer take a used-car purchase from research through signing, in a single guided workflow:

- **Multi-site inventory research** across major US listing sites
- **Mass dealer email outreach** with templated, market-data-anchored asks
- **Gmail cron monitoring** for dealer replies (durable, background)
- **OTD (out-the-door) negotiation** with state-by-state tax/fee/registration math
- **CARFAX & service-record analysis** (PDF ingest)
- **Dossier PDF generation** summarizing inventory, comps, outreach status, and OTD targets
- **All 50 US states + DC** coverage in the OTD calculator
- **Bilingual English + Chinese**

8-phase workflow: discovery → research → comps → outreach → monitoring → negotiation → inspection → close.

## Real-world tested

Built and refined during a real used-Subaru purchase cycle by the author. Not theoretical.

## Metadata

- **Repo**: https://github.com/DaizeDong/buy-me-a-car
- **License**: MIT
- **Maintainer**: [@DaizeDong](https://github.com/DaizeDong) (active)
- **Status**: production-ready
- See repo `README.md` and `ROADMAP.md` for full feature list.

## Checklist

- [x] Real use case (real Subaru purchase)
- [x] Searched README for duplicates — none found
- [x] Added to a single appropriate category (Business & Marketing)
- [x] Followed existing entry format (link + " - " + description + `*By [@author]*`)
- [x] Inserted alphabetically (between Brand Guidelines and Competitive Ads Extractor)
- [x] Only `README.md` modified