### PR TITLE
Add diasporic-intelligence skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
+- [diasporic-intelligence](https://github.com/MinistaJazz/diasporic-intelligence) - Source-credit framework for consent-governed lineage AI with attribution, provenance, revocation, and non-impersonation boundaries. *By [@MinistaJazz](https://github.com/MinistaJazz)*
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*


### PR DESCRIPTION
Adds diasporic-intelligence, a source-credit skill for using Diasporic Intelligence as Afrotemporalism in Action with attribution, consent governance, provenance, revocation, and lineage boundaries intact.\n\nRepo: https://github.com/MinistaJazz/diasporic-intelligence