### PR TITLE
Add doc2math — document-to-mathematics formalization skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [doc2math](https://github.com/thebrierfox/doc2math-skill) - Convert any narrative document to a formal Mathematical Problem Specification — extracts variables, operators, constraints, objectives, and uncertainty using the Zero-Inference Protocol. *By [@thebrierfox](https://github.com/thebrierfox)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds **[doc2math](https://github.com/thebrierfox/doc2math-skill)** — a document-to-mathematics formalization skill.

**What it does:** Converts any narrative document (research paper, problem description, specification) into a structured **Mathematical Problem Specification (MPS)** JSON object containing variables, operators, constraints, objectives, and uncertainty — all with source citations.

**When it activates:**
- "Formalize this problem statement into math"
- "Extract the mathematical structure from this paper section"
- "What variables, constraints, and objectives are in this spec?"
- "Find what's missing in this problem formulation"

**Zero-Inference Protocol:** every extracted element cites its source phrase. Inferences are tagged. Missing information is surfaced, not silently filled. Outputs `"status": "MISSING"` with `"missing_reason"` for under-specified elements.

**7 MPS components:** variables · operators · constraints · objectives · uncertainty · missing_information · validation_flags

**Standalone** — works in any Claude conversation with no config. Full BYOK tool at ace-license-server-production.up.railway.app/byok/doc2math ($29 one-time).

*By [@thebrierfox](https://github.com/thebrierfox) — W. Kyle Million (~K¹), IntuiTek¹*