### PR TITLE
Add Bilig WorkPaper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [Bilig WorkPaper](https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper) - Formula-backed WorkPaper state for agents: edit inputs, recalculate, read computed values, and persist JSON without Excel UI automation. *By [@gregkonush](https://github.com/gregkonush)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## Summary

Adds Bilig WorkPaper to the Claude skills list as an agent-facing workbook/formula skill.

Bilig WorkPaper gives an agent a small spreadsheet-style model it can operate through tools: read inputs, set cells, recalculate, verify formula readback, and export JSON state without driving Excel or a browser UI.

## Validation

```bash
npm view @bilig/workpaper version
npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json
git diff --check
```

`npm view @bilig/workpaper version` returned `0.157.0`.

The current public Bilig evaluator returned `verified: true` with package versions `@bilig/workpaper@0.157.0` and `xlsx-formula-recalc@0.157.0`. It verified 8 MCP tools, edited `Inputs!B3`, changed expected ARR from `60000` to `96000`, persisted the WorkPaper JSON, restored readback, and confirmed restart readback.

## Notes

This PR only adds a listing entry. It does not change runtime code or add dependencies.



