### PR TITLE
Add autopunk-media-skills (394 skills + 6 agents for media professionals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [autopunk-media-skills](https://github.com/ur-grue/autopunk-media-skills) - 354 production-tested skills for TV producers, journalists, podcasters, YouTubers, and media professionals. Covers development through distribution with quality-evaluated outputs. *By [@ur-grue](https://github.com/ur-grue)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
## New Entry: autopunk-media-skills

**Section:** Creative & Media

394 production-tested Claude skills + 6 agent pipelines for media professionals — the largest free skill library for TV producers, journalists, podcasters, YouTubers, and content creators.

- 394 stable skills across 21 categories, all G-Eval scored (≥ 4.0/5)
- 6 agent pipelines: investigative reporter, magazine editor, documentary development, YouTube channel operator, podcast producer, PR crisis response
- Quality-evaluated using a documented 7-dimension G-Eval framework with Editorial Naturalness hard floor
- Docs site with interactive skill browser, role picker, and multi-harness install guides

Repository: https://github.com/ur-grue/autopunk-media-skills
License: MIT