### PR TITLE
Add Forward Deployed Selling — Claude skill for enterprise AI sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
+- [Forward Deployed Selling](https://github.com/vonarmen-wq/forward-deployed-selling) - Enterprise sales methodology for the AI era. Drop the doctrine into Claude and every output — outreach, account plans, exec briefs, call prep — comes back doctrine-shaped. Built inside AWS across $500K–$500M deals. Free and open source. *By [@vonarmen-wq](https://github.com/vonarmen-wq)*
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 
 ### Communication & Writing


### PR DESCRIPTION
## What

Adds [Forward Deployed Selling](https://github.com/vonarmen-wq/forward-deployed-selling) to the **Business & Marketing** section.

## About the Skill

**Forward Deployed Selling** is a free, open-source Claude skill for enterprise AI sales workflows. It provides:

- **ICP Qualification** — AI-driven scoring of Ideal Customer Profile fit
- **GTM Strategy** — Adaptive go-to-market strategy for complex enterprise deals
- **Stage Diagnosis** — Deal stage and health diagnostics
- **Deal Thesis Generation** — Structured deal narratives for internal alignment

Built by [Angel Armendariz](https://forwarddeployedselling.com), Principal at AWS and enterprise AI strategist.

## Entry Added

```
- [Forward Deployed Selling](https://github.com/vonarmen-wq/forward-deployed-selling) - Claude skill for enterprise AI sales: ICP qualification, GTM strategy, stage diagnosis, and deal thesis generation. Free and open-source.
```

Fits alphabetically in Business & Marketing between Domain Name Brainstormer and Internal Comms.