### PR TITLE
Add growth-retrospective skill to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [growth-retrospective](https://github.com/YoungApple/growth-retrospective-skill) - Personal growth retrospectives ranked by decision-velocity signals from git + chat history. Tracks 5 categories (domain knowledge, human skills, work habits, meta-cognition, productivity) with graduation markers so items leave the list instead of piling up. Includes a Step 0 forcing function that blocks new scans if prior level-up actions are untouched. Cross-agent (Claude Code, Codex CLI, Antigravity). *By [@YoungApple](https://github.com/YoungApple)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
## What

Adds [growth-retrospective](https://github.com/YoungApple/growth-retrospective-skill) to the **Productivity & Organization** category.

## Why this category

It's a personal-growth retrospective tool — closer to `ship-learn-next` and `tapestry` (already in this section) than to the Collaboration / Project Management section. Solo dev / indie builder is the target user.

## What's different from existing entries in this section

- **Graduation markers**: every Tier 1/2 item ships with an observable, time-bounded exit condition. Items leave the list — the list shrinks as you actually improve. `ship-learn-next` and `tapestry` don't have this exit-criteria semantic.
- **Step 0 Action Audit (forcing function)**: before any new scan, the skill checks the filesystem for artifacts named in prior level-up actions. If ≥3 are pending >14 days AND 0 completed, the skill pushes back instead of generating new items. Designed to prevent the "items pile up forever" failure mode common to learning logs.
- **5-category sweep** (domain / human / habit / meta / productivity) — most learning tools track only category 1.
- **Cross-agent**: same SKILL.md format works in Claude Code, OpenAI Codex CLI, and Google Antigravity.

## Requirements checklist

- [x] Solves a real problem (personal growth logs pile up forever; this one is designed to shrink)
- [x] Well-documented (README + README.zh-CN + FAQ + CONTRIBUTING + SECURITY + CHANGELOG + EVAL framework + 4 references)
- [x] Includes examples (4 worked examples in `examples/`: anonymized real project, real dogfood audit, fresh-project Day-1, runnable demo fixture)
- [x] Tested (iteration-1 → iteration-2 evals, all v1 defects fixed in v2; CI/Actions on every push validates frontmatter + scripts + line budget)
- [x] Safe (no destructive operations; reads git history + chat archive locally; no outbound calls — see SECURITY.md)
- [x] Portable (Claude Code + Codex CLI + Antigravity supported; uses SKILL.md open standard)
- [x] No duplicates (closest neighbors are `ship-learn-next` and `tapestry`; differentiation explained above)

## Try it in 5 seconds without installing

```bash
git clone https://github.com/YoungApple/growth-retrospective-skill /tmp/grs && \
  bash /tmp/grs/examples/demo-fixture/demo.sh
```

Color-coded output of Step 0 Action Audit + signal extraction on a synthetic 14-day project. Pure shell, no LLM, no install. About 5 seconds.

## Honest notes

The "shrinking gap" outcome claim is Layer 3 in the eval framework and currently has zero real-user data — see [EVAL-FRAMEWORK.md](https://github.com/YoungApple/growth-retrospective-skill/blob/main/EVAL-FRAMEWORK.md). Layers 1 (output) and 2 (acceptance via persona simulation) are validated.

Brand new repo (created 2026-05-24, 1 star at time of submission). If the policy is "wait for community traction before listing," I understand a hold — but the [CONTRIBUTING.md](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/CONTRIBUTING.md) doesn't specify a stars threshold and emphasizes merit / use-case / structure, which I believe this skill meets.