### PR TITLE
Add career-ops-evaluator skill (companion to tailored-resume-generator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
+- [Career-Ops Evaluator](./career-ops-evaluator/) - Structured A-F job offer evaluation across 10 weighted dimensions with a 6-block analysis output. Companion to Tailored Resume Generator: evaluate first, tailor only offers scoring ≥4.0. Production reference at github.com/santifer/career-ops (46K ⭐).
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.

--- a/career-ops-evaluator/LICENSE.txt
+++ b/career-ops-evaluator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/career-ops-evaluator/SKILL.md
+++ b/career-ops-evaluator/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: career-ops-evaluator
+description: Structured A-F job offer evaluation across 10 weighted dimensions. Before tailoring your resume to a JD, decide whether the offer is worth your time. Filter out offers below 4.0/5 before applying. Production implementation at github.com/santifer/career-ops (46K ⭐).
+---
+
+# Career-Ops Evaluator
+
+A structured framework for evaluating job offers **before** applying — a filter, not a spray-and-pray tool. Most candidates spend hours customizing resumes for offers they shouldn't have applied to in the first place. This skill flips the workflow: rank offers first, then tailor only the top ones.
+
+> **Companion skill**: pair this with [tailored-resume-generator](../tailored-resume-generator) — evaluate first, then tailor only for offers scoring ≥4.0.
+
+## When to Use This Skill
+
+- You have 5+ job postings in your pipeline and need to decide where to spend your application effort
+- You are not sure whether an offer is "good enough" relative to your other options
+- A recruiter reached out and you want a structured way to assess fit before responding
+- You want to track applications over time with comparable, structured data
+- You suspect ATS keyword-matching is making you waste effort on poor-fit roles
+- You are negotiating and need a defensible scoring rationale ("Here is why offer A is a stronger match than offer B")
+
+## What This Skill Does
+
+Given a job description (JD) and your background, produces a structured evaluation across 10 weighted dimensions, returning a single A-F letter grade plus a 6-block analysis you can act on.
+
+### The 10 evaluation dimensions
+
+| Dim | What it measures | Default weight |
+|---|---|---|
+| 1. Role-level match | Is the seniority above, at, or below your current level? | 15% |
+| 2. Domain alignment | How close is the problem space to your strongest narrative? | 15% |
+| 3. Technical fit | Skill stack overlap with your CV | 10% |
+| 4. Compensation | Total comp vs your floor / market band | 15% |
+| 5. Geographic fit | Remote / hybrid / on-site vs your constraints | 8% |
+| 6. Company stage | Pre-seed → Series C → Public, vs your risk appetite | 7% |
+| 7. Manager / team signal | What does the hiring manager's profile tell you? | 8% |
+| 8. Growth trajectory | Promotion path, mentorship, IC ladder | 7% |
+| 9. Cultural fit | Public artifacts: blog, OSS, principles docs | 8% |
+| 10. Exit optionality | Where does this role take you in 2-3 years? | 7% |
+
+Weights are adjustable — a founder-track candidate weights company stage higher; a senior IC weights technical fit higher.
+
+### Scoring
+
+- Each dimension scored 1-5
+- Weighted average → 0.0-5.0 score
+- Letter grade mapping: **A** ≥4.5 / **B** 4.0-4.5 / **C** 3.5-4.0 / **D** 3.0-3.5 / **F** <3.0
+- **Rule of thumb**: do not apply to offers scoring below 4.0 unless they unlock a specific narrative.
+
+### The 6-block analysis output
+
+For every evaluation the skill produces:
+
+1. **Role summary** — what this role is in 3 sentences, including unstated implications
+2. **CV match** — which 3-5 bullets from your CV are the strongest signals; what you should down-weight or hide
+3. **Level strategy** — is this a stretch role, lateral, or step-down? What language signals their level expectation?
+4. **Comp research** — market band for this title + location + stage, plus a recommended ask
+5. **Personalization angle** — what would make your application memorable vs the median candidate
+6. **Interview prep** — the 2-3 likely behavioral questions for this role; STAR+R stories you should rehearse
+
+## How to Use
+
+### Basic usage
+
+Provide a JD and your background, ask for the evaluation:
+
+```
+Evaluate this offer with career-ops-evaluator.
+
+Job Description:
+[paste full JD including company, role, location, comp band if listed]
+
+My Background:
+- 10 years backend engineering, last 4 as Staff at FinTech unicorn
+- Strong Python + Go; some Rust on the side
+- Led platform migration for 200-engineer org
+- Located in Madrid, prefer remote-first, EU timezone
+- Floor comp: €130K base
+```
+
+The skill responds with:
+- Per-dimension scores with one-line rationales
+- Weighted total + letter grade
+- The 6-block analysis
+- A clear apply / skip / negotiate-first recommendation
+
+### Comparing multiple offers
+
+Paste up to 5 JDs at once. The skill returns a ranked comparison table plus per-offer evaluations, plus an "if you can only apply to 2 of these, pick X and Y because…" recommendation.
+
+### Adjusting weights
+
+If the defaults don't match your career stage, declare custom weights:
+
+```
+Use these dimension weights:
+- Role-level match: 25%
+- Domain alignment: 20%
+- Technical fit: 5%
+- Compensation: 10%
+- Geographic fit: 5%
+- Company stage: 15%
+- Manager/team: 10%
+- Growth trajectory: 5%
+- Cultural fit: 3%
+- Exit optionality: 2%
+```
+
+Total must sum to 100%. The skill validates and applies the override.
+
+### Re-evaluating after recruiter call
+
+After a recruiter screen you usually learn comp band, team size, and growth plans. Re-run the evaluation with the new signals — frequently a C becomes a B or vice versa.
+
+```
+Re-evaluate offer #3 with these updates from the recruiter call:
+- Comp band confirmed: €160-180K base + 0.15-0.30% equity
+- Team is currently 4 engineers, hiring to 8 by EOY
+- Manager has been there 18 months, was previously at Stripe
+- They will sponsor relocation but require 2 days/week in-office in Berlin
+```
+
+## Output Format
+
+The skill returns a structured Markdown report:
+
+```markdown
+# Evaluation — [Company] / [Role]
+
+**Overall**: 4.2/5 (B) — Strong apply
+
+## Dimension scores
+
+| # | Dimension | Score | Weighted | Rationale |
+|---|---|---:|---:|---|
+| 1 | Role-level match | 4 | 0.60 | Senior role, you are mid-Staff. Slight downlevel. |
+| 2 | Domain alignment | 5 | 0.75 | Payments infra, exact match to your last 4 years. |
+| ... |
+
+## 6-block analysis
+
+### 1. Role summary
+[3 sentences]
+
+### 2. CV match
+- Strongest bullets to surface: ...
+- Bullets to hide or rephrase: ...
+
+[etc through all 6 blocks]
+
+## Recommendation
+Apply. Personalize the cover note around the platform migration story.
+Negotiate from a base of €165K — that's the upper end of the market band.
+```
+
+## Why This Approach
+
+**The asymmetric mistake**: most candidates optimize the wrong side of the funnel. They write 50 tailored resumes and apply to 50 offers, then wonder why they got 3 interviews. The honest math says they should have applied to 8 offers and gotten 5 interviews.
+
+A structured filter changes the optimization. You spend 15 minutes per offer scoring it, then spend 90 minutes on the top 3 — instead of 30 minutes on each of 50.
+
+This skill encodes the methodology that produced 740+ structured evaluations across an open-source production deployment ([github.com/santifer/career-ops](https://github.com/santifer/career-ops)), with the outcome of a Head of Applied AI role landed and dozens of contributors building on the same patterns.
+
+## Provenance
+
+- **Production reference**: [github.com/santifer/career-ops](https://github.com/santifer/career-ops) — 46,511 stars, MIT, 9 README languages
+- **Case study**: [santifer.io/career-ops-system](https://santifer.io/career-ops-system) — 740+ offers evaluated, 100+ tailored CVs, 1 dream role landed
+- **License**: Apache-2.0 (same as Composio's skills)
+
+This SKILL.md is a self-contained methodology — it does not require installing career-ops to use. The skill teaches the framework; career-ops is one production implementation among many possible ones.


### PR DESCRIPTION
Adds **`career-ops-evaluator`** — a new skill in `Productivity & Organization` that complements the existing [`tailored-resume-generator`](./tailored-resume-generator/).

### Why this skill exists

The current `tailored-resume-generator` solves the **apply-side** of the funnel. This new skill solves the **filter-side** that has to come first: deciding whether an offer is worth tailoring a resume for. The two are designed to be used together:

> Evaluate with `career-ops-evaluator` → if score ≥4.0/5, tailor with `tailored-resume-generator` → ignore the rest.

This pairs with Composio's existing positioning — provide reusable, composable skills, not redundant ones.

### What it provides (standalone — no external install required)

- 10-dimension weighted scoring framework (role-level match, domain alignment, technical fit, compensation, geographic fit, company stage, manager signal, growth trajectory, cultural fit, exit optionality)
- A-F letter grading mapped from weighted 0-5 score
- 6-block analysis output (role summary, CV match, level strategy, comp research, personalization, interview prep)
- Configurable dimension weights for different career stages (founder-track, senior IC, etc.)
- Multi-offer comparison mode for ranking 5+ JDs side by side
- Re-evaluation mode for post-recruiter-screen updates

### Real-world provenance

The methodology was extracted from [santifer/career-ops](https://github.com/santifer/career-ops) — a production Claude Code skill collection that has been used to:

- Evaluate **740+ job offers** with structured A-F scoring
- Generate **100+ tailored CVs** (the apply-side, handled by the existing Composio skill)
- Land a **Head of Applied AI** role ([case study](https://santifer.io/career-ops-system))

Career-ops has **46,511 stars / 9,725 forks / 151 active issues** at time of submission, with an MIT-licensed Apache-2.0-compatible foundation.

### Conformance to CONTRIBUTING.md

- ✅ **Real use case** — 740+ evaluations in production
- ✅ **Standalone value** — SKILL.md teaches the methodology without requiring any external clone or paid tool
- ✅ **Non-promotional** — career-ops is referenced as one production implementation among possible ones; the skill itself is the framework
- ✅ **Well-documented** — clear When/What/How sections, structured Markdown output spec, multiple usage modes
- ✅ **Includes examples** — basic, comparison, weights override, re-evaluation
- ✅ **Safe** — no destructive operations, output-only
- ✅ **Portable** — works across Claude.ai, Claude Code, and API

### Files added

- `career-ops-evaluator/SKILL.md` — full skill spec (~170 lines)
- `career-ops-evaluator/LICENSE.txt` — Apache-2.0 (matches Composio convention)
- `README.md` — single-line entry in `Productivity & Organization` section, immediately before `Tailored Resume Generator` to make the pairing obvious