### PR TITLE
Add md2wechat skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
+- [md2wechat](./md2wechat/) - Agent-native CLI workflow for turning Markdown into WeChat Official Account HTML, previewing locally, handling article assets, and creating drafts from Claude Code, Codex, OpenCode, or OpenClaw. *By [@geekjourneyx](https://github.com/geekjourneyx)*
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 

--- a/md2wechat/SKILL.md
+++ b/md2wechat/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: md2wechat
+description: Agent-native CLI workflow for formatting Markdown articles, previewing WeChat Official Account HTML, handling article assets, and creating WeChat draft posts.
+---
+
+# md2wechat
+
+Use this skill when a user wants an AI agent to turn Markdown into a WeChat Official Account-ready article. The workflow is CLI-first and agent friendly, so Claude Code, Codex, OpenCode, or OpenClaw can inspect an article, preview the output, choose themes and layout modules, upload images, generate covers, and create a WeChat draft when credentials are configured.
+
+## When to Use This Skill
+
+- Format a Markdown article for WeChat Official Account publishing.
+- Preview WeChat HTML locally before creating a draft.
+- Add professional themes, mobile-friendly layout modules, covers, or generated images to an article workflow.
+- Let an agent run the repetitive publishing steps while keeping draft creation explicit and confirm-first.
+
+## What This Skill Does
+
+1. **Inspects article readiness**: Checks article metadata, image requirements, and target readiness before publishing.
+2. **Previews locally**: Generates local preview output so the user can review layout before any remote side effects.
+3. **Formats for WeChat**: Converts Markdown into WeChat Official Account-compatible HTML with themes and layout modules.
+4. **Handles publishing assets**: Supports image upload, cover selection, and draft creation when the user explicitly asks for it.
+
+## How to Use
+
+### Basic Usage
+
+```bash
+md2wechat preview article.md
+```
+
+### Agent Workflow
+
+```bash
+md2wechat inspect article.md --json
+md2wechat preview article.md
+md2wechat convert article.md --draft --cover cover.jpg
+```
+
+### Install As An Agent Skill
+
+```bash
+npx skills add https://github.com/geekjourneyx/md2wechat-skill --skill md2wechat
+```
+
+## Example
+
+**User**: "Use md2wechat to prepare this Markdown article for WeChat. Preview it first, then only create a draft if the article is ready."
+
+**Output**:
+
+```text
+The agent inspects the Markdown, reports readiness blockers, generates a local preview, and waits for confirmation before running draft creation.
+```
+
+## Tips
+
+- Run `md2wechat capabilities --json` when the installed CLI version or supported features are uncertain.
+- Use `md2wechat themes list --json` and `md2wechat layout list --json` before selecting visual formatting options.
+- Treat preview, image upload, and draft creation as separate steps. Draft creation requires configured WeChat credentials.
+
+## Common Use Cases
+
+- Technical writers publishing Markdown posts to WeChat Official Accounts.
+- Content teams standardizing WeChat article formatting through Claude Code or Codex.
+- Indie developers turning documentation, changelogs, or product essays into WeChat-ready drafts.
+
+**Credit:** Created by [@geekjourneyx](https://github.com/geekjourneyx) and maintained at [geekjourneyx/md2wechat-skill](https://github.com/geekjourneyx/md2wechat-skill).


### PR DESCRIPTION
## What changed

Adds `md2wechat` as a Communication & Writing skill and includes a complete `SKILL.md` entry.

## Why it is useful

Markdown-to-WeChat publishing is a repetitive workflow that is difficult for agents to automate safely unless preview, asset handling, and draft creation are separated. `md2wechat` is an agent-native CLI and skill that lets Claude Code, Codex, OpenCode, or OpenClaw inspect a Markdown article, preview WeChat Official Account HTML locally, apply themes and layout modules, handle covers/images, and create a WeChat draft only when credentials are configured.

## Who uses this workflow

Technical writers, indie developers, and content teams publishing Markdown articles to WeChat Official Accounts.

## Example

```bash
npx skills add https://github.com/geekjourneyx/md2wechat-skill --skill md2wechat
md2wechat inspect article.md --json
md2wechat preview article.md
md2wechat convert article.md --draft --cover cover.jpg
```

## Attribution

Created and maintained by [@geekjourneyx](https://github.com/geekjourneyx).

## Validation

Documentation/listing change only. I verified the new entry follows the repository's README format and the skill folder contains `md2wechat/SKILL.md`.
