### PR TITLE
Add open-source sample of Septim Agents Pack (one agent, MIT, drop-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [Septim Agents Pack Sample (open-source)](https://github.com/septimlabs-code/septim-agents-pack-sample) - MIT-licensed sample of one Claude Code sub-agent from Septim Agents Pack. Drop `pip-intern.md` into `~/.claude/agents/` and Claude Code picks it up. Demonstrates the named-agent + scope-+-refusal-conditions format. Full 10-agent pack at septimlabs.com/agents ($49 lifetime).
 
 ### Data & Analysis
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 - [Septim Agents Pack Sample (open-source)](https://github.com/septimlabs-code/septim-agents-pack-sample) - MIT-licensed sample of one Claude Code sub-agent from Septim Agents Pack. Drop `pip-intern.md` into `~/.claude/agents/` and Claude Code picks it up. Demonstrates the named-agent + scope-+-refusal-conditions format. Full 10-agent pack at septimlabs.com/agents ($49 lifetime).
+- [Septim Agents Pack Sample (open-source)](https://github.com/septimlabs-code/septim-agents-pack-sample) - MIT-licensed sample of one Claude Code sub-agent from Septim Agents Pack. Drop `pip-intern.md` into `~/.claude/agents/` and Claude Code picks it up. Demonstrates the named-agent + scope-+-refusal-conditions format. Full 10-agent pack at septimlabs.com/agents ($49 lifetime).
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds the [Septim Agents Pack](https://septimlabs.com/agents) — 10 named Claude Code sub-agents covering the full exec layer for solo founders (chief of staff, CTO, brand, CMO, CFO, design, legal, customer, research, intern coordinator).

The pack ships under the Claude Code sub-agent framework: each agent is a markdown file dropped into `~/.claude/agents/`, invoked via `/agents <name>`.

One agent (Pip the intern) is open-sourced under MIT at https://github.com/septimlabs-code/septim-agents-pack-sample so anyone can evaluate the format before buying the full pack.

Thanks for maintaining this list.
