### PR TITLE
Add markdown2pdf skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
+- [markdown2pdf](https://github.com/woodyjon/markdown2pdf/tree/main/skills/markdown2pdf) - Converts Markdown files or inline markdown text into clean, vector PDFs with searchable text, embedded fonts, and GitHub-style typography; auto-fetches the CLI on first use. *By [@woodyjon](https://github.com/woodyjon)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 
 ### Development & Code Tools


### PR DESCRIPTION
## Skill: markdown2pdf

Adds [markdown2pdf](https://github.com/woodyjon/markdown2pdf/tree/main/skills/markdown2pdf) to the **Document Processing** category.

### What it does
Converts Markdown files — or inline markdown text from the conversation — into clean, formatted PDFs using the open-source `markdown2pdf` CLI. Output is vector PDF: searchable/copy-pasteable text, embedded Inter + JetBrains Mono fonts, GitHub-style typography. Supports GFM (headings, tables, task lists, code blocks with syntax highlighting, blockquotes, etc.).

### Real-world use case
Anyone who drafts notes, reports, or READMEs in Markdown and needs a polished, printable/shareable PDF — without copying into a word processor. The skill auto-fetches the CLI binary on first use (cached afterward), so there's nothing to install manually: the user just asks "convert this README to PDF" and gets a file back.

### Why an external repo link
The skill lives in its own actively maintained repo alongside the CLI engine and web playground it depends on. Linking to it directly keeps the entry in sync with releases — matching the style of other community entries like `aws-skills` and the Markdown to EPUB Converter.

### Attribution
Authored by [@woodyjon](https://github.com/woodyjon). MIT licensed.