### PR TITLE
Add pitchcraft skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [pitchcraft](https://github.com/moshuying/pitchcraft) - Structured persuasion for tech leads, PMs, and founders—not activity logs. Five scenarios (kickoff, status, wrap-up, investor pitch, solution selling) on one 5-part framework (Hook→Context→Proposal→Evidence→Ask), with AI material intake and pre-submit checklist. EN + 中文; Claude Code, Cursor, Codex. By [@moshuying](https://github.com/moshuying)
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 
 ### Creative & Media


### PR DESCRIPTION
## Summary
Adds [pitchcraft](https://github.com/moshuying/pitchcraft) — structured persuasion for executive briefings (not generic status/activity logs).

## Problem
Tech leads, PMs, and founders often have strong execution but weak upward communication: leaders don't understand impact, trust, or the ask.

## Who uses it
- Tech leads / EMs: kickoff, milestone review, wrap-up
- PMs: quarterly / annual reviews
- Founders: investor pitch
- Pre-sales: solution selling

## How it works
One 5-part framework (Hook → Context → Proposal → Evidence → Ask) with five scenario templates, AI prompts for missing materials and audience context, and a pre-submit checklist.

## Platforms tested
- Claude Code (`/plugin install pitchcraft`)
- Cursor / Codex (via `prompts/universal.md`)

## Differentiation
Unlike [Internal Comms](./internal-comms/) (fixed internal formats), pitchcraft focuses on persuasion and securing decisions/resources across kickoff, status, wrap-up, pitch, and solution selling.

## Attribution
Created by [@moshuying](https://github.com/moshuying), refined through real executive briefings. Apache-2.0.