### PR TITLE
Add AsOf to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Development & Code Tools
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
+- [AsOf](https://github.com/amatayomosley-web/asof) - Temporal-awareness skill that surfaces freshness verdicts on in-context data. Tracks file mtime drift between Reads, parses prompts for embedded dates, and compares pseudo-stable claims against the training cutoff. Install via `pip install asoftime && asof install`. *By [@amatayomosley-web](https://github.com/amatayomosley-web)*
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
Adds [AsOf](https://github.com/amatayomosley-web/asof) to the **Development & Code Tools** section, alphabetically between `artifacts-builder` and `aws-skills`.

## What it is

A temporal-awareness skill for tool-using LLMs. It addresses a specific failure mode: the agent treats all in-context data as if captured "now," regardless of how stale it actually is.

AsOf surfaces three categories of staleness via Claude Code hooks:

1. **In-context file staleness** — files Read earlier whose mtime has moved since (peer edits, user edits in another tool)
2. **Dated content in user paste** — stock quotes, earnings, log entries with embedded timestamps
3. **Pseudo-stable factual claims** — "current Python version," "typical hotel cost," etc. — compared against the model's training cutoff

The hook does all date arithmetic in Python; the model reads pre-computed verdicts. No multi-step date math in chat means no boundary errors at end-of-month or leap years.

## Why it fits the list

It's a real Claude skill (with `SKILL.md` and YAML frontmatter), tested across Claude tiers (Opus 4.7, Sonnet 4.6, Haiku 4.5), and addresses a documented LLM failure mode. A/B tests show categorical behavior change when the verdict block is present.

## Install

`pip install asoftime && asof install` — patches `~/.claude/settings.json` idempotently. MIT.