### PR TITLE
Add revops-skills skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [revops-skills](https://github.com/elijeangilles/revops-skills) - Production-ready Claude Agent Skills pack for Salesforce RevOps work. Four skills covering pipeline hygiene audits, forecast call preparation, deal investigation, and a salesforce-revops-audit diagnostic. MIT licensed. *By [@elijeangilles](https://github.com/elijeangilles)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adding revops-skills, an open-source Claude Agent Skills pack for Salesforce-native Revenue Operations work.

The pack includes four skills using an audit-then-remediate architecture:
- salesforce-revops-audit (the keystone diagnostic)
- forecast-call-prep
- pipeline-hygiene-audit
- deal-investigator

Built and validated against a synthetic 251-opportunity Salesforce dataset. MIT licensed. Companion benchmark RevOpsEval (revopseval.com) launching Q3 2026.

Thanks for maintaining this list.