### PR TITLE
Add Catalan Natural skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
+- [Catalan Natural](https://github.com/albertolive/claude-skills) - Writes and reviews correct, natural Catalan: fixes castellanismes, English calques (catalanglish), weak pronouns, punctuation, accents, and currency formatting. *By [@albertolive](https://github.com/albertolive)*
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.


### PR DESCRIPTION
Adds **Catalan Natural** to the Communication & Writing section.

A Claude Code skill that writes and reviews correct, natural Catalan, fixing the two big sources of bad Catalan: castellanismes (Spanish interference) and English calques (catalanglish). It also covers weak-pronoun errors, per/per a, diacritics, apostrophation, punctuation (« » quotes, currency formatting) and accents. Every rule is sourced from official references (IEC, Optimot, ésAdir, Softcatalà).

- Repo: https://github.com/albertolive/claude-skills (MIT)
- Install: `/plugin marketplace add albertolive/claude-skills` then `/plugin install catalan-natural@albertolive-skills`

Entry placed alphabetically after `brainstorming`. Links to the external repo, matching existing entries like `article-extractor` and `NotebookLM Integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)