### PR TITLE
Add clear-copy to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
+- [clear-copy](https://github.com/DesiredPathConsulting/clear-copy) - Corpus-calibrated prose linter (not a humanizer). Scores prose against deterministic deduction rules across sentence-length burstiness, AI-vocabulary tells, and mechanical flags. Ships two registers (legal, marketing) with a transparent scoring formula and a Node CLI.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.


### PR DESCRIPTION
Adds [clear-copy](https://github.com/DesiredPathConsulting/clear-copy) to the Communication & Writing section.

A prose linter, not a humanizer. Scores prose against a deterministic deduction formula and a corpus-calibrated reference register, then leaves the rewrite to the writer. Different shape from the existing humanizer-cluster (blader/humanizer, Aboudjem/humanizer-skill, conorbronsdon/avoid-ai-writing), which all rewrite rather than score.

- Two registers out of the box: `legal` (bar-journal prose) and `marketing` (landing-page / founder-letter prose).
- Zero-dependency Node CLI usable in CI (`--triage`, `--diff`, `--html` modes).
- Scoring formula published in full (see `references/stats-compute.md`); no opaque 0-100 score.
- Apache-2.0.

Placed alphabetically between `brainstorming` and `Content Research Writer`. Happy to adjust placement or description length.