### PR TITLE
Add polis-protocol skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
+- [polis-protocol](https://github.com/yehudalevy-collab/polis-protocol) - Markdown coordination protocol for multi-vendor agent teams. Signed capability cards, ε-greedy bandit routing that learns from settled contracts, chavruta paired review, self-amending constitution. Vendor-agnostic across Claude Code, Codex, Gemini. *By [@yehudalevy-collab](https://github.com/yehudalevy-collab)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
 


### PR DESCRIPTION
## Summary

Adds **polis-protocol** to **Skills → Collaboration & Project Management** (alphabetical position between `outline` and `review-implementing`).

## What problem it solves

When agents from different vendors (Claude Code, Codex, Gemini CLI, etc.) work on the same long-lived project, they have no shared state or learning. Each session starts cold. Polis Protocol gives them a shared markdown "polis" — capability cards, contracts, bandit-routed assignment, settlement lessons that feed back into routing.

## Who uses this workflow

Teams running multi-vendor agent setups on a shared codebase or knowledge base — research teams, software teams using Claude+Codex+Gemini in parallel, anyone who wants their agent collaboration patterns to compound over time rather than reset each session.

## Example

After settling a contract about Spanish localization, a `madrij-not-líder` lesson updates `routing_stats.yml`. The next localization contract routes to a different citizen — bandit learning from real outcomes, not static declarations.

## Attribution

Original work by Yehuda Levy. MIT licensed.

Repo: https://github.com/yehudalevy-collab/polis-protocol
Worked example: https://github.com/yehudalevy-collab/polis-protocol/tree/main/examples/research-team
