### PR TITLE
Add network-optimizer-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
+- [network-optimizer-skill](https://github.com/6Kmfi6HP/network-optimizer-skill) - Safe cross-platform network diagnostics and reversible tuning for Claude Code, Codex, and Agent Skills. Includes macOS/Linux/Windows audits plus Linux BBR and BBR+FQ plan/apply/restore helpers. *By [@6Kmfi6HP](https://github.com/6Kmfi6HP)*
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 
 ### Assistive Technology


### PR DESCRIPTION
Adds network-optimizer-skill to Security & Systems.

Why it fits:
- Ships as a Claude Code plugin and Agent Skill, with Codex support too.
- Provides safe before/after network diagnostics across macOS, Linux, and Windows.
- Includes Linux BBR and BBR+FQ diagnose/plan/apply/restore helpers with backups and explicit approval requirements.

Repo: https://github.com/6Kmfi6HP/network-optimizer-skill