### PR TITLE
Add aave-respect skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Communication & Writing
 
+- [AAVE Respect](https://github.com/MinistaJazz/aave-respect) - Respect-layer skill for recognizing African American Vernacular English accurately, preserving meaning, avoiding correction, and preventing mimicry. *By [@MinistaJazz](https://github.com/MinistaJazz)*
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.


### PR DESCRIPTION
Adds aave-respect, an external public Claude-compatible skill for recognizing and respecting African American Vernacular English without correction, flattening, or mimicry.\n\nRepo: https://github.com/MinistaJazz/aave-respect\n\nThe skill includes recognition, response, transcription, editing, generation guidance, red-team prompts, and developer resources for AAVE-aware AI behavior.