### PR TITLE
Add hormozi-offer-audit to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [hormozi-offer-audit](https://github.com/johnericforte/claude-skill-hormozi-offer-audit) - Audits sales offers (landing pages, pricing tiers, lead magnets) against Alex Hormozi's Value Equation. Returns a 100-point score across four levers (Dream Outcome, Perceived Likelihood, Time Delay, Effort & Sacrifice) plus a Top 3 Fixes block ranked by impact-to-effort. Also runs Grand Slam Offer + M.A.G.I.C. naming checks. *By [@johnericforte](https://github.com/johnericforte)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
Adds [hormozi-offer-audit](https://github.com/johnericforte/claude-skill-hormozi-offer-audit) to **Business & Marketing**.

## What it does

A Claude Code plugin that audits sales offers (landing pages, pricing tiers, lead magnets) using Alex Hormozi's frameworks from $100M Offers and $100M Leads.

- Scores the Value Equation: Dream Outcome, Perceived Likelihood of Achievement, Time Delay, Effort & Sacrifice (0-25 per lever, 100 total)
- Flags the weakest lever and returns a Top 3 Fixes block with before/after examples ranked by impact-to-effort
- Runs the Grand Slam Offer 5-step build (Dream Outcome to Obstacles to Solutions to Trim & Stack to Delivery Vehicle)
- Runs the 5 enhancement levers (Scarcity, Urgency, Bonuses, Guarantees, M.A.G.I.C. naming check)
- Handles paid offers OR lead magnets (separate path for each)

This skill audits existing offers. It does not generate offers from scratch.

## Compliance

- Added under Business & Marketing, alphabetized between Domain Name Brainstormer and Internal Comms
- MIT-licensed
- DISCLAIMER.md addresses IP framing (frameworks cited descriptively under nominative fair use, not affiliated with Alex Hormozi, Bumble IP LLC, or Acquisition.com)
- Plugin format with .claude-plugin/plugin.json manifest
- One entry per PR (per repo convention)

## Links

- Repo: https://github.com/johnericforte/claude-skill-hormozi-offer-audit
- Write-up: https://www.ericforte.com/blog/3-claude-code-skills-i-built