### PR TITLE
Add Writer's Voice — constructed-voice skill for AI writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [Writer's Voice](https://github.com/travsteward/writers-voice) - Constructed voice for AI writing. Anchors the agent to a training-data author blend (matched at openwriter.io/writers-voice), then layers NEVER rules and presentation fingerprints from a growing local corpus. Pure markdown — agent-agnostic. Gets better as you add samples. *By [@travsteward](https://github.com/travsteward)*
 
 ### Creative & Media
 


### PR DESCRIPTION
## Skill

**Writer's Voice** — pure-markdown agent-agnostic skill for constructing a voice for AI writing.

Repo: https://github.com/travsteward/writers-voice

## What it does

Anchors the agent to a training-data author blend (3-5 authors with weights, matched via the openwriter.io/writers-voice free web tool OR generated in-agent by the skill itself), then layers NEVER rules and presentation fingerprints from a growing local corpus.

The skill is pure markdown — no Node.js runtime, no dependencies, no install step beyond cloning. The agent reads the catalog files (60+ AI tells, 8 fingerprint detectors, authenticity hurdle thresholds) and the user's corpus, then writes the analysis output as markdown files.

## Category

**Communication & Writing** — slotted alphabetically between Twitter Algorithm Optimizer and Creative & Media section break.

## Agent compatibility

- Claude Code: `claude install github:travsteward/writers-voice`
- Vercel skills CLI (any agent): `npx skills add travsteward/writers-voice`
- Manual: `git clone https://github.com/travsteward/writers-voice`

## License

MIT.