### PR TITLE
Update anydesign entry: add Claude Code + claude.ai/design

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Creative & Media
 
-- [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
+- [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` (design system + component inventory + reconstruction notes) — portable to v0, Lovable, Cursor, Claude Code, or **claude.ai/design** via the bundled exporter. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.


### PR DESCRIPTION
## Summary

Updates the `anydesign` entry under **Creative & Media** to reflect v0.4.0 portability.

**Before:**
> portable to v0, Lovable, Cursor or any AI builder

**After:**
> portable to v0, Lovable, Cursor, Claude Code, or **claude.ai/design** via the bundled exporter

## Why

[anydesign v0.4.0](https://github.com/uxKero/anydesign/releases/tag/v0.4.0) ships `scripts/export_for_claude_design.py`, which packages a `design.md` + `design-tokens.json` into a multi-format bundle (PPTX, DOCX, CSS, Tailwind config) ready to upload as "brand and product assets" during [Claude Design](https://claude.ai/design) setup.

This is currently the only path to get a captured design system **persistently** into Claude Design's org-scoped design system layer — pasting `design.md` as a prompt only works for a single project.

## Test plan

- [x] No formatting / style drift from neighboring entries
- [x] Markdown renders cleanly (single line, no broken syntax)
- [x] Links resolve (anydesign repo, @uxKero handle, claude.ai/design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)