### PR TITLE
Add Career Skills - 6 job-search skill pack (CN/EN bilingual)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [Career Skills](https://github.com/agentsope/career-skills) - 6 job-search skill pack (中文/English bilingual): JD analysis, experience mapping, bullet building, resume tailoring, role finding, gap planning. Core principle: "Reframe, never fabricate." *By [@agentsope](https://github.com/agentsope)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
A 6-skill pack built on real-world job-seeking workflows, bilingual in Chinese and English. Covers the full pipeline: JD analysis → experience mapping → bullet building → resume tailoring → role discovery → gap planning. Core principle: "Reframe, never fabricate."