### PR TITLE
Add anydesign skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Creative & Media
 
+- [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.


### PR DESCRIPTION
## What this skill does

`anydesign` analyzes any visual source — image, URL, or Figma file — and produces a structured `design.md` with full token system, component inventory, and reconstruction notes. The output is portable: feed it to v0, Lovable, Cursor, Claude Code, Bolt, or hand it to a designer.

## What problem it solves

"Describe this design to AI" prompts produce vague output ("modern and clean") instead of actionable tokens. Existing design.md approaches require hand-curation per brand. `anydesign` auto-extracts the live system: 808 CSS variables pulled verbatim from vercel.com in 3 seconds, full Geist token map, real screenshots, WCAG contrast report.

## Who uses this workflow

- Designers replicating a reference for a client (analyze Linear → brief Notion doc)
- Devs briefing v0 / Lovable / Cursor from scratch (no more 50-line prompts)
- Teams auditing Figma vs production (cross-reference declared tokens vs live CSS)
- Anyone documenting a legacy product's implicit visual language

## How to use

After installation, ask Claude any of:
- "Analyze the design of https://stripe.com"
- "Extract the design system from this screenshot" (attach image)
- "Document the visual language of this Figma file" (Figma MCP required)

The skill activates automatically — no explicit slash-command needed.

## Example output

Live, runnable example at https://github.com/uxKero/anydesign/tree/main/examples/vercel-landing — real end-to-end run against vercel.com, including:
- 11KB design.md with 6 analytical layers
- 6KB design-tokens.json in W3C DTCG format
- 1.5KB design-a11y.md WCAG report
- 233KB real desktop screenshot

## Companion scripts (optional)

Six standalone Python scripts that also work without Claude:
- `extract_css_vars.py` — pull CSS custom properties from any URL (stdlib)
- `capture_site.py` — multi-viewport Playwright captures with cookie banner auto-dismiss
- `extract_colors.py` — Pillow-based dominant color extraction from images
- `check_contrast.py` — WCAG 2.1 contrast checker (stdlib)
- `lint_design_md.py` — validates design.md against the spec (stdlib)
- `verify_design.py` — audits design-tokens.json against a live URL, reports drift (stdlib)

## Inspired by

The DESIGN.md format concept introduced by Google Stitch and popularized by VoltAgent. This implementation differentiates via: real auto-extraction (vs hand-curated catalogs), W3C DTCG token format (vs custom YAML), confidence markers, WCAG report, reconstruction notes, and the audit tool for live drift detection.

## Tested on

- Claude Code (Skills folder at `~/.claude/skills/`)
- Claude.ai web app (uploaded as `.zip` via Settings → Skills)

Skill source repository: https://github.com/uxKero/anydesign