### PR TITLE
Add authsome skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Security & Systems
 
+- [authsome](https://github.com/agentrhq/authsome) - Local credential broker for Claude Code, Codex, and Cursor. A local proxy holds OAuth tokens and API keys; the agent's env only sees placeholders, so prompt-injections can't exfiltrate real secrets. *By [@agentrhq](https://github.com/agentrhq)*
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.


### PR DESCRIPTION
Hey, maintainer here. Adding authsome under Security & Systems.

authsome is a local credential broker for Claude Code, Codex, and Cursor. The narrow problem it addresses: agents accumulate 10+ long-lived API keys and OAuth tokens in `os.environ`, any tool they load can read those, and a prompt-injection can nudge the model into printing env contents into a transcript that gets logged downstream. There've been a few public incidents along these lines.

Mechanism is simple. A local HTTP proxy holds the real credentials. The agent's env has placeholders like `LINEAR_API_KEY=__authsome__`. When the agent makes an outbound request, the proxy substitutes the real value only for the matching host. If a prompt-injection convinces the model to dump env, all that leaks is placeholders.

Install with `uv tool install authsome`, then `authsome run -- claude` instead of `claude` directly. Skill lives at `skills/authsome/SKILL.md` in the repo.

Where it is today: MIT, Python, on PyPI, 45 providers bundled (14 OAuth2, 31 API key), tests in CI.

Slotted under Security & Systems because credential exfiltration prevention is the primary value. Happy to move to Development & Code Tools if that fits the taxonomy better.