### PR TITLE
Add cialdini-influence-audit to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
+- [cialdini-influence-audit](https://github.com/johnericforte/claude-skill-cialdini-influence-audit) - Scores persuasive copy (landing pages, emails, sales sequences, cold pitches) against Cialdini's seven principles plus Pre-Suasion. Returns PRESENT, WEAK, or MISSING per principle with one-line evidence and an anti-overstacking check. *By [@johnericforte](https://github.com/johnericforte)*
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.


### PR DESCRIPTION
Adds [cialdini-influence-audit](https://github.com/johnericforte/claude-skill-cialdini-influence-audit) to **Business & Marketing**.

## What it does

A Claude Code plugin that audits persuasive copy (landing pages, emails, sales sequences, cold pitches) against Robert Cialdini's seven principles of influence plus Pre-Suasion. Returns PRESENT, WEAK, or MISSING per principle with one-line evidence each, audits the opener for Pre-Suasion attentional channeling, and includes an anti-overstacking check that flags when 5+ principles read as manipulative.

This skill audits existing copy. It does not generate copy from scratch.

## Compliance

- Added under Business & Marketing, alphabetized between Brand Guidelines and Competitive Ads Extractor
- MIT-licensed
- DISCLAIMER.md addresses IP framing (frameworks cited descriptively under nominative fair use, not affiliated with Robert Cialdini or Influence At Work)
- Plugin format with .claude-plugin/plugin.json manifest
- One entry per PR (per repo convention)

## Links

- Repo: https://github.com/johnericforte/claude-skill-cialdini-influence-audit
- Write-up: https://www.ericforte.com/blog/3-claude-code-skills-i-built