### PR TITLE
Add FunASR Transcription skill to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [FunASR Transcription](./funasr-transcription/) - Transcribe audio/video to text with 50+ language support, speaker diarization, and emotion detection using FunASR MCP server. *By [FunAudioLLM](https://github.com/FunAudioLLM)*
 
 ### Productivity & Organization
 

--- a/funasr-transcription/SKILL.md
+++ b/funasr-transcription/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: funasr-transcription
+description: Transcribe audio and video files to text using FunASR's MCP server — 50+ languages, speaker diarization, emotion detection.
+---
+
+# FunASR Audio Transcription
+
+Transcribe audio and video files to text using [FunASR](https://github.com/modelscope/FunASR), an industrial-grade speech recognition toolkit. Supports 50+ languages with built-in VAD, punctuation restoration, speaker diarization, and emotion detection.
+
+## When to Use This Skill
+
+- Transcribe meeting recordings, interviews, or lectures to text
+- Generate subtitles from video/audio files
+- Extract spoken content from media for analysis or summarization
+- Transcribe multilingual audio (50+ languages including Chinese, English, Japanese, Korean)
+
+## What This Skill Does
+
+1. **Speech-to-Text**: Transcribes audio files with high accuracy using SenseVoice (non-autoregressive, ~10x faster than Whisper) or Paraformer models
+2. **Speaker Diarization**: Identifies who spoke when using the cam++ model
+3. **Emotion Detection**: Detects speaker emotions (happy, sad, angry, neutral) built into SenseVoice
+4. **Audio Event Detection**: Identifies non-speech events like laughter, applause, and music
+
+## Setup
+
+### Option 1: MCP Server (Recommended)
+
+Add FunASR's built-in MCP server to your Claude Code settings:
+
+```json
+{
+  "mcpServers": {
+    "funasr": {
+      "command": "funasr-server",
+      "args": ["--mcp", "--device", "cuda"]
+    }
+  }
+}
+```
+
+### Option 2: OpenAI-Compatible API
+
+```bash
+pip install funasr
+funasr-server --device cuda
+# Server runs at http://localhost:8000
+# Endpoint: /v1/audio/transcriptions
+```
+
+## How to Use
+
+### Basic Transcription
+
+> "Transcribe this audio file: recording.wav"
+
+### Meeting Notes with Speaker Identification
+
+> "Transcribe meeting.mp3 and identify each speaker"
+
+### Multilingual Transcription
+
+> "Transcribe this Japanese audio file: interview_ja.wav"
+
+## Example Output
+
+```
+Speaker 1 (00:00 - 00:15): Welcome everyone to today's meeting.
+Speaker 2 (00:16 - 00:32): Thanks. Let me share the quarterly results.
+Speaker 1 (00:33 - 00:45): The numbers look great this quarter. [happy]
+```
+
+## Links
+
+- [FunASR GitHub](https://github.com/modelscope/FunASR) (16K+ stars)
+- [SenseVoice](https://github.com/FunAudioLLM/SenseVoice) (8K+ stars)
+- [Documentation](https://www.funasr.com)


### PR DESCRIPTION
## New Skill: FunASR Audio Transcription

Adding [FunASR](https://github.com/modelscope/FunASR) as an audio transcription skill under **Creative & Media**.

**What it does:**
- Transcribes audio/video files to text using FunASR's built-in MCP server
- Supports 50+ languages (Chinese, English, Japanese, Korean, and more)
- Speaker diarization (who said what)
- Emotion detection (happy, sad, angry, neutral)
- ~10x faster than Whisper (non-autoregressive architecture)

**Why it belongs here:**
- FunASR has a built-in MCP server that works with Claude Code
- 16K+ GitHub stars, actively maintained
- Real use case: meeting transcription, subtitle generation, multilingual audio processing
- OpenAI-compatible API endpoint (`/v1/audio/transcriptions`)

**Checklist:**
- [x] Solves a real problem (audio transcription)
- [x] Well-documented (includes setup, usage examples, and output format)
- [x] Includes practical examples
- [x] Tested with Claude Code MCP integration
- [x] Safe (read-only audio processing)
- [x] Portable (works via MCP or API)