### PR TITLE
Add: api-vs-selfhost-skill — LLM API-vs-self-host cost calculator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [api-vs-selfhost-skill](https://github.com/artvandelay/api-vs-selfhost-skill) - Decide API-vs-self-host LLM economics and fine-tune ROI from any agent context. Live GPU+API prices, deterministic local math. *By [@artvandelay](https://github.com/artvandelay)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
Adds api-vs-selfhost-skill under Data & Analysis. Anthropic-standard SKILL.md with YAML frontmatter. MIT licensed. CI green. Repo: https://github.com/artvandelay/api-vs-selfhost-skill