### PR TITLE
Add winston-coach to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [winston-coach](https://github.com/Anastasios3/winston-coach) - Apply Patrick Winston's MIT framework (How to Speak + Make It Clear) to any talk, deck, report, email, or pitch. Mandatory humanizer pass strips AI tells from every written output. *By [@Anastasios3](https://github.com/Anastasios3)*
 
 ### Creative & Media
 


### PR DESCRIPTION
Adds **winston-coach** — a Claude skill that applies Patrick Winston's framework from MIT's "How to Speak" lecture and his book *Make It Clear: Speak and Write to Persuade and Inform* to any writing or speaking task.

**What it does**
- 14 Winston tools: Empowerment Promise, VSN-C structure (Vision-Steps-News-Contributions), Winston's Star (Symbol-Slogan-Surprise-Salient-Story), the four engagement heuristics, slide hygiene, six standard openings for written work, the abstract checklist, broken-glass outline, surface clues for skimmers, plus format-specific guidance.
- Routes by format: talks, decks, reports, memos, emails, blog posts, pitches, recommendation letters, abstracts, press releases, papers, more.
- Mandatory humanizer pass on every written output — strips em-dash overuse, AI vocabulary, copula avoidance, synonym cycling, fake parallelisms, the usual tells.
- Eats its own dog food: the skill content itself avoids the patterns it strips.

**Why it might be useful**
Winston's "How to Speak" has ~19M views on YouTube and is widely cited but rarely applied consistently. Packaging the framework as a Claude skill means it auto-applies on every writing or speaking task without having to re-read the source. The skill also corrects several common popularization errors (e.g., "salient" means *sticks out*, not *important*; the book co-author is Karen Prendergast not "Prensky"; the book was finished by Winston himself in 2020, not posthumously by someone else).

**Repo:** https://github.com/Anastasios3/winston-coach
**License:** CC BY-NC-SA 4.0
**Working SKILL.md with YAML frontmatter:** yes
**Author:** [@Anastasios3](https://github.com/Anastasios3)

Happy to adjust the entry placement or wording if needed.
