### PR TITLE
feat: add skills-for-humanity

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) - 171 structured reasoning methodologies (logic, probability, decision, creativity, ethics, writing, strategy, and more) packaged as Claude Code skills. Based on frameworks from de Bono, Meadows, Tetlock, Sun Tzu, and 15 other thinkers. Install with `npx @human-avatar/skills-for-humanity`. *By [@human-avatar](https://github.com/human-avatar)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 
 ### Creative & Media


### PR DESCRIPTION
## Summary

- Adds [skills-for-humanity](https://github.com/human-avatar/skills-for-humanity) to the **Communication & Writing** section
- 171 structured reasoning methodologies (logic, probability, decision, creativity, ethics, writing, strategy, and more) packaged as Claude Code skills
- Based on frameworks from de Bono, Meadows, Tetlock, Sun Tzu, and others
- Installable via `npx @human-avatar/skills-for-humanity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)