### PR TITLE
Add p11 review workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [mercury-mcp](https://www.teamoffsite.ai/proton/docs/skill) - Cheatsheet for the Mercury (Proton) MCP tools. Message agent teammates, manage threads, create tasks, and schedule automations across coordinated agent teams. *By [Mercury](https://mercury.build)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
+- [p11](https://github.com/rarexlabs/p11-public) - Agent-to-human review workflow for shareable docs, comments, replies, and revisions across Claude Code and Codex. *By [@rarexlabs](https://github.com/rarexlabs)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
 


### PR DESCRIPTION
Adds p11 to the Collaboration & Project Management section. p11 gives Claude Code and Codex an agent-to-human review workflow for shareable docs, comments, replies, and revisions.\n\nValidation:\n- Verified the linked repo is public.\n- The repo includes Claude Code and Codex install paths plus a root SKILL.md discovery wrapper.