### PR TITLE
Add agency-agents-fork skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [agency-agents-fork](https://github.com/daehounan/agency-agents-fork) - Claude Code plugin: 163 specialist agent personas + 24 routing skills across 15 domains (engineering, design, finance, game-dev, marketing, paid-media, sales, support, testing, etc.). Ships Korean / Japanese Business Navigators, game-dev routing across Unity / Unreal / Godot / Roblox / Blender, XR / spatial routing, and `skill-routing-arbitrator` for disambiguating ~500 ecosystem skills. One-liner install via `claude --plugin-url <release-zip>`. Fork of msitarzewski/agency-agents with China-market agents excluded. *By [@daehounan](https://github.com/daehounan)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds `daehounan/agency-agents-fork` to Skills → Development & Code Tools.

## What this is

A Claude Code plugin bundle: 163 specialist agent personas + 24 routing skills + 16 NEXUS strategy playbooks. Fork of [msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents) with China-market agents excluded (22 files dropped) and Korean + Japanese Business Navigators added.

## Real-world use case

Agencies, consultancies, and multi-domain operators rarely need one specialist — they need ten in rapid sequence (marketing → finance → engineering → legal → support). This bundle ships pre-composed personas across 15 domains plus 24 routing skills that disambiguate across ~500 ecosystem skills (`ecc:*`, `anthropic-skills:*`, `engineering:*`, etc.).

## Differentiation vs `great_cto` (already in this section)

- `great_cto` = 7 SDLC subagents for one engineering team
- `agency-agents-fork` = 163 agents across 15 business domains, plus regional cultural intelligence (Korean / Japanese Business Navigators have no public equivalent I am aware of)

## Why it belongs here

- Real use case (multi-domain agency work), not speculative
- One-liner install — no clone, no PowerShell required (`claude --plugin-url <release-zip>`)
- 3 CI workflows green on every push (Lint Skills, audit-agent-refs, Build Plugin)
- Cross-reference audit enforced — 0 orphans across 180 backticked refs
- No outbound network calls (verified — see SECURITY.md)
- Does NOT require `--dangerously-skip-permissions`
- MIT licensed, attribution to upstream msitarzewski/agency-agents

## Resource age

Initial commits 2026-05-16, v1.2.0 tagged 2026-05-18. Well past the typical "one week public" minimum.

## Inspired by

[msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents) — upstream agent roster.
