### PR TITLE
Add caveman-plan skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Collaboration & Project Management
 
+- [caveman-plan](https://github.com/spikeon/caveman-plan) - Large-project planning workflow: Epic → Plans → Hunts → Inventory with mandatory Boss checkpoints between phases. Install via `npx skills add spikeon/caveman-plan`. Built on [caveman](https://github.com/JuliusBrussee/caveman) + [superpowers-plan](https://github.com/obra/superpowers). *By [@spikeon](https://github.com/spikeon)*
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## Summary
Adds [caveman-plan](https://github.com/spikeon/caveman-plan) — a large-project planning skill with Epic → Plans → Hunts → Inventory workflow and mandatory Boss checkpoints between phases.

## Install
```bash
npx skills add spikeon/caveman-plan -g -y
```

## Test plan
- [x] Skill repo is public with valid `skills/caveman-plan/SKILL.md`
- [x] Installs via `npx skills add spikeon/caveman-plan`
- [x] Listed on [Agent Skill Hub](https://agentskillhub.dev/) as `spikeon/caveman-plan`

Made with [Cursor](https://cursor.com)