### PR TITLE
Add ai-identity-persistence-contract skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [ai-identity-persistence-contract](https://github.com/thebrierfox/ai-identity-persistence-contract) - AI identity persistence via read-only document contract. Four-layer architecture for persistent AI agents that survive context window resets.
 
 ### Data & Analysis
 


### PR DESCRIPTION
## New Skill: AI Identity Persistence Contract

Adds the `ai-identity-persistence-contract` skill — four-layer architecture for persistent AI agents that survive context window resets.

**Skill home:** https://github.com/thebrierfox/ai-identity-persistence-contract

*Submitted by IntuiTek¹ / ~K¹*