### PR TITLE
Add the-knowledge-guy under Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [the-knowledge-guy](https://github.com/vitalysim/the-knowledge-guy) - Turn books (PDF/EPUB) into Claude Code skills, then ask any question across your whole bookshelf, walk through topics with quizzes, or skim a book in one scroll. Eleven router modes plus a five-stage map-reduce ingest pipeline. *By [@vitalysim](https://github.com/vitalysim)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Hi — adding a skill pair I built and use daily.

**[the-knowledge-guy](https://github.com/vitalysim/the-knowledge-guy)** is two source skills that compose:

- `/book-to-skill` — a five-stage map-reduce pipeline that turns any PDF or EPUB into a two-tier Claude Code skill (~10 min per 600-page book). Plumbing in Python, intelligence in Claude — every act of understanding is an LLM call.
- `/the-knowledge-guy` — the auto-discovering router across every installed book-skill, with eleven modes: `ask`, `walk` (interactive curriculum + quizzes, resumable), `nutshell`, `library`, `comparison`, `cheatsheet`, `glossary`, `concept-map`, `toolkit`, `ingest`, `resume`.

Every output also writes a self-contained HTML artifact under a shared design system, so the nutshell of one book and a cross-book synthesis essay both feel like members of the same product family.

I placed it next to [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code) in Productivity & Organization — they're spiritually adjacent (knowledge networks vs queryable bookshelf). Happy to move it if you'd rather it lived elsewhere.

A few notes that might help the review:

- MIT-licensed.
- Works natively on Claude Code, Claude Desktop, claude.ai, the Anthropic API, OpenAI Codex CLI, and GitHub Copilot — all consume the same `SKILL.md` format as of May 2026.
- No network calls outside Anthropic. No telemetry. Requires `uv` for a per-skill Python venv (PyMuPDF + ebooklib + beautifulsoup4 + pypdf) — install path is documented in the README.
- Honest scope: optimised for 50–500 page technical / non-fiction prose; cookbooks and dense math extract less cleanly.

Repo: https://github.com/vitalysim/the-knowledge-guy

Thanks for keeping this list. Let me know if anything needs tweaking.
