### PR TITLE
Add skill: multi-agent-coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
+- [multi-agent-coordination](https://github.com/RahimjonovBoburjon/multi-agent-coordination) - Coordinate multiple Claude Code terminals on one project: file locks, shared kanban, planner approval gate, configurable git workflow. *By [@RahimjonovBoburjon](https://github.com/RahimjonovBoburjon)*
 
 ### Security & Systems
 

--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [mercury-mcp](https://www.teamoffsite.ai/proton/docs/skill) - Cheatsheet for the Mercury (Proton) MCP tools. Message agent teammates, manage threads, create tasks, and schedule automations across coordinated agent teams. *By [Mercury](https://mercury.build)*
+- [multi-agent-coordination](https://github.com/RahimjonovBoburjon/multi-agent-coordination) - Coordinate multiple Claude Code terminals on one project: file locks, shared kanban, planner approval gate, configurable git workflow. *By [@RahimjonovBoburjon](https://github.com/RahimjonovBoburjon)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
-- [multi-agent-coordination](https://github.com/RahimjonovBoburjon/multi-agent-coordination) - Coordinate multiple Claude Code terminals on one project: file locks, shared kanban, planner approval gate, configurable git workflow. *By [@RahimjonovBoburjon](https://github.com/RahimjonovBoburjon)*
 
 ### Security & Systems
 


### PR DESCRIPTION
Adds the multi-agent-coordination skill to the **Collaboration & Project Management** section.

**Repo:** https://github.com/RahimjonovBoburjon/multi-agent-coordination

**What it does:** Coordinate multiple Claude Code terminals on one project — file locks (active_files.md), shared kanban (active_tasks.md), planner approval gate, configurable git workflow (Variant A feature-branches or Variant B single integration branch). Battle-tested in production.

**Features:**
- `/multi-agent-coordination:multi-agent-init` — interactive setup wizard (3-5 prompts via presets: Solo / Pair / Squad / Swarm / Custom)
- Role-tailored intros auto-generated for each terminal (planner `P` / developer `T1`, `T2`, ...)
- Stale-lock TTL detection and warn / auto-clear policies
- Smart CLAUDE.md detect on re-run: preserves user's existing sections, replaces legacy markers cleanly

**Latest release:** v1.0.3 — https://github.com/RahimjonovBoburjon/multi-agent-coordination/releases/tag/v1.0.3

MIT licensed. Links verified.