### PR TITLE
Add wrapup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [wrapup](https://github.com/ebaumel/claude-wrapup) - End-of-Session Ritual for Claude Code - so the next one starts with zero friction.
 
 ### Data & Analysis
 


### PR DESCRIPTION
Add wrapup skill

/wrapup — End-of-Session Ritual for Claude Code

A Claude Code slash command that closes every coding session cleanly — so the next one starts with zero friction.

/wrapup runs a structured end-of-session ritual automatically. Instead of relying on memory or manual updates, it reads your git diff, figures out what changed, and walks you through every closure step in order. Updates CLAUDE.md, DECISIONS.md, commits to git and code block to add to Claude memory.