### PR TITLE
Add codex-imagegen skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Creative & Media
 
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [codex-imagegen](https://github.com/JunSeo99/claude-skill-codex-imagegen) - Generate and edit images from inside Claude Code via OpenAI's gpt-image-2 through the Codex CLI's `$imagegen`, with a verified five-part prompting playbook and a safe-by-default split workflow (opt-in automated mode). *By [@JunSeo99](https://github.com/JunSeo99)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
## What problem it solves

Claude Code does not ship with an image-generation model of its own. This skill closes that gap by teaching Claude Code to call OpenAI's `gpt-image-2` through the Codex CLI's built-in `$imagegen` feature — so users can generate icons, banners, OG cards, illustrations, infographics, and photo edits without leaving their Claude Code session.

The skill bakes in fixes for several rough edges that Claude misses on its own:

- `gpt-image-2` ignores the exact output size you request (e.g. 256×256 → 1254×1254) — the skill resizes via `sips` / ImageMagick after generation.
- Transparent PNGs aren't supported by `gpt-image-2` (only `gpt-image-1.5` supports them).
- Raw PNGs land at `~/.codex/generated_images/<session-uuid>/ig_*.png`, not where you asked — the skill parses the absolute path from stdout and moves it.
- Five-part structured prompts (per the OpenAI Cookbook) outperform "stunning, cinematic, 8K" keyword prompts — the skill ships a verified prompting playbook.
- The naive non-interactive recipe requires `--dangerously-bypass-approvals-and-sandbox`, which is unsafe as a default — the skill defaults to a **split workflow** (Codex generates only; the host does the file moves) and only opts into bypass mode on explicit request.

## Who uses this workflow

Anyone using Claude Code who needs visual assets (icons, banners, OG images, hero illustrations, infographics, photo edits) without round-tripping to a separate image-generation tool. Particularly useful for indie devs, landing-page builders, and anyone who already has a Codex CLI / ChatGPT subscription.

## Example

> **User**: Make a 512×512 hero icon for my landing page — a single seedling growing from a flat horizon, line-art only, no text.
>
> **Claude**: *(invokes the skill, composes a five-part prompt, runs `codex exec` in Mode A — safe, parses the absolute path from stdout, `cp`s and `sips`-resizes it to `./assets/hero-icon.png`, then opens the file with Read to verify it matches the intent)*

Activates on phrases like "generate an image", "make an icon", "create a banner", "OG image", "imagegen", "GPT Image 2", "codex image", "이미지 만들어줘", "아이콘 생성", "배너 디자인", or any request that produces a visual file saved to disk.

## Skill repository

https://github.com/JunSeo99/claude-skill-codex-imagegen

Verified against `codex-cli 0.130.0` on macOS. Includes `SKILL.md`, prompting guide, CLI reference, `SECURITY.md`, sample output asset, and a pre-packaged `.skill` bundle.

## Category

Added under **Creative & Media** in alphabetical position between `Canvas Design` and `imagen`, since this is the OpenAI counterpart to the existing Gemini-based `imagen` skill (complementary, not duplicate).