### PR TITLE
Add bumblebee skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Security & Systems
 
+- [bumblebee](./bumblebee/) - Run Bumblebee supply-chain inventory and exposure scans for compromised npm/PyPI/Go/RubyGems/Composer packages, editor and browser extensions, and MCP host configs. *Wraps the [bumblebee](https://github.com/perplexityai/bumblebee) CLI by Perplexity.*
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.

--- a/bumblebee/LICENSE.txt
+++ b/bumblebee/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/bumblebee/SKILL.md
+++ b/bumblebee/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: bumblebee
+description: Run Bumblebee supply-chain inventory and exposure scans on the local machine. Use this skill whenever the user wants to check developer endpoints for compromised npm/PyPI/Go/RubyGems/Composer packages, audit installed editor or browser extensions, inspect MCP host configs, or perform supply-chain incident response on macOS/Linux. Trigger on phrases like "Bumblebee scan", "supply-chain check", "compromised package", "exposure scan", "baseline inventory", "project scan", "deep scan", "scan my machine for vulnerable packages", "check for malicious extensions", or any request involving the bumblebee CLI. Also use when the user names an advisory and wants to know if their machine is affected. The skill handles requirements checks (Go, Bumblebee), installs Bumblebee via `go install` if missing, runs the requested profile, and produces both raw NDJSON and a human-readable Markdown report.
+license: Complete terms in LICENSE.txt
+---
+
+# Bumblebee Security Scan
+
+Bumblebee (https://github.com/perplexityai/bumblebee) is a read-only inventory collector that surfaces package, extension, and developer-tool metadata on developer endpoints. It answers a focused supply-chain question: when an advisory names a package or version, do any matches exist on this machine right now?
+
+This skill drives a single Bumblebee scan from start to finish:
+
+1. Verify Go is on the PATH (provide install guidance if not).
+2. Verify or install the `bumblebee` binary.
+3. Run the requested scan profile (`baseline`, `project`, or `deep`).
+4. Save raw NDJSON output plus a Markdown report into the user's workspace.
+5. Summarize findings — especially exposure-catalog matches — in the chat reply.
+
+Communicate with the user in the language they used (German for Stefan). Code, commit messages, and on-disk file contents stay in English to match existing project conventions.
+
+## Step 1 — Clarify the scan request
+
+Before running anything, confirm two things with the user via `AskUserQuestion`, unless the message already pins them down:
+
+- **Profile**: `baseline` (global package roots), `project` (specific dev folders like `~/code`), or `deep` (explicit `--root` paths, including `$HOME` for incident response).
+- **Roots**: For `project` and `deep` profiles, ask which directories to scan. `deep` is the only profile that accepts a bare-home root.
+
+If the user has an advisory or exposure-catalog file ready, also ask whether they want to pass it via `--exposure-catalog`. The skill does not ship its own catalogs — point them at `threat_intel/` in the Bumblebee repo if they ask where to find ready-made ones.
+
+Skip the questions for one-liner asks like "lauf mal ne Baseline-Scan" — just run a baseline.
+
+## Step 2 — Check Go
+
+Run `command -v go && go version` in bash. Three outcomes:
+
+- **Go ≥ 1.25 present** → continue.
+- **Go present but < 1.25** → tell the user the version, explain Bumblebee needs Go 1.25+, and stop until they upgrade.
+- **Go missing** → do not install Go automatically. Show platform-appropriate instructions and stop:
+  - macOS: `brew install go` (or download from https://go.dev/dl/).
+  - Debian/Ubuntu: prefer the official tarball from https://go.dev/dl/ because distro repos lag; `sudo apt install golang-go` only as fallback.
+  - Fedora/RHEL: `sudo dnf install golang` or the official tarball.
+
+After installation, the user must ensure `$GOBIN` (or `$HOME/go/bin`) is on `$PATH` so `bumblebee` is found later.
+
+## Step 3 — Check or install Bumblebee
+
+Run `command -v bumblebee && bumblebee version`. If missing:
+
+```bash
+go install github.com/perplexityai/bumblebee/cmd/bumblebee@latest
+```
+
+Then re-check `bumblebee version`. If the binary still cannot be located, the user's `GOBIN`/`PATH` is likely misconfigured — surface the resolved `go env GOPATH` and `go env GOBIN` so they can fix it. Do not fall back to running the binary by absolute path silently; explain what is happening.
+
+Once installed, also run `bumblebee selftest` as a sanity check. A non-zero exit means the local install is broken and the scan should not proceed.
+
+## Step 4 — Run the scan
+
+All scans write NDJSON to a file. Use the workspace folder for output so the user can open the results afterwards.
+
+Output filenames (use the user's workspace path; the example below assumes `$OUT` is set):
+
+- `bumblebee-<profile>-<UTC-timestamp>.ndjson` — raw records.
+- `bumblebee-<profile>-<UTC-timestamp>.report.md` — Markdown report (generated in Step 5).
+
+Pick a sensible `--max-duration` so a runaway scan does not hang the session. Reasonable defaults:
+
+- `baseline`: 5m
+- `project`: 10m
+- `deep`: 15m (warn the user that scanning `$HOME` can still take longer; offer to raise the limit)
+
+Always stream stderr to a sibling `.log` file — Bumblebee emits diagnostic NDJSON there that helps explain partial scans.
+
+### Baseline
+
+```bash
+bumblebee scan --profile baseline \
+  --max-duration 5m \
+  > "$OUT/bumblebee-baseline-$TS.ndjson" \
+  2> "$OUT/bumblebee-baseline-$TS.log"
+```
+
+Optional: scope to specific ecosystems if the user only cares about, say, npm and PyPI:
+
+```bash
+bumblebee scan --profile baseline --ecosystem npm,pypi ...
+```
+
+### Project
+
+Each `--root` must be an existing absolute path. Reject bare `$HOME` for this profile (Bumblebee will reject it too — surface the message clearly).
+
+```bash
+bumblebee scan --profile project \
+  --root "$HOME/code" \
+  --root "$HOME/Developer" \
+  --max-duration 10m \
+  > "$OUT/bumblebee-project-$TS.ndjson" \
+  2> "$OUT/bumblebee-project-$TS.log"
+```
+
+### Deep
+
+Used for incident response — broad roots are allowed but should be paired with an exposure catalog and `--findings-only` whenever possible, so the output stays focused.
+
+```bash
+bumblebee scan --profile deep \
+  --root "$HOME" \
+  --exposure-catalog "$CATALOG" \
+  --findings-only \
+  --max-duration 15m \
+  > "$OUT/bumblebee-deep-$TS.ndjson" \
+  2> "$OUT/bumblebee-deep-$TS.log"
+```
+
+If the user has no catalog, run deep without `--findings-only` but warn them that the NDJSON file can grow large (hundreds of MB on dense developer machines).
+
+## Step 5 — Generate the Markdown report
+
+Run the bundled helper to turn the NDJSON into a human-readable report:
+
+```bash
+python3 scripts/render_report.py \
+  "$OUT/bumblebee-<profile>-$TS.ndjson" \
+  "$OUT/bumblebee-<profile>-$TS.report.md"
+```
+
+The helper groups records by type and ecosystem, lists every `finding` record with its catalog entry and severity, and embeds the `scan_summary` for traceability. It is dependency-free Python 3 — no `pip install` needed.
+
+If `render_report.py` exits non-zero (malformed NDJSON, missing summary), surface stderr to the user instead of silently producing an empty report.
+
+## Step 6 — Present results
+
+End the turn with:
+
+- A short summary in chat: profile, root(s), record counts, and — most importantly — any findings with their severity. If there are zero findings, say so explicitly; silence on findings is the kind of thing that gets misread.
+- `computer://` links to both the NDJSON and the Markdown report so the user can open them directly.
+- If diagnostics in the `.log` file indicate skipped roots or read errors, mention it and link the log too.
+
+Do not paste large chunks of NDJSON into the chat — it is noisy and not where the user will read it.
+
+## Safety and privacy notes
+
+- Bumblebee is read-only by design. Do not propose patches, deletions, or `npm uninstall` actions from inside this skill; the user runs remediation themselves once they know what is affected.
+- MCP host configs can carry secrets in their `env` blocks. Bumblebee does not emit those values, but the `.log` file may still contain paths to sensitive config files. Treat the output files as containing inventory data and do not upload them to third-party services without the user's explicit consent (DSGVO-relevant).
+- Never run `bumblebee` with elevated privileges (`sudo`). It is meant to inspect the current user's developer environment, not the whole system.
+
+## Failure modes to watch for
+
+- `bumblebee: command not found` after `go install` → almost always a `PATH`/`GOBIN` problem. Show `go env GOPATH GOBIN PATH` to debug.
+- `refusing to scan bare home with profile baseline` → use `deep` for `$HOME`, or pick a subdirectory for `project`.
+- Scan times out → either narrow the `--root` set, scope with `--ecosystem`, or raise `--max-duration`. Do not loop and retry blindly.
+- Exposure catalog rejected → check that the JSON has both `schema_version` and `entries` keys (bare top-level arrays are rejected) and that `schema_version` is one Bumblebee understands.
+
+## Reference
+
+See `scripts/render_report.py` for the report layout. Bumblebee's own documentation lives at https://github.com/perplexityai/bumblebee — consult `docs/inventory-sources.md`, `docs/transport.md`, and `docs/state-model.md` when a question goes beyond what this skill covers.
+
+## Credit
+
+Bumblebee is developed by Perplexity. This skill drives the official `bumblebee` CLI from https://github.com/perplexityai/bumblebee. All scan logic, output formats, and exposure-catalog semantics belong to that project; this skill is just a workflow wrapper.

--- a/bumblebee/scripts/render_report.py
+++ b/bumblebee/scripts/render_report.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Render a Bumblebee NDJSON scan into a human-readable Markdown report.
+
+Bumblebee emits one JSON record per line. Record types we know about:
+
+- package           — an inventory record for a discovered package
+- finding           — an exposure-catalog match (high signal)
+- scan_summary      — emitted once at end of run, contains counts/duration
+- diagnostic        — non-fatal warnings (skipped roots, parse errors)
+
+Unknown record types are bucketed under "other" and counted but not
+rendered in detail. The script never imports anything outside the
+standard library — it has to run on whatever Python 3 ships with the
+developer's machine.
+
+Usage:
+    python3 render_report.py <input.ndjson> <output.md>
+
+Exit codes:
+    0  success
+    1  usage error
+    2  input file unreadable or empty
+    3  no records parsed (likely malformed file)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SEVERITY_ORDER = ["critical", "high", "medium", "low", "info", "unknown"]
+
+
+def severity_rank(value: str | None) -> int:
+    """Return a sort key for severities; unknown values sort last."""
+    if not value:
+        return len(SEVERITY_ORDER)
+    try:
+        return SEVERITY_ORDER.index(value.lower())
+    except ValueError:
+        return len(SEVERITY_ORDER)
+
+
+def load_records(path: Path) -> list[dict[str, Any]]:
+    """Parse NDJSON, tolerating blank lines and trailing whitespace.
+
+    Malformed lines are reported on stderr but do not abort the run —
+    Bumblebee can interleave records from multiple goroutines and a single
+    truncated line should not lose the rest of the report.
+    """
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                print(
+                    f"warning: skipping malformed line {lineno}: {exc}",
+                    file=sys.stderr,
+                )
+    return records
+
+
+def group_by_kind(records: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for rec in records:
+        kind = rec.get("record_type") or rec.get("type") or "unknown"
+        groups[kind].append(rec)
+    return groups
+
+
+def render_findings(findings: list[dict[str, Any]]) -> str:
+    """Findings are the most important section — render them first.
+
+    Each finding carries the matched package's identity (Bumblebee uses
+    `normalized_name` / `source_file` per docs/state-model.md) plus
+    catalog metadata. We look up by the canonical Bumblebee names first
+    and keep a small set of fallbacks so the helper still works against
+    older schemas or hand-rolled fixtures.
+    """
+    if not findings:
+        return "## Findings\n\nNo exposure-catalog matches.\n"
+
+    # Sort by severity (critical first) then by package name.
+    sorted_findings = sorted(
+        findings,
+        key=lambda f: (
+            severity_rank(_get(f, "severity", "catalog_severity")),
+            _get(f, "normalized_name", "package", "name", "package_name") or "",
+        ),
+    )
+
+    out = [f"## Findings\n\n**{len(sorted_findings)} match(es) against exposure catalog.**\n"]
+    for finding in sorted_findings:
+        severity = _get(finding, "severity", "catalog_severity") or "unknown"
+        catalog_id = _get(finding, "catalog_id", "advisory_id", "id") or "—"
+        catalog_name = _get(finding, "catalog_name", "advisory", "name") or ""
+        ecosystem = _get(finding, "ecosystem") or "?"
+        pkg = _get(finding, "normalized_name", "package", "name", "package_name") or "?"
+        version = _get(finding, "version", "matched_version") or "?"
+        # Bumblebee emits `source_file` (and often a `project_path`);
+        # legacy / demo records may use `source_path`. Render both when
+        # available — responders need that traceability.
+        source_file = _get(finding, "source_file", "source_path", "evidence_path", "path") or ""
+        project_path = _get(finding, "project_path") or ""
+        finding_type = _get(finding, "finding_type") or ""
+
+        out.append(f"### [{severity.upper()}] {pkg}@{version} ({ecosystem})")
+        out.append("")
+        out.append(f"- Catalog entry: `{catalog_id}`" + (f" — {catalog_name}" if catalog_name else ""))
+        if finding_type:
+            out.append(f"- Finding type: {finding_type}")
+        if source_file:
+            out.append(f"- Source file: `{source_file}`")
+        if project_path and project_path != source_file:
+            out.append(f"- Project path: `{project_path}`")
+        confidence = _get(finding, "confidence")
+        if confidence:
+            out.append(f"- Confidence: {confidence}")
+        root_kind = _get(finding, "root_kind")
+        if root_kind:
+            out.append(f"- Root kind: {root_kind}")
+        evidence = _get(finding, "evidence")
+        if evidence and isinstance(evidence, (str, int, float)):
+            out.append(f"- Evidence: {evidence}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_inventory(packages: list[dict[str, Any]]) -> str:
+    if not packages:
+        return "## Inventory\n\nNo package records emitted (findings-only mode?).\n"
+
+    by_ecosystem: Counter[str] = Counter()
+    by_root_kind: Counter[str] = Counter()
+    by_confidence: Counter[str] = Counter()
+    for pkg in packages:
+        by_ecosystem[pkg.get("ecosystem", "unknown")] += 1
+        by_root_kind[pkg.get("root_kind", "unknown")] += 1
+        by_confidence[pkg.get("confidence", "unknown")] += 1
+
+    lines = [
+        "## Inventory",
+        "",
+        f"Total package records: **{len(packages):,}**",
+        "",
+        "### By ecosystem",
+        "",
+        "| Ecosystem | Count |",
+        "| --- | ---: |",
+    ]
+    for eco, count in by_ecosystem.most_common():
+        lines.append(f"| {eco} | {count:,} |")
+
+    lines += [
+        "",
+        "### By root kind",
+        "",
+        "| Root kind | Count |",
+        "| --- | ---: |",
+    ]
+    for kind, count in by_root_kind.most_common():
+        lines.append(f"| {kind} | {count:,} |")
+
+    lines += [
+        "",
+        "### By confidence",
+        "",
+        "| Confidence | Count |",
+        "| --- | ---: |",
+    ]
+    for conf, count in by_confidence.most_common():
+        lines.append(f"| {conf} | {count:,} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_summary(summary_records: list[dict[str, Any]]) -> str:
+    """Render scan_summary record(s).
+
+    Bumblebee's real scan_summary (per docs/state-model.md) is flat —
+    `scan_time`, `end_time`, `status`, `package_records_emitted`,
+    `findings_emitted`, `diagnostics_count`, `roots`, plus HTTP-sink
+    counters when applicable. We render those canonical fields first
+    and still fall back to the older `counts`/`totals` shape for
+    backwards compatibility with hand-rolled fixtures.
+    """
+    if not summary_records:
+        return "## Scan summary\n\n_No `scan_summary` record found — the run may not have completed cleanly._\n"
+
+    # Bumblebee canonical scan_summary fields (per docs/state-model.md).
+    # Order matters: identity → status → timing → counts → delivery → versioning.
+    canonical_fields = (
+        "endpoint_id",
+        "profile",
+        "run_id",
+        "status",
+        "scan_time",
+        "end_time",
+        "timed_out",
+        "package_records_emitted",
+        "package_records_suppressed",
+        "findings_emitted",
+        "diagnostics_count",
+        "http_batches_attempted",
+        "http_batches_succeeded",
+        "http_batches_failed",
+        "http_last_status",
+        "scanner_version",
+        "schema_version",
+    )
+
+    out = ["## Scan summary", ""]
+    for idx, rec in enumerate(summary_records, start=1):
+        if len(summary_records) > 1:
+            out.append(f"### Summary {idx}")
+            out.append("")
+
+        status = rec.get("status")
+        if status and status != "complete":
+            out.append(f"> **Status `{status}`** — this run is not a trustworthy complete snapshot. Treat as raw evidence only.")
+            out.append("")
+
+        # Canonical fields
+        for key in canonical_fields:
+            if key in rec and rec[key] not in (None, ""):
+                out.append(f"- **{key}**: `{rec[key]}`")
+
+        # Roots can be a list of objects; render compactly.
+        roots = rec.get("roots")
+        if roots:
+            if isinstance(roots, list):
+                out.append(f"- **roots**: {len(roots)} root(s) scanned")
+                for r in roots[:20]:
+                    if isinstance(r, dict):
+                        # Common shape: {kind, path}
+                        kind = r.get("kind") or r.get("root_kind") or "?"
+                        path = r.get("path") or r.get("root") or "?"
+                        out.append(f"  - `{kind}`: `{path}`")
+                    else:
+                        out.append(f"  - `{r}`")
+                if len(roots) > 20:
+                    out.append(f"  - _… {len(roots) - 20} more truncated_")
+            else:
+                out.append(f"- **roots**: `{roots}`")
+
+        # Legacy / fixture shape: nested counts dict
+        counts = rec.get("counts") or rec.get("totals") or {}
+        if counts:
+            out.append("- **counts** (legacy):")
+            for k, v in counts.items():
+                out.append(f"  - {k}: {v}")
+
+        # Surface any remaining fields we didn't recognize so the helper
+        # never silently drops data when the schema gains new keys.
+        rendered = set(canonical_fields) | {"roots", "counts", "totals", "record_type", "type", "record_id"}
+        extras = {k: v for k, v in rec.items() if k not in rendered and v not in (None, "", [], {})}
+        if extras:
+            out.append("- **other fields**:")
+            for k, v in extras.items():
+                out.append(f"  - {k}: `{v}`")
+
+        out.append("")
+    return "\n".join(out)
+
+
+def render_diagnostics(diagnostics: list[dict[str, Any]]) -> str:
+    if not diagnostics:
+        return ""
+    out = ["## Diagnostics", "", f"{len(diagnostics)} diagnostic record(s) emitted on stdout."]
+    out.append("")
+    for diag in diagnostics[:50]:  # Cap output — log file has full detail.
+        level = diag.get("level", "info")
+        msg = diag.get("message") or diag.get("msg") or json.dumps(diag, sort_keys=True)
+        path = diag.get("path") or diag.get("source_path") or ""
+        suffix = f" — `{path}`" if path else ""
+        out.append(f"- **{level}**: {msg}{suffix}")
+    if len(diagnostics) > 50:
+        out.append("")
+        out.append(f"_… {len(diagnostics) - 50} more diagnostic record(s) truncated. See the `.log` file for the full list._")
+    out.append("")
+    return "\n".join(out)
+
+
+def _get(record: dict[str, Any], *keys: str) -> Any:
+    """Return the first non-empty value found for any of the candidate keys."""
+    for key in keys:
+        value = record.get(key)
+        if value not in (None, "", [], {}):
+            return value
+    return None
+
+
+def build_report(records: list[dict[str, Any]], source_path: Path) -> str:
+    groups = group_by_kind(records)
+    findings = groups.get("finding", []) + groups.get("findings", [])
+    packages = groups.get("package", []) + groups.get("packages", [])
+    summaries = groups.get("scan_summary", [])
+    diagnostics = groups.get("diagnostic", []) + groups.get("diagnostics", [])
+
+    other_kinds = {
+        kind: len(items)
+        for kind, items in groups.items()
+        if kind not in {"finding", "findings", "package", "packages", "scan_summary", "diagnostic", "diagnostics"}
+    }
+
+    generated = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    header = [
+        "# Bumblebee Scan Report",
+        "",
+        f"- Source: `{source_path}`",
+        f"- Generated: `{generated}`",
+        f"- Total records: **{len(records):,}**",
+    ]
+    if other_kinds:
+        header.append(f"- Other record types: {', '.join(f'{k} ({v})' for k, v in sorted(other_kinds.items()))}")
+    header.append("")
+
+    sections = [
+        "\n".join(header),
+        render_findings(findings),
+        render_summary(summaries),
+        render_inventory(packages),
+        render_diagnostics(diagnostics),
+    ]
+    return "\n".join(s for s in sections if s).rstrip() + "\n"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {Path(argv[0]).name} <input.ndjson> <output.md>", file=sys.stderr)
+        return 1
+
+    input_path = Path(argv[1])
+    output_path = Path(argv[2])
+
+    if not input_path.exists() or input_path.stat().st_size == 0:
+        print(f"error: {input_path} is missing or empty", file=sys.stderr)
+        return 2
+
+    records = load_records(input_path)
+    if not records:
+        print("error: no JSON records parsed from input", file=sys.stderr)
+        return 3
+
+    report = build_report(records, input_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report, encoding="utf-8")
+    print(f"wrote {output_path} ({len(records)} records)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Adds a skill that wraps Perplexity's open-source `bumblebee` CLI
(https://github.com/perplexityai/bumblebee), a read-only inventory
collector for package, extension, and developer-tool metadata on
macOS/Linux developer endpoints. Useful for supply-chain incident
response: when an advisory names a compromised npm/PyPI/Go/RubyGems/
Composer package, the skill scans the local machine and surfaces
any matches.

The skill handles requirements checks (Go, `bumblebee` binary),
installs `bumblebee` via `go install ...@latest` if missing, runs
the requested profile (`baseline`, `project`, or `deep`), and produces
both raw NDJSON and a human-readable Markdown report via a bundled,
dependency-free Python helper.

Inspired by Perplexity's public release of Bumblebee.