### PR TITLE
fix(lint): Fix all ruff lint errors across Python files

### DIFF
--- a/skill-creator/scripts/quick_validate.py
+++ b/skill-creator/scripts/quick_validate.py
@@ -4,7 +4,6 @@ Quick validation script for skills - minimal version
 """
 
 import sys
-import os
 import re
 from pathlib import Path
 

--- a/slack-gif-creator/core/color_palettes.py
+++ b/slack-gif-creator/core/color_palettes.py
@@ -6,7 +6,6 @@ Using consistent, well-designed color palettes makes GIFs look professional
 and polished instead of random and amateurish.
 """
 
-from typing import Optional
 import colorsys
 
 

--- a/slack-gif-creator/core/frame_composer.py
+++ b/slack-gif-creator/core/frame_composer.py
@@ -116,7 +116,7 @@ def draw_text(frame: Image.Image, text: str, position: tuple[int, int],
     # Try to use default font, fall back to basic if not available
     try:
         font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", font_size)
-    except:
+    except Exception:
         font = ImageFont.load_default()
 
     if centered:
@@ -149,7 +149,7 @@ def draw_emoji(frame: Image.Image, emoji: str, position: tuple[int, int], size: 
     # Use Apple Color Emoji font on macOS
     try:
         font = ImageFont.truetype("/System/Library/Fonts/Apple Color Emoji.ttc", size)
-    except:
+    except Exception:
         # Fallback to text-based emoji
         font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", size)
 
@@ -292,11 +292,11 @@ def draw_emoji_enhanced(frame: Image.Image, emoji: str, position: tuple[int, int
     # Use Apple Color Emoji font on macOS
     try:
         font = ImageFont.truetype("/System/Library/Fonts/Apple Color Emoji.ttc", size)
-    except:
+    except Exception:
         # Fallback to text-based emoji
         try:
             font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", size)
-        except:
+        except Exception:
             font = ImageFont.load_default()
 
     # Draw shadow first if enabled
@@ -307,13 +307,13 @@ def draw_emoji_enhanced(frame: Image.Image, emoji: str, position: tuple[int, int
             try:
                 draw.text((shadow_pos[0] + offset, shadow_pos[1] + offset),
                          emoji, font=font, embedded_color=True, fill=(0, 0, 0, 100))
-            except:
+            except Exception:
                 pass  # Skip shadow if it fails
 
     # Draw main emoji
     try:
         draw.text(position, emoji, font=font, embedded_color=True)
-    except:
+    except Exception:
         # Fallback to basic drawing if embedded color fails
         draw.text(position, emoji, font=font, fill=(0, 0, 0))
 

--- a/slack-gif-creator/core/gif_builder.py
+++ b/slack-gif-creator/core/gif_builder.py
@@ -7,7 +7,6 @@ generated frames, with automatic optimization for Slack's requirements.
 """
 
 from pathlib import Path
-from typing import Optional
 import imageio.v3 as imageio
 from PIL import Image
 import numpy as np
@@ -163,8 +162,6 @@ class GIFBuilder:
             raise ValueError("No frames to save. Add frames with add_frame() first.")
 
         output_path = Path(output_path)
-        original_frame_count = len(self.frames)
-
         # Remove duplicate frames to reduce file size
         if remove_duplicates:
             removed = self.deduplicate_frames(threshold=0.98)
@@ -223,7 +220,7 @@ class GIFBuilder:
         }
 
         # Print info
-        print(f"\n✓ GIF created successfully!")
+        print("\n✓ GIF created successfully!")
         print(f"  Path: {output_path}")
         print(f"  Size: {file_size_kb:.1f} KB ({file_size_mb:.2f} MB)")
         print(f"  Dimensions: {self.width}x{self.height}")

--- a/slack-gif-creator/core/typography.py
+++ b/slack-gif-creator/core/typography.py
@@ -7,7 +7,6 @@ in GIFs, with outlines for readability and effects for visual impact.
 """
 
 from PIL import Image, ImageDraw, ImageFont
-from typing import Optional
 
 
 # Typography scale - proportional sizing system
@@ -48,7 +47,7 @@ def get_font(size: int, bold: bool = False) -> ImageFont.FreeTypeFont:
     for font_path in font_paths:
         try:
             return ImageFont.truetype(font_path, size)
-        except:
+        except Exception:
             continue
 
     # Ultimate fallback

--- a/slack-gif-creator/core/validators.py
+++ b/slack-gif-creator/core/validators.py
@@ -51,7 +51,7 @@ def check_slack_size(gif_path: str | Path, is_emoji: bool = True) -> tuple[bool,
         overage_kb = size_kb - limit_kb
         overage_percent = (overage_kb / limit_kb) * 100
         print(f"  Over by: {overage_kb:.1f} KB ({overage_percent:.1f}%)")
-        print(f"  Try: fewer frames, fewer colors, or simpler design")
+        print("  Try: fewer frames, fewer colors, or simpler design")
 
     return passes, info
 
@@ -163,7 +163,7 @@ def validate_gif(gif_path: str | Path, is_emoji: bool = True) -> tuple[bool, dic
                 duration_ms = img.info.get('duration', 100)
                 total_duration = (duration_ms * frame_count) / 1000
                 fps = frame_count / total_duration if total_duration > 0 else 0
-            except:
+            except Exception:
                 duration_ms = None
                 total_duration = None
                 fps = None

--- a/slack-gif-creator/core/visual_effects.py
+++ b/slack-gif-creator/core/visual_effects.py
@@ -443,7 +443,6 @@ def create_speed_lines(frame: Image.Image, position: tuple[int, int],
         end_y = start_y + math.sin(trail_angle) * line_length
 
         # Draw line with varying opacity
-        alpha = random.randint(100, 200)
         width = random.randint(1, 3)
 
         # Simple line (full opacity simulation)

--- a/slack-gif-creator/templates/bounce.py
+++ b/slack-gif-creator/templates/bounce.py
@@ -13,7 +13,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 
 from core.gif_builder import GIFBuilder
 from core.frame_composer import create_blank_frame, draw_circle, draw_emoji
-from core.easing import ease_out_bounce, interpolate
+from core.easing import ease_out_bounce
 
 
 def create_bounce_animation(

--- a/slack-gif-creator/templates/explode.py
+++ b/slack-gif-creator/templates/explode.py
@@ -13,7 +13,6 @@ import random
 sys.path.append(str(Path(__file__).parent.parent))
 
 from PIL import Image, ImageDraw
-import numpy as np
 from core.gif_builder import GIFBuilder
 from core.frame_composer import create_blank_frame, draw_emoji_enhanced
 from core.visual_effects import ParticleSystem

--- a/slack-gif-creator/templates/fade.py
+++ b/slack-gif-creator/templates/fade.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).parent.parent))
 
-from PIL import Image, ImageDraw
+from PIL import Image
 import numpy as np
 from core.gif_builder import GIFBuilder
 from core.frame_composer import create_blank_frame, draw_emoji_enhanced

--- a/slack-gif-creator/templates/kaleidoscope.py
+++ b/slack-gif-creator/templates/kaleidoscope.py
@@ -33,9 +33,6 @@ def apply_kaleidoscope(frame: Image.Image, segments: int = 8,
     if center is None:
         center = (width // 2, height // 2)
 
-    # Create output frame
-    output = Image.new('RGB', (width, height))
-
     # Calculate angle per segment
     angle_per_segment = 360 / segments
 

--- a/slack-gif-creator/templates/morph.py
+++ b/slack-gif-creator/templates/morph.py
@@ -11,7 +11,6 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent))
 
 from PIL import Image
-import numpy as np
 from core.gif_builder import GIFBuilder
 from core.frame_composer import create_blank_frame, draw_emoji_enhanced, draw_circle
 from core.easing import interpolate

--- a/slack-gif-creator/templates/move.py
+++ b/slack-gif-creator/templates/move.py
@@ -209,7 +209,7 @@ def apply_trail_effect(frames: list, trail_length: int = 5,
     Returns:
         List of frames with trail effect
     """
-    from PIL import Image, ImageChops
+    from PIL import Image
     import numpy as np
 
     trailed_frames = []

--- a/slack-gif-creator/templates/spin.py
+++ b/slack-gif-creator/templates/spin.py
@@ -13,7 +13,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 
 from PIL import Image
 from core.gif_builder import GIFBuilder
-from core.frame_composer import create_blank_frame, draw_emoji_enhanced, draw_circle
+from core.frame_composer import create_blank_frame, draw_emoji_enhanced
 from core.easing import interpolate
 
 

--- a/slack-gif-creator/templates/wiggle.py
+++ b/slack-gif-creator/templates/wiggle.py
@@ -14,7 +14,6 @@ sys.path.append(str(Path(__file__).parent.parent))
 from PIL import Image
 from core.gif_builder import GIFBuilder
 from core.frame_composer import create_blank_frame, draw_emoji_enhanced
-from core.easing import interpolate
 
 
 def create_wiggle_animation(
@@ -126,9 +125,6 @@ def create_wiggle_animation(
         # Apply transformations
         if object_type == 'emoji':
             size = object_data['size']
-            size_x = int(size * scale_x)
-            size_y = int(size * scale_y)
-
             # For non-uniform scaling or rotation, we need to use PIL transforms
             if abs(scale_x - scale_y) > 0.01 or abs(rotation) > 0.1:
                 # Create emoji on transparent canvas

--- a/video-downloader/scripts/download_video.py
+++ b/video-downloader/scripts/download_video.py
@@ -90,7 +90,7 @@ def download_video(url, output_path="/mnt/user-data/outputs", quality="best", fo
         
         # Download the video
         subprocess.run(cmd, check=True)
-        print(f"\n✅ Download complete!")
+        print("\n✅ Download complete!")
         return True
     except subprocess.CalledProcessError as e:
         print(f"\n❌ Error downloading video: {e}")

--- a/webapp-testing/examples/console_logging.py
+++ b/webapp-testing/examples/console_logging.py
@@ -32,4 +32,4 @@ with open('/mnt/user-data/outputs/console.log', 'w') as f:
     f.write('\n'.join(console_logs))
 
 print(f"\nCaptured {len(console_logs)} console messages")
-print(f"Logs saved to: /mnt/user-data/outputs/console.log")
+print("Logs saved to: /mnt/user-data/outputs/console.log")


### PR DESCRIPTION
Fixes 28 ruff lint errors across the codebase:

- Remove unused imports (`os`, `numpy`, `typing.Optional`, etc.)
- Replace bare `except:` with `except Exception:`
- Remove unused variable assignments
- Remove extraneous `f` prefixes from f-strings without placeholders