### PR TITLE
Add Clinical AI Agent Safety skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [Clinical AI Agent Skills](https://github.com/2023Anita/clinical-ai-agent-skills) - Evidence-first agent rules for clinical research, medical literature review, and healthcare-adjacent AI workflows. *By [@2023Anita](https://github.com/2023Anita)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## Summary

- Add `clinical-ai-agent-safety`, a portable Claude Skill for clinical research and healthcare-adjacent AI agent workflows.
- Add the skill to the Data & Analysis section of the README.

## Real-world use case

Clinicians and medical AI builders increasingly use agentic tools for literature review, research note cleanup, documentation, and coding support. This skill gives those agents practical safety boundaries: do not invent evidence, keep research separate from medical advice, preserve uncertainty, avoid sensitive data, and recommend human clinical review when claims could affect health decisions.

## Who uses this workflow

- Clinicians using AI agents for research synthesis or medical knowledge workflows
- Clinical researchers reviewing health claims, citations, or evidence summaries
- Builders documenting healthcare-adjacent AI demos or prototypes

## Attribution / inspiration

Inspired by my open-source rulebook, Clinical AI Agent Skills: https://github.com/2023Anita/clinical-ai-agent-skills

## Example usage

```
Use clinical-ai-agent-safety. Review this draft paragraph and identify unsupported medical claims, missing citations, overconfident clinical recommendations, and any places where uncertainty should be preserved.
```

## Verification

- `git diff --check`
- Confirmed the README link points to `./clinical-ai-agent-safety/`
