### PR TITLE
Add Google Maps Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Google Maps Agent Skills](https://github.com/gmapsscraper/google-maps-agent-skills) - 8-skill collection for Google Maps lead generation: scrape businesses, extract emails, find local leads, analyze competitors, and write cold outreach. Free skills process CSV locally; paid skills call gmapsscraper.io API. *By [@gmapsscraper](https://github.com/gmapsscraper)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds Google Maps Agent Skills (https://github.com/gmapsscraper/google-maps-agent-skills) to Business & Marketing section. 8-skill collection for lead generation: scrape businesses, extract emails, analyze competitors, write cold outreach. Free + paid tier design. By @gmapsscraper