### PR TITLE
Add Suppr Skills for academic literature workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [Suppr Skills](https://github.com/WildDataX/suppr-skills) - Claude Code skills for academic literature search and document translation workflows through the Suppr APIs.
 
 ### Business & Marketing
 


### PR DESCRIPTION
Hi, thanks for maintaining this collection.

This PR adds Suppr Skills as a research/document-workflow skill. Suppr Skills provides Claude Code skills for academic literature search and document translation APIs, supporting research reading, paper discovery, and document translation workflows.

Disclosure: I maintain/am affiliated with Suppr, so I kept the entry concise and transparent. Happy to adjust wording or placement.