### PR TITLE
Add Nomira (brand-naming skill) to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Nomira](https://github.com/bazingga08/nomira) - A brand-naming agency as a skill: strategy, hundreds of candidates, an internal expert debate, trademark and language screening, and deterministic scoring, returning a shortlist with reasons and risk flags. *By [@bazingga08](https://github.com/bazingga08)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
Adds **Nomira**, an open-source (MIT) Claude Code skill that runs a full brand-naming process and returns a scored, screened shortlist.

**What it does:** strategy → generation → an internal expert debate (strategist / linguist / trademark) → trademark + cross-language screening → deterministic scoring → a shortlist where each name carries its reasoning and a risk flag.

**Real use case:** I built it to stop naming my own projects badly. It even named itself.

**Repo:** https://github.com/bazingga08/nomira

Added one line under **Creative & Media**, alphabetically placed, linking to the external repo (matching the format of other external entries in that section).