### PR TITLE
Add time-awareness skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
+- [time-awareness](https://github.com/amosshacareer-netizen/time-awareness-skill) - Gives Claude precise time awareness by reading the system clock — fixes stale date context across conversations, detects time gaps, checks memory freshness, and handles cross-timezone coordination. Bilingual (EN+中文).
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 


### PR DESCRIPTION
## What is this?

[time-awareness](https://github.com/amosshacareer-netizen/time-awareness-skill) is a lightweight skill that gives Claude precise knowledge of the current date, time, day of week, and timezone by reading the system clock.

## Why it matters

Claude frequently carries stale date context across conversations — you chat on Monday, come back Wednesday, and Claude still thinks it's Monday. This skill fixes that.

## Features

- Cross-platform: Windows (PowerShell), macOS, Linux (Bash)
- Cross-conversation time gap detection
- Memory staleness checking (`last_updated` field comparison)
- Key date countdown calculations
- Cross-timezone coordination
- Bilingual: English + Chinese

## Install

```bash
npx skills add amosshacareer-netizen/time-awareness-skill
```

## Category

Added to **Productivity & Organization** — fits alongside other workflow and context-management skills.