### PR TITLE
Add Docs to Book skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
+- [Docs to Book](https://github.com/EliaTolin/docs-to-book-skills) - Crawls an online technical documentation site and turns it into a colorful, readable PDF book, translated into the language of your choice. *By [@EliaTolin](https://github.com/EliaTolin)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 


### PR DESCRIPTION
**What problem it solves**
Reading a long online documentation site in the browser is tiring and not portable. *Docs to Book* turns a documentation website into a single, well-typeset PDF book you can read offline, annotate, or print.

**What it does**
[Docs to Book](https://github.com/EliaTolin/docs-to-book-skills) crawls an online technical documentation site, extracts and reorganizes the content into book form, applies a brand-aware Typst theme (with a trademark guardrail on palette extraction), translates it into the language of your choice, and compiles a colorful, readable PDF.

**Who uses this workflow**
Developers and learners who want to study a framework/library's docs offline or produce a printable manual/ebook from a docs site.

**Placement**
Added as an external-link entry in *Document Processing* (next to the Markdown to EPUB Converter), following the existing `*By [@author]*` pattern used by other linked skills.

**Example**
> "Turn https://docs.example.dev into a PDF book in Italian."
> → produces a translated, brand-themed PDF book of the documentation.

*By [@EliaTolin](https://github.com/EliaTolin)*