### PR TITLE
Add Walter Skills to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Walter Skills](https://github.com/walterwritesai/walter-skills) - 12 drop-in markdown skills for SEO content writing, agency QC, local SEO, programmatic SEO, content repurposing, and brand voice. Each humanizes AI output through Walter Writes and preserves target keywords. *By [@walterwritesai](https://github.com/walterwritesai)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds Walter Skills ([https://github.com/walterwritesai/walter-skills](https://github.com/walterwritesai/walter-skills)) to the Business & Marketing section.

Walter Skills is a public MIT-licensed collection of 12 drop-in markdown skills for Claude projects, covering SEO content writing, agency QC, local SEO, programmatic SEO, content repurposing, and brand voice. Each skill follows the Agent Skills spec (YAML frontmatter + instructions) and invokes Walter Writes AI tools via MCP for humanization, AI detection, and keyword preservation.

The entry follows the same format as the existing rampstackco/claude-skills entry (the other collection-style entry in this section).

Happy to adjust wording, section, or scope if helpful.