### PR TITLE
Add ai-investment-skills to Data & Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) - Six daily skills for individual investors: options flow scanner with lottery-call filtering, stop-loss monitor, earnings risk check, sector rotation signal, and real-vs-lottery position classifier. Runs on cron schedule with Telegram alerts; free tier included. *By [@tellmefrankie](https://github.com/tellmefrankie)*
 
 ### Business & Marketing
 

--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) - Six daily skills for individual investors: options flow scanner with lottery-call filtering, stop-loss monitor, earnings risk check, sector rotation signal, and real-vs-lottery position classifier. Runs on cron schedule with Telegram alerts; free tier included. *By [@tellmefrankie](https://github.com/tellmefrankie)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
-- [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) - Six daily skills for individual investors: options flow scanner with lottery-call filtering, stop-loss monitor, earnings risk check, sector rotation signal, and real-vs-lottery position classifier. Runs on cron schedule with Telegram alerts; free tier included. *By [@tellmefrankie](https://github.com/tellmefrankie)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
## What this adds

**[ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)** added to the **Data & Analysis** section.

Six daily skills for individual investors:
- Options flow scanner with lottery-call filtering (strips <$0.10 premium calls before computing P/C ratio)
- Stop-loss monitor with configurable thresholds
- Earnings risk check (implied move vs historical realized)
- Sector rotation signal via ETF momentum comparison
- Real-vs-lottery position classifier
- Morning briefing aggregator

Runs on a cron schedule with Telegram alerts. Free tier included (EV calculator + news sentiment engine). Compatible with Claude Code, Cursor, and Codex CLI via SKILL.md format.

## Checklist
- [x] Skill is public on GitHub
- [x] Follows SKILL.md format
- [x] Added to appropriate section (Data & Analysis)
- [x] Description is accurate and concise
- [x] Free tier available