### PR TITLE
Add Humanize Text skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
+- [Humanize Text](./humanize-text/) - Improves AI-generated drafts by preserving meaning while making the writing more natural, varied, and reader-friendly. *By [@lynote-ai](https://github.com/lynote-ai)*
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.

--- a/humanize-text/SKILL.md
+++ b/humanize-text/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: humanize-text
+description: Improve AI-generated drafts by preserving meaning while making the writing more natural, varied, and reader-friendly.
+---
+
+# Humanize Text
+
+Use this skill when a user wants to polish an AI-generated draft so it reads more naturally while keeping the original meaning intact.
+
+## When to Use This Skill
+
+- Polish AI-generated essays, blog posts, articles, emails, or documentation.
+- Reduce repetitive phrasing and overly uniform sentence rhythm.
+- Make a draft clearer, warmer, and more reader-friendly without changing the core message.
+
+## What This Skill Does
+
+1. **Preserve meaning**: Keep facts, claims, citations, and user intent intact.
+2. **Improve rhythm**: Vary sentence length, transitions, and paragraph flow.
+3. **Polish wording**: Replace stiff or robotic phrasing with natural language.
+4. **Check the result**: Review the rewrite for semantic drift, missing details, and tone mismatch.
+
+## How to Use
+
+### Basic Usage
+
+```text
+Humanize this draft while preserving the original meaning:
+<paste text>
+```
+
+### With Constraints
+
+```text
+Humanize this academic paragraph. Keep citations unchanged, avoid adding new claims, and make the tone natural but professional:
+<paste text>
+```
+
+## Optional Tooling
+
+For a reference open-source workflow and web tool, see [Lynote AI Humanize Text](https://github.com/lynote-ai/humanize-text).
+
+## Example
+
+**User**: "Humanize this product paragraph but keep it concise."
+
+**Output**:
+
+```text
+A polished version that keeps the same claims, removes repetitive wording, and uses more natural sentence rhythm.
+```
+
+## Tips
+
+- Ask for the target audience and tone when the request is ambiguous.
+- Preserve technical terms, citations, and exact numbers.
+- Do not claim that text is undetectable or guaranteed to pass any detector.
+- For high-stakes writing, tell the user to review the final draft carefully.
+
+**Inspired by:** Common editing workflows for polishing AI-generated writing, with reference implementation from [Lynote AI Humanize Text](https://github.com/lynote-ai/humanize-text).


### PR DESCRIPTION
Adds a Humanize Text skill for polishing AI-generated drafts while preserving meaning.

Problem solved: users often need a repeatable editing workflow that improves rhythm, wording, and clarity without changing facts or citations.

Who uses it: writers, students, content teams, and developers polishing AI-drafted documentation or articles.

Inspiration: common AI draft editing workflows, with a reference open-source implementation from Lynote AI Humanize Text.

Project context update (2026-06-04):
- GitHub: 1,069 stars and 58 forks.
- Current version highlights four open-source text humanization approaches: multilingual translation chains, multi-turn LLM rewriting, detection-guided feedback loops, and mixed-engine translation.
- The repository now includes usage paths for developers and workflow builders, with topics including n8n, Dify, and OpenClaw.
- Public social/web tracking has surfaced recent X/social mentions discussing the repository; I am keeping the submitted list entry concise and factual to match this awesome list's style.

Disclosure: I am submitting this on behalf of the Lynote project.