### PR TITLE
fix: require explicit approval in organizer skills

### DIFF
--- a/developer-growth-analysis/SKILL.md
+++ b/developer-growth-analysis/SKILL.md
@@ -193,8 +193,10 @@ When a user requests analysis of their developer growth or coding patterns from 
    Use Rube MCP to send the complete report to the user's own Slack DMs:
 
    - Check if Slack connection is active via RUBE_SEARCH_TOOLS
-   - If not connected, use RUBE_MANAGE_CONNECTIONS to initiate Slack auth
-   - Use RUBE_MULTI_EXECUTE_TOOL to send the report as a formatted message:
+   - If not connected, ask the user before starting Slack auth
+   - Before sending, show the resolved Slack workspace/user and a short report preview; redact secrets and private project/customer details unless explicitly included
+   - Wait for explicit approval
+   - Use RUBE_MULTI_EXECUTE_TOOL to send the approved report as a formatted message:
      - Send the report title and period as the first message
      - Break the report into logical sections (Summary, Improvements, Strengths, Actions, Resources)
      - Format each section as a well-structured Slack message with proper markdown

--- a/file-organizer/SKILL.md
+++ b/file-organizer/SKILL.md
@@ -196,22 +196,23 @@ When a user requests file organization help:
 
 6. **Execute Organization**
    
-   After approval, organize systematically:
+   After approval in a new user message, organize systematically:
    
    ```bash
    # Create folder structure
    mkdir -p "path/to/new/folders"
    
-   # Move files with clear logging
-   mv "old/path/file.pdf" "new/path/file.pdf"
+   # Move files without overwriting and with clear logging
+   mv -n "old/path/file.pdf" "new/path/file.pdf"
    
    # Rename files with consistent patterns
    # Example: "YYYY-MM-DD - Description.ext"
    ```
    
    **Important Rules**:
-   - Always confirm before deleting anything
-   - Log all moves for potential undo
+   - Always confirm before deleting anything; deletion needs its own explicit confirmation
+   - Log all moves before executing them
+   - Use `mv -n` or equivalent no-clobber behavior; never overwrite silently
    - Preserve original modification dates
    - Handle filename conflicts gracefully
    - Stop and ask if you encounter unexpected situations
@@ -430,4 +431,3 @@ Documents folder.
 - Cleaning up before storage cleanup
 - Organizing shared team folders
 - Structuring new project directories
-

--- a/invoice-organizer/SKILL.md
+++ b/invoice-organizer/SKILL.md
@@ -192,16 +192,16 @@ When a user requests invoice organization:
    Process [X] files? (yes/no)
    ```
    
-   After approval:
+   After approval in a new user message:
    ```bash
    # Create folder structure
    mkdir -p "Invoices/2024/Software/Adobe"
    
    # Copy (don't move) to preserve originals
-   cp "original.pdf" "Invoices/2024/Software/Adobe/2024-03-15 Adobe - Invoice - Creative Cloud.pdf"
+   cp -n "original.pdf" "Invoices/2024/Software/Adobe/2024-03-15 Adobe - Invoice - Creative Cloud.pdf"
    
