### PR TITLE
Add ai-investment-skills to Investment & Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
+- [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) - Daily options flow scanner, stop-loss monitor, EV calculator, and investment briefing agent. 6 battle-tested skills for real-money portfolio management. *By [@tellmefrankie](https://github.com/tellmefrankie)*
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.


### PR DESCRIPTION
## Summary

Adds ai-investment-skills repository to the Awesome Claude Skills list under a new "Investment & Finance" subsection within Business & Marketing.

## What's Included

- **Repository**: [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)
- **Skills Count**: 6 battle-tested skills for investment analysis
- **Key Skills**: 
  - EV calculator
  - Options flow analyzer
  - Price monitor
  - Multi-agent orchestrator
  - News sentiment engine
  - Investment briefing agent

## Changes

1. Added new "Investment & Finance" subsection under Business & Marketing
2. Added ai-investment-skills entry with description and attribution
3. Updated table of contents to include the new subsection

This collection provides practical, real-world investment analysis skills that solve actual use cases for financial professionals and investors.