### PR TITLE
Add restorative-repair skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [Restorative Repair](https://github.com/MinistaJazz/restorative-repair) - Response-layer repair skill for AI agents that names output errors, offers proportionate repair, routes crisis safely, and avoids apology loops. *By [@MinistaJazz](https://github.com/MinistaJazz)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 
 ### Creative & Media


### PR DESCRIPTION
Adds restorative-repair, an external public Claude-compatible skill for response-layer repair when AI agents make output errors.\n\nRepo: https://github.com/MinistaJazz/restorative-repair\n\nThe skill includes trigger taxonomy, severity tiers, crisis suppression rules, bounded loop-exit behavior, and auditable benchmark prompts.