-   # Or move if user prefers
-   mv "original.pdf" "new/path/standardized-name.pdf"
+   # Only move if the user explicitly requested moving originals in a separate message
+   mv -n "original.pdf" "new/path/standardized-name.pdf"
    ```
 
 6. **Generate Summary Report**
@@ -443,4 +443,3 @@ For unusual receipt formats:
 - Archiving old financial records
 - Preparing for audits
 - Tracking subscription costs over time
-


### PR DESCRIPTION
## Description

This updates three existing organizer skills so file moves, invoice organization, and Slack delivery require approval of the concrete plan before execution.

## Real-world use case

These skills automate personal files and private development reports. That is useful, but the side effects are real: files can be moved or renamed, originals can disappear from their old location, and a report can leave the local machine via Slack.

## Problem it solves

The fragile pattern is:

1. Present a broad organization or delivery plan.
2. Treat a generic "yes" as approval for many concrete operations.
3. Use commands that can overwrite or move originals.

For example, `file-organizer` previously showed:

```bash
mv "old/path/file.pdf" "new/path/file.pdf"
```

If the destination already exists, that is not the same operation the user reviewed in the plan. The patch switches examples to no-clobber operations and requires logging before execution.

## Who uses this workflow

- Users cleaning large folders such as Downloads or Desktop.
- Users preparing invoices and receipts for taxes or reimbursement.
- Users sending a private developer-growth report to their own Slack DM.

## Changes

- `file-organizer/SKILL.md`
  - require approval in a new user message before execution
  - use `mv -n`
  - log moves before executing
  - require a separate delete confirmation
- `invoice-organizer/SKILL.md`
  - make copy-only the default
  - use `cp -n`
  - allow moves only when explicitly requested
- `developer-growth-analysis/SKILL.md`
  - show Slack workspace/user target before delivery
  - do not start Slack auth during delivery without a separate request
  - redact secrets and private project/customer details unless explicitly included by the user

## Testing

Checked locally after patch:

```bash
git diff --check origin/master..HEAD
git diff --stat origin/master..HEAD
rg -n "approval in a new user message|mv -n|cp -n|Slack workspace/user|Do not start Slack auth|Redact secrets" \
  file-organizer/SKILL.md invoice-organizer/SKILL.md developer-growth-analysis/SKILL.md
```

Observed output:

```text
$ git diff --check origin/master..HEAD
# no output

$ git diff --stat origin/master..HEAD
 developer-growth-analysis/SKILL.md |  6 ++++--
 file-organizer/SKILL.md            | 12 ++++++------
 invoice-organizer/SKILL.md         |  9 ++++-----
 3 files changed, 14 insertions(+), 13 deletions(-)

$ rg -n "approval in a new user message|mv -n|cp -n|Slack workspace/user|Do not start Slack auth|Redact secrets" \
  file-organizer/SKILL.md invoice-organizer/SKILL.md developer-growth-analysis/SKILL.md
invoice-organizer/SKILL.md:195:   After approval in a new user message:
invoice-organizer/SKILL.md:201:   cp -n "original.pdf" "Invoices/2024/Software/Adobe/2024-03-15 Adobe - Invoice - Creative Cloud.pdf"
file-organizer/SKILL.md:199:   After approval in a new user message, organize systematically:
file-organizer/SKILL.md:206:   mv -n "old/path/file.pdf" "new/path/file.pdf"
file-organizer/SKILL.md:215:   - Use `mv -n` or equivalent no-clobber behavior; never overwrite silently
developer-growth-analysis/SKILL.md:197:   - Before sending, show the resolved Slack workspace/user and a short report preview; redact secrets and private project/customer details unless explicitly included
```

### Behavior proof trace

I ran this against the patched checkout on branch `skill-safety-gates`, commit `a46ba1b`. The trace uses the repo's validation/package scripts plus temporary mock folders. It does not touch real user files and does not start Slack auth or send anything.

Native validation:

```text
$ python3 skill-creator/scripts/quick_validate.py file-organizer
Skill is valid!
$ python3 skill-creator/scripts/quick_validate.py invoice-organizer
Skill is valid!
$ python3 skill-creator/scripts/quick_validate.py developer-growth-analysis
Skill is valid!

$ python3 skill-creator/scripts/package_skill.py file-organizer "$TMP/packages"
Added: file-organizer/SKILL.md
Successfully packaged skill to: .../file-organizer.zip
$ python3 skill-creator/scripts/package_skill.py invoice-organizer "$TMP/packages"
Added: invoice-organizer/SKILL.md
Successfully packaged skill to: .../invoice-organizer.zip
$ python3 skill-creator/scripts/package_skill.py developer-growth-analysis "$TMP/packages"
Added: developer-growth-analysis/SKILL.md
Successfully packaged skill to: .../developer-growth-analysis.zip
```

Loaded patched guard lines:

```text
LOADED file-organizer/SKILL.md
MATCH file-organizer/SKILL.md:199: approval in a new user message
MATCH file-organizer/SKILL.md:206: mv -n
MATCH file-organizer/SKILL.md:215: Use `mv -n` or equivalent no-clobber behavior

LOADED invoice-organizer/SKILL.md
MATCH invoice-organizer/SKILL.md:195: After approval in a new user message
MATCH invoice-organizer/SKILL.md:200: Copy (don't move) to preserve originals
MATCH invoice-organizer/SKILL.md:201: cp -n
MATCH invoice-organizer/SKILL.md:203: Only move if the user explicitly requested moving originals

LOADED developer-growth-analysis/SKILL.md
MATCH developer-growth-analysis/SKILL.md:197: Before sending, show the resolved Slack workspace/user
MATCH developer-growth-analysis/SKILL.md:196: ask the user before starting Slack auth
MATCH developer-growth-analysis/SKILL.md:197: redact secrets and private project/customer details
```

file-organizer rehearsal:

```text
Prompt before mutation: No deletions. No overwrite. Ready to proceed? (yes/no/modify)
Before approval tree changed: False
After approved mv -n:
70d35f763103331c6a12c66a8f13777721149c351a9089c5eca7fc30ab451011  Inbox/photo.png
99acd61509778379d99fbece470042da3336ddc87bc201be8b3efffb05286761  Inbox/report.pdf
948c3740b3e1bfde36d2a1b2a5658d0ed1680d8622e7ccd67d3426d03a5969a4  Organized/Documents/report.pdf
5351164e67b4bbd6bf58dee06df89f20df5858c934f220f9155bcd3d6e997d80  Organized/Images/photo.png
Existing report preserved: True
Conflicting report source still present: True
```

invoice-organizer rehearsal:

```text
Prompt before mutation: Default action after approval: copy with cp -n, preserve originals, no overwrite. Process 2 files? (yes/no)
Before approval tree changed: False
After approved cp -n:
ce0e7b5579bab12f1f6805a34d99e58312366333d8df7bab75415b89140c9075  Invoices/2026/Office/Staples/2026-05-02 Staples - Receipt - Office Supplies.jpg
1ec43dfefa0b74a1a562be6b6d9f9333e1d79b247fe3f6d98d0178d574b49943  Invoices/2026/Software/Adobe/2026-05-01 Adobe - Invoice - Creative Cloud.pdf
ce0e7b5579bab12f1f6805a34d99e58312366333d8df7bab75415b89140c9075  receipts-to-sort/IMG_1001.jpg
ed7969e5f8f9ceb1ba916eaed21e69614569899566d13c5bc1f112dc3716b68b  receipts-to-sort/adobe_may.pdf
Original Adobe remains: True
Preexisting Adobe destination preserved: True
New Staples copy created: True
```

developer-growth-analysis:

```text
Resolved Slack preview: workspace="Dry Run Engineering Workspace"; user="@hanzhi"; delivery="DM to self"; auth_status="not checked in dry run".
Report preview: Recent work focused on TypeScript async debugging and cautious shell automation; private tokens/customer names redacted.
Stop point: awaiting explicit user approval before Slack auth or send.
```

Command and external mutation logs:

```text
Command log:
mv -n .../file-organizer/Inbox/report.pdf .../file-organizer/Organized/Documents/report.pdf
mv -n .../file-organizer/Inbox/photo.png .../file-organizer/Organized/Images/photo.png
cp -n .../invoice-organizer/receipts-to-sort/adobe_may.pdf .../invoice-organizer/Invoices/2026/Software/Adobe/2026-05-01 Adobe - Invoice - Creative Cloud.pdf
cp -n .../invoice-organizer/receipts-to-sort/IMG_1001.jpg .../invoice-organizer/Invoices/2026/Office/Staples/2026-05-02 Staples - Receipt - Office Supplies.jpg

External/mutation log:
<empty>

PASS: validator and packaging completed; temp-only mv -n/cp -n preserved existing destinations; no delete, overwrite, Slack auth, Rube, network, or Slack send command was executed.
```

## Risks

- These skills operate on local files and private delivery targets. If approval is not tied to the concrete plan, an agent can move the wrong file set, overwrite or hide useful originals, or send a private report to the wrong Slack workspace/user.
- This PR is instruction-level hardening, not runtime enforcement. Direct shell/Rube calls or agents that ignore the skill text can still perform the underlying operation.
- No-clobber examples reduce overwrite risk, but skipped operations still require review through the move/copy log so conflicts are handled intentionally.
