### PR TITLE
Add StyleSeed Motion to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
+- [StyleSeed Motion](https://github.com/bitjaru/styleseed) - Translates vibe words into framer-motion code — 5 named motion seeds (Spring/Silk/Snap/Float/Pulse) plus a copy-paste keyword library of distinctive moves like toggle-flip, tilt-3d, and glow-pulse. *By [@bitjaru](https://github.com/bitjaru)*
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.


### PR DESCRIPTION
Adds **StyleSeed Motion** to the **Creative & Media** section as an externally-linked skill (same style as existing entries like `anydesign`, `swiftui-design-skill`, and `imagen`).

**Why it's awesome:** Most AI-generated motion is the same default fade. StyleSeed gives motion a *vocabulary* so Claude produces consistent, intentional animation: 5 named motion seeds (Spring/Silk/Snap/Float/Pulse × 5 contexts) plus a copy-paste library of distinctive keyword moves (`toggle-flip`, `tilt-3d`, `glow-pulse`, `confetti-pop`…). It's a real, tested use case — open-source (MIT), works in Claude Code & Cursor via a `/ss-motion` skill, with a live gallery to preview every move: https://styleseed-demo.vercel.app/motion

- Added in alphabetical order (between *Slack GIF Creator* and *Theme Factory*)
- Not a duplicate of any existing entry
- Format matches the section's externally-linked entries: `- [Name](link) - Description. *By [@author](link)*`