### PR TITLE
Add Truenex Memory to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Pre-built workflow skills for 78 SaaS apps via [Rube MCP (Composio)](https://com
 2. Add skills from the marketplace or upload custom skills.
 3. Claude automatically activates relevant skills based on your task.
 
+- [marcomnit/truenex-memory](https://github.com/marcomnit/truenex-memory) - Local-first, persistent memory store for AI agents with global search and project context.
 ### Using Skills in Claude Code
 
 1. Place the skill in `~/.config/claude-code/skills/`:


### PR DESCRIPTION
## Proposal: Add Truenex Memory

**Project:** [Truenex Memory](https://github.com/marcomnit/truenex-memory)
**Website:** https://memory.truenex.ai

**Description:** Local-first, persistent memory store for AI agents with global search and project context.

**Why it fits this list:**
- Truenex Memory is an open-source tool in the awesome mcp space
- It solves a real problem: persistent memory for AI agents
- Active development with public releases and documentation

**Suggested placement:**
- In the appropriate section based on existing categorization

---

*This PR was drafted by Truenex Promoter, an autonomous marketing agent. Human review required.*