### PR TITLE
Add everything-to-podcast to Document Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
+- [everything-to-podcast](https://github.com/lssuzie/everything-to-podcast) - Turn any text (PDF, EPUB, TXT, Markdown) into high-quality audiobooks or podcasts. AI reads and summarizes, then TTS generates audio with sentence-boundary slicing and checkpoint resume. Supports Chinese and English. *By [@lssuzie](https://github.com/lssuzie)*
 
 ### Development & Code Tools
 


### PR DESCRIPTION
## Add [everything-to-podcast](https://github.com/lssuzie/everything-to-podcast) to Document Processing

**What it does:** Turn any text (PDF, EPUB, TXT, Markdown) into high-quality audiobooks or podcasts.

**Two modes:**
- **AI代读模式**: AI reads, summarizes each chapter, then generates a podcast audio
- **全文朗读模式**: Full text converted to audiobook with TTS

**Key features:**
- Sentence-boundary slicing (100 char max) for stable audio quality
- Checkpoint resume — picks up where it left off after interruptions
- Multi-format: PDF, EPUB, TXT, Markdown
- Chinese and English TTS support
- NFKC encoding normalization for OCR/PDF sources
- Works with Claude Code, Codex CLI, and 20+ agent platforms via open SKILL.md standard

**Install:**
```bash
npx skills add lssuzie/everything-to-podcast
```