### PR TITLE
Add CreatorSkills to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [CreatorSkills](https://creatorskills.co) - Marketplace of AI skills for content creators — YouTubers, podcasters, and course builders. Skills for Claude, ChatGPT, and universal platforms across scriptwriting, thumbnails, analytics, sponsorships, and more.
 
 ### Inspiration & Use Cases
 


### PR DESCRIPTION
[CreatorSkills](https://creatorskills.co) is a marketplace of AI skills for content creators — YouTubers, podcasters, and course builders. It fits naturally in the Community Resources section alongside the official Skills Marketplace.

Skills cover: scriptwriting, thumbnail brainstorming, audience growth, sponsorship workflows, community engagement, course creation. Supports Claude, ChatGPT, and universal platforms.