### PR TITLE
Add Alpha Insights skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
+- [Alpha Insights](https://github.com/Ericyoung-183/alpha-insights) - Harness-enforced business research skill for Claude Code and Codex Desktop with consulting frameworks, source grading, quality gates, and HTML reports. *By [@Ericyoung-183](https://github.com/Ericyoung-183)*
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.


### PR DESCRIPTION
Adds Alpha Insights under Business & Marketing.\n\nAlpha Insights is a public MIT-licensed skill for structured business research. It combines consulting frameworks, source confidence grading, harness-enforced quality gates, and HTML report output.\n\nRepository includes README, SKILL.md, demo report, and an active V4.1 release.