### PR TITLE
Add agent guidance and Claude Code project config

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,25 @@
+# Claude Instructions — awesome-claude-skills
+
+Read `AGENTS.md` and `WARP.md` at the repo root for full project context before starting any work.
+
+## Key Rules
+
+- Every new skill requires: a lowercase hyphenated folder + `SKILL.md` with valid frontmatter
+- README listings must be alphabetical, no emojis, format: `- [Name](./folder/) - Description. Inspired by [Source].`
+- Never edit `composio-skills/` manually, never add crypto/web3 skills, never commit secrets
+- Run `cat .github/workflows/label-ready-skill.yml` before touching `README.md`
+
+## New Skill Workflow
+
+```bash
+cp -r template-skill/ <skill-name>/
+# edit <skill-name>/SKILL.md
+git checkout -b add-<skill-name>
+git commit -m "Add [Skill Name] skill"
+```
+
+## Listing-Only PR Checklist
+
+1. `git --no-pager diff --name-only origin/main...HEAD` → must show only `README.md`
+2. Entry is in the correct category and alphabetical order
+3. Links to an external URL (not a local folder)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,159 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Claude Code, Codex, Warp, Copilot, etc.) working in this repository.
+
+## Project Overview
+
+**awesome-claude-skills** — a curated catalog of Claude Skills for Claude.ai, Claude Code, and the Claude API.  
+No traditional application stack; the primary artifact in every contribution is `SKILL.md`.  
+Languages present: Markdown (skills), Python (MCP Builder eval harness), JavaScript/HTML (connect plugin, theme-factory).
+
+## Key Commands
+
+> Run from repo root (`/Users/elorm/awesome-claude-skills`) unless noted.
+
+```bash
+# Inspect working tree
+git --no-pager status
+git --no-pager diff
+
+# Confirm PR scope (listing-only PRs must touch only README.md)
+git --no-pager diff --name-only origin/main...HEAD
+
+# Launch Connect apps plugin inside Claude Code
+claude --plugin-dir ./connect-apps-plugin
+# then inside Claude Code:
+/connect-apps:setup
+
+# MCP Builder evaluation harness
+pip install -r mcp-builder/scripts/requirements.txt
+python mcp-builder/scripts/evaluation.py \
+  -t stdio -c python -a my_mcp_server.py \
+  mcp-builder/scripts/example_evaluation.xml
+
+# Install skill-local dependencies (only when working on that skill)
+pip install -r slack-gif-creator/requirements.txt
+```
+
+## Project Structure
+
+```
+awesome-claude-skills/
+├── README.md                  ← curated index; structured — edits must stay in Skills section
+├── CONTRIBUTING.md            ← authoritative contribution guide
+├── .github/workflows/         ← CI; label-ready-skill.yml enforces README format rules
+├── template-skill/            ← canonical new-skill scaffold (copy this first)
+├── composio-skills/           ← large generated collection; don't edit manually unless asked
+├── document-skills/           ← bundled docx / pdf / pptx / xlsx skills
+├── connect-apps-plugin/       ← Claude Code plugin for third-party app connections
+├── mcp-builder/               ← MCP server scaffold + evaluation harness
+└── <skill-name>/              ← any hand-authored skill
+    └── SKILL.md               ← required artifact
+```
+
+## Skill Structure
+
+Every skill is a folder containing `SKILL.md` plus optional support dirs:
+
+```
+skill-name/            ← lowercase, hyphens only
+├── SKILL.md           ← required
+├── scripts/           ← optional
+├── reference/         ← optional
+├── templates/         ← optional
+└── resources/         ← optional
+```
+
+**Required SKILL.md frontmatter:**
+```yaml
+---
+name: skill-name
+description: One-sentence description of what this skill does and when to use it.
+---
+```
+
+## Code Style
+
+Follow `template-skill/SKILL.md` exactly. One example beats a paragraph of description.
+
+**Good** (specific, actionable):
+```markdown
+## When to Use This Skill
+
+- Generating weekly status reports from Jira exports
+- Summarising long meeting transcripts into action items
+```
+
+**Bad** (too vague):
+```markdown
+## When to Use This Skill
+
+- When you need to do something with text
+```
+
+**README listing format** (no deviations — CI validates this):
+```markdown
+- [Skill Name](./skill-name/) - One-sentence description. Inspired by [Person/Source].
+```
+Rules: alphabetical within category, no emojis, consistent punctuation, link to the skill folder.
+
+## Git Workflow
+
+```bash
+git checkout -b add-<skill-name>
+git commit -m "Add [Skill Name] skill"
+# PR title: "Add [Skill Name] skill"
+```
+
+CI (`label-ready-skill.yml`) enforces strict rules on listing-only PRs:
+- Changed files must be only `README.md`
+- Edits must be within the `## Skills` … `## Getting Started` region
+- New bullets must link to external URLs
+- Entries must be in alphabetical order
+- Blocked keyword list includes crypto/web3 terms
+
+## Testing
+
+No repo-wide test suite. Validation is structural:
+
+| Contribution type | What to verify |
+|---|---|
+| New skill | `<skill-name>/SKILL.md` exists, frontmatter valid, README listing added |
+| Listing-only PR | `git diff --name-only` shows only `README.md` |
+| MCP server skill | Run evaluation harness before submitting |
+| Connect plugin change | Test with `claude --plugin-dir ./connect-apps-plugin` |
+
+Always inspect CI rules before opening a PR:
+```bash
+cat .github/workflows/label-ready-skill.yml
+```
+
+## Boundaries
+
+✅ **Proceed without asking:**
+- Edit content within an existing `SKILL.md`
+- Add a new skill folder with `SKILL.md`
+- Update the README Skills listing (correct category, alphabetical)
+- Add/edit files inside a skill's `scripts/`, `reference/`, `templates/`, `resources/`
+- Install skill-local Python deps with `pip install -r <skill>/requirements.txt`
+
+⚠️ **Ask first:**
+- Rename or delete any existing skill folder
+- Edit README sections outside the Skills listing
+- Add root-level tooling files (`package.json`, `Makefile`, etc.)
+- Modify `.github/workflows/`
+- Bulk-edit `composio-skills/`
+
+🚫 **Never:**
+- Commit secrets, API keys, or credentials
+- Use emojis in README listings
+- Add crypto, web3, or blockchain skills (blocked by CI)
+- Submit skills that duplicate existing catalog entries
+- Skip the CONTRIBUTING.md checklist for new skills
+
+## Key Files for Orientation
+
+1. `README.md` — catalog index and skill categories
+2. `CONTRIBUTING.md` — full contribution checklist
+3. `.github/workflows/label-ready-skill.yml` — CI rules (read before any README edit)
+4. `template-skill/SKILL.md` — canonical skill template

--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,85 @@
+# WARP.md
+
+Warp agent guidance for the **awesome-claude-skills** repository.  
+Complements `AGENTS.md`; read both before starting work.
+
+## Repository at a Glance
+
+| Property | Value |
+|---|---|
+| Type | Skill catalog — no root build system |
+| Primary artifact | `SKILL.md` per skill folder |
+| Languages | Markdown, Python (eval harness), JS/HTML (plugins) |
+| CI enforcement | `.github/workflows/label-ready-skill.yml` |
+| Contribution guide | `CONTRIBUTING.md` |
+
+## Quick Commands
+
+```bash
+# Check what a PR touches
+git --no-pager diff --name-only origin/main...HEAD
+
+# Launch Connect plugin
+claude --plugin-dir ./connect-apps-plugin
+
+# MCP Builder evaluation
+pip install -r mcp-builder/scripts/requirements.txt
+python mcp-builder/scripts/evaluation.py \
+  -t stdio -c python -a <server>.py \
+  mcp-builder/scripts/example_evaluation.xml
+```
+
+## Skill Authoring Workflow
+
+```
+1. cp -r template-skill/ <skill-name>/
+2. Edit <skill-name>/SKILL.md  →  fill in frontmatter + sections
+3. Add listing to README.md    →  correct category, alphabetical order
+4. git checkout -b add-<skill-name>
+5. git commit -m "Add [Skill Name] skill"
+6. Open PR: "Add [Skill Name] skill"
+```
+
+**SKILL.md frontmatter (required):**
+```yaml
+---
+name: skill-name
+description: One-sentence description of what this skill does and when to use it.
+---
+```
+
+## Navigation Landmarks
+
+| File/Directory | Purpose |
+|---|---|
+| `README.md` | Curated index — structured, do not free-edit |
+| `CONTRIBUTING.md` | Full checklist for new skills |
+| `template-skill/SKILL.md` | Canonical template to copy |
+| `.github/workflows/label-ready-skill.yml` | CI rules for README edits |
+| `composio-skills/` | Large generated collection — don't manually edit |
+| `mcp-builder/` | MCP scaffold + evaluation harness |
+| `connect-apps-plugin/` | Claude Code plugin for app connections |
+
+## Boundaries
+
+| Action | Policy |
+|---|---|
+| Edit existing `SKILL.md` content | ✅ OK |
+| Add new skill folder + `SKILL.md` | ✅ OK |
+| Update README Skills listing (alphabetical) | ✅ OK |
+| Edit files inside skill support dirs | ✅ OK |
+| Rename or delete a skill folder | ⚠️ Ask first |
+| Edit README outside Skills section | ⚠️ Ask first |
+| Modify `.github/workflows/` | ⚠️ Ask first |
+| Bulk-edit `composio-skills/` | ⚠️ Ask first |
+| Commit API keys / secrets | 🚫 Never |
+| Add emojis to README listings | 🚫 Never |
+| Add crypto / web3 skills | 🚫 Never (CI blocked) |
+| Submit duplicate skills | 🚫 Never |
+
+## Warp Agent Tips
+
+- Use **terminal mode** to run git diff checks before any README edit.
+- When authoring a skill, open `template-skill/SKILL.md` side-by-side to mirror the structure.
+- Run `cat .github/workflows/label-ready-skill.yml` to understand CI constraints before touching `README.md`.
+- Verify alphabetical placement with: `grep -n "^\- \[" README.md | less`


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with full project context, contribution rules, git workflow, and boundaries for AI coding agents (Claude Code, Warp, Copilot, etc.)
- Adds `WARP.md` with Warp-specific quick commands, navigation landmarks, and agent tips for this repo
- Adds `.claude/CLAUDE.md` with a concise project-level summary of contribution rules, new-skill workflow, and listing PR checklist for Claude Code

## Why

Without these files, AI agents working in this repo have no discoverable guidance and must infer rules from the codebase. AGENTS.md and WARP.md are the standard convention for surfacing project rules to agents at session start.

## Test plan

- [ ] Verify `AGENTS.md` frontmatter and structure match repo conventions
- [ ] Verify `WARP.md` quick commands match those documented in `CONTRIBUTING.md`
- [ ] Verify `.claude/CLAUDE.md` rules are consistent with `CONTRIBUTING.md` and CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)