### PR TITLE
Add TqSdk Trading and Data skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [TqSdk Trading and Data](./tqsdk-trading-and-data/) - Guides Python market data, trading, margin, simulation, backtest, and debugging workflows for TqSdk users. *By [@shinny-xuyida](https://github.com/shinny-xuyida)*
 
 ### Business & Marketing
 

--- a/tqsdk-trading-and-data/SKILL.md
+++ b/tqsdk-trading-and-data/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: tqsdk-trading-and-data
+description: "Guide TqSdk Python market data, trading, margin, simulation, backtest, and debugging workflows."
+risk: safe
+source: "https://github.com/shinny-xuyida/tqsdk-agent-skills/tree/main/skills/tqsdk-trading-and-data"
+---
+
+# TqSdk Trading and Data
+
+Use this skill to answer TqSdk questions with the repository's real APIs, docs, and examples. Prefer minimal runnable snippets, keep futures and stock behavior separate, and explain the update loop explicitly whenever the user's issue depends on `wait_update()`.
+
+## When to Use This Skill
+
+- Use when the user asks about TqSdk, TqApi, TqAuth, TqAccount, TqKq, TqKqStock, TqSim, TqSimStock, TqMultiAccount, TqBacktest, TqScenario, TargetPosTask, TargetPosScheduler, or DataDownloader.
+- Use when the user needs TqSdk market data, K-line, tick, historical data, account, position, order, trade, margin, simulation, backtest, or error-debugging help.
+- Use when the user asks TqSdk questions in Chinese, especially about quotes, K-lines, historical data, margin, risk ratio, scenario trials, positions, fills, orders, accounts, order placement, cancellation, rebalancing, field meanings, or errors.
+
+## Route The Request First
+
+Read only the references needed for the user's question.
+
+1. Read [references/wait-update-and-update-loop.md](references/wait-update-and-update-loop.md) for `wait_update`, `is_changing`, `deadline`, async update notifications, Jupyter caveats, or backtest progression questions.
+2. Read [references/market-data.md](references/market-data.md) for `get_quote`, `get_kline_serial`, `get_tick_serial`, contract discovery, symbol metadata, and `DataDownloader`.
+3. Read [references/account-type-matrix.md](references/account-type-matrix.md) for `TqAccount`, `TqKq`, `TqKqStock`, `TqSim`, `TqSimStock`, OTG account classes, and `TqMultiAccount`.
+4. Read [references/accounts-and-trading.md](references/accounts-and-trading.md) for account, position, order, and trade getters plus multi-account getter patterns.
+5. Read [references/scenario-and-margin.md](references/scenario-and-margin.md) for `TqScenario`, real-account margin-rate lookup, margin occupancy calculation, risk-ratio what-if analysis, and limited built-in margin discount rules.
+6. Read [references/order-functions-and-position-tools.md](references/order-functions-and-position-tools.md) for `insert_order`, `cancel_order`, `TargetPosTask`, `support_open_min_volume`, `TargetPosScheduler`, and advanced execution helpers.
+7. Read [references/object-fields.md](references/object-fields.md) when the user asks what fields mean on `Quote`, K-line or tick rows, `Account`, `Position`, `Order`, `Trade`, or their stock variants.
+8. Read [references/simulation-and-backtest.md](references/simulation-and-backtest.md) for local sim, Quick sim, stock sim, backtest, and cross-account backtest limits.
+9. Read [references/error-faq.md](references/error-faq.md) when the user asks about common TqSdk failures, confusing behavior, or exception messages.
+10. Read [references/example-map.md](references/example-map.md) when you want a repository-backed example or doc page to imitate.
+
+## Core Rules
+
+1. Treat `get_*` results as live references, not snapshots. Explain that they refresh during `wait_update()`.
+2. Explain `wait_update()` whenever the user is confused by missing data, stale fields, orders not leaving the client, or `TargetPosTask` not acting.
+3. Distinguish futures and stock workflows:
+   - Futures accounts and objects use `Account`, `Position`, `Order`, `Trade`.
+   - Stock accounts and objects use `SecurityAccount`, `SecurityPosition`, `SecurityOrder`, `SecurityTrade`.
+   - Stock trading does not use `offset`, and `TargetPosTask` is not for stock trading.
+4. Choose account type before writing code. Do not default to `TqKq` or `TqAccount` unless the user really needs that account mode.
+5. In multi-account mode, pass `account=` for getters and trading calls, or use the account object's own `get_account`, `get_position`, `get_order`, and `get_trade`.
+6. For current market examples, avoid expired contracts. Prefer contract discovery APIs or main-contract symbols.
+7. When the user asks for field meanings, explain the smallest relevant field set first and say whether the object is futures or stock.
+8. When the user asks for long historical ranges, prefer `DataDownloader` over pretending `get_kline_serial` is an unlimited history API.
+9. When the user asks for advanced execution, prefer public helpers first:
+   - `TargetPosTask` for target net position.
+   - `TargetPosTask(..., support_open_min_volume=True)` only for contracts with exchange minimum opening size rules when approximate completion is acceptable.
+   - `TargetPosScheduler` plus `twap_table` or `vwap_table` from `tqsdk.algorithm` for scheduled execution.
+   - Mention `InsertOrderTask` and `InsertOrderUntilAllTradedTask` as internal or advanced helpers, not the default answer.
+10. Use `TqScenario` for synchronous what-if margin and risk trials, not for live order placement. It is futures-only, single-account, and updates the trial snapshot immediately after each call.
+11. Explain the margin-rate source in every `TqScenario` answer:
+   - `account=None` or `TqSim()` uses `Quote` margin data.
+   - `TqAccount(...)` or `TqKq()` queries account-specific rates synchronously and may fall back to `Quote` margin if lookup fails.
+12. Treat margin discounts conservatively. Reuse one `TqScenario` object for step-by-step trial actions, and do not promise broker-specific preferential rules beyond the limited built-in rules modeled by TqSdk.
+13. Preserve exchange-specific close semantics in `TqScenario`. For SHFE or INE futures, keep `CLOSE` versus `CLOSETODAY` consistent with the imported position snapshot.
+
+## Answering Style
+
+- Prefer imports from `tqsdk.__init__` for top-level APIs. When an API is documented under a submodule, use that official submodule path such as `tqsdk.tools` or `tqsdk.algorithm`.
+- Prefer short, correct code blocks over broad pseudo-code.
+- Name the exact API the user should call next.
+- If behavior differs in live trading, Quick sim, local sim, stock sim, or backtest, say so explicitly.
+- If the answer depends on a common pitfall, state the pitfall directly instead of burying it in examples.
+- If the answer uses `TqScenario`, say what snapshot goes into `positions`, what balance goes into `init_balance`, and whether the result comes from quote margin or account-specific margin rates.
+
+## Examples
+
+Ask:
+
+```text
+Use this skill to write a TqSdk example that downloads 1-minute K-lines and avoids expired contracts.
+```
+
+Ask:
+
+```text
+Use this skill to debug why my TqSdk insert_order call does not appear to send an order.
+```
+
+## Limitations
+
+- This skill is guidance for agents. It does not connect to broker accounts or place trades by itself.
+- Generated trading code must be reviewed before live use.
+- Broker-specific margin discounts, preferential rules, and account permissions may differ from generic examples.
+- Public examples should avoid expired contracts and should not expose account credentials.

--- a/tqsdk-trading-and-data/agents/openai.yaml
+++ b/tqsdk-trading-and-data/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TqSdk Trading and Data"
+  short_description: "Guide TqSdk data, trading, margin, and strategy workflows"
+  default_prompt: "Use $tqsdk-trading-and-data to explain or implement a TqSdk data, trading, scenario, or debugging task."

--- a/tqsdk-trading-and-data/references/account-type-matrix.md
+++ b/tqsdk-trading-and-data/references/account-type-matrix.md
@@ -1,0 +1,84 @@
+# Account Type Matrix
+
+## Use This Reference For
+
+- Choosing the right account mode before writing code
+- Explaining the difference among `TqAccount`, `TqKq`, `TqKqStock`, `TqSim`, `TqSimStock`, and `TqMultiAccount`
+- Answering "which account class should I use?"
+
+## Quick Selection
+
+Use the smallest account type that satisfies the request.
+
+| Account type | Use when | Futures or stock | Needs `TqAuth` | Notes |
+| --- | --- | --- | --- | --- |
+| `TqApi(auth=TqAuth(...))` | Data access or disposable examples | Defaults to futures-style local sim | Yes | If no explicit account is given, TqSdk creates `TqSim()` |
+| `TqSim()` | Local simulation, strategy development, futures backtest | Futures | Usually yes for data | Local simulated account |
+| `TqKq()` | Quick simulated trading that should match Quick clients | Futures | Yes | Remote simulated account in the Quick ecosystem |
+| `TqAccount(...)` | Broker live trading | Futures | Yes | Real trading account |
+| `TqSimStock()` | Local stock simulation or stock backtest | Stock | Usually yes for data | Stock-only simulated account |
+| `TqKqStock()` | Quick stock simulation | Stock | Yes | Remote stock sim |
+| `TqMultiAccount([...])` | One API driving multiple accounts | Mixed | Yes | Pass `account=` for account-sensitive operations |
+
+## Other Supported Real-Account Classes
+
+These are valid when the user explicitly asks about them or already uses them:
+
+- `TqCtp`
+- `TqRohon`
+- `TqJees`
+- `TqYida`
+- `TqZq`
+- `TqTradingUnit`
+
+Do not lead with these unless the user needs that exact connectivity.
+
+## Important Distinctions
+
+### `TqSim` vs `TqKq`
+
+- `TqSim` is local and disposable.
+- `TqKq` is Quick simulation tied to the user's Quick account.
+- If the user expects account data to appear in official Quick clients, use `TqKq`, not `TqSim`.
+
+### `TqSimStock` vs `TqKqStock`
+
+- Both are stock-mode accounts.
+- Stock accounts return `SecurityAccount`, `SecurityPosition`, `SecurityOrder`, `SecurityTrade`.
+- Stock trading does not use `offset`.
+
+### `TqAccount` vs `TqApi(auth=...)`
+
+- `TqApi(auth=...)` alone is not a real broker account.
+- It is enough for data questions and defaults to a local simulated account.
+- Use `TqAccount(...)` only when the user wants live trading through a supported broker.
+
+### `TqMultiAccount`
+
+Use this when one strategy must operate more than one account at once.
+
+Rules:
+
+- pass `account=` to `insert_order`, `cancel_order`, `get_account`, `get_position`, `get_order`, `get_trade`, and similar account-sensitive APIs
+- or use `account_obj.get_account()`, `account_obj.get_position()`, `account_obj.get_order()`, `account_obj.get_trade()`
+- if the user forgets this, they will hit the common "多账户模式下, 需要指定账户实例 account" error
+
+## Selection Advice To Reuse
+
+- Data only: `TqApi(auth=TqAuth(...))`
+- Futures local sim: `TqSim()`
+- Futures Quick sim: `TqKq()`
+- Stock local sim or stock backtest: `TqSimStock()`
+- Stock Quick sim: `TqKqStock()`
+- Broker live trading: `TqAccount(...)`
+- One API, many accounts: `TqMultiAccount([...])`
+
+## Repository Sources
+
+- `tqsdk/__init__.py`
+- `tqsdk/tradeable/__init__.py`
+- `doc/usage/framework.rst`
+- `doc/usage/shinny_account.rst`
+- `doc/reference/tqsdk.tqkq.rst`
+- `doc/reference/tqsdk.sim.rst`
+- `tqsdk/api.py`

--- a/tqsdk-trading-and-data/references/accounts-and-trading.md
+++ b/tqsdk-trading-and-data/references/accounts-and-trading.md
@@ -1,0 +1,136 @@
+# Accounts And Trading
+
+## Use This Reference For
+
+- Reading funds, positions, orders, and trades
+- Futures versus stock account objects
+- Multi-account getter patterns
+
+## Table Of Contents
+
+- Core getters
+- Futures and stock objects
+- Funds, positions, orders, trades
+- Common field subsets
+- Multi-account patterns
+
+Read [account-type-matrix.md](account-type-matrix.md) first if the user is still choosing an account class.
+Read [object-fields.md](object-fields.md) when the user asks what a field means.
+Read [order-functions-and-position-tools.md](order-functions-and-position-tools.md) for `insert_order`, `cancel_order`, and `TargetPosTask`.
+Read [scenario-and-margin.md](scenario-and-margin.md) for `TqScenario`, real-account margin-rate lookup, and margin or risk what-if analysis.
+
+## Core Getters
+
+- `api.get_account(account=None)`
+- `api.get_position(symbol=None, account=None)`
+- `api.get_order(order_id=None, account=None)`
+- `api.get_trade(trade_id=None, account=None)`
+
+These all return live references that refresh during `wait_update()`.
+
+## Futures And Stock Objects
+
+Futures-like accounts return:
+
+- `Account`
+- `Position`
+- `Order`
+- `Trade`
+
+Stock-like accounts return:
+
+- `SecurityAccount`
+- `SecurityPosition`
+- `SecurityOrder`
+- `SecurityTrade`
+
+Do not explain futures-only fields such as `offset`, `margin`, or `pos_long_today` on stock objects.
+
+## Funds, Positions, Orders, Trades
+
+Basic pattern:
+
+```python
+from tqsdk import TqApi, TqAuth
+
+api = TqApi(auth=TqAuth("快期账户", "账户密码"))
+account = api.get_account()
+position = api.get_position("DCE.m2505")
+orders = api.get_order()
+trades = api.get_trade()
+
+while True:
+    api.wait_update()
+    if api.is_changing(account, "available"):
+        print("available", account.available)
+    if api.is_changing(position, ["pos_long", "pos_short", "float_profit"]):
+        print(position.pos_long, position.pos_short, position.float_profit)
+```
+
+For generic examples, `TqApi(auth=...)` is enough and defaults to a local `TqSim()` account.
+Switch to `TqKq()`, `TqAccount(...)`, or another explicit account class only when the user needs that exact account mode.
+
+Important collection behavior:
+
+- `get_order()` without `order_id` returns a dict-like collection keyed by order id
+- `get_trade()` without `trade_id` returns a dict-like collection keyed by trade id
+- `order.trade_records` is usually a better answer than dumping every trade in the account
+- `position.orders` returns related ALIVE orders for that position
+
+## Common Field Subsets
+
+Use the smallest relevant subset when answering users.
+
+Account:
+
+- futures: `balance`, `available`, `margin`, `float_profit`, `position_profit`, `risk_ratio`
+- stock: `asset`, `available`, `drawable`, `market_value`, `hold_profit`, `profit_today`
+
+Position:
+
+- futures: `pos`, `pos_long`, `pos_short`, `pos_long_today`, `pos_short_today`, `float_profit`, `position_profit`
+- stock: `volume`, `volume_his`, `last_price`, `market_value`, `hold_profit`, `profit_today`
+
+Order:
+
+- futures: `order_id`, `status`, `direction`, `offset`, `volume_orign`, `volume_left`, `limit_price`, `last_msg`
+- stock: `order_id`, `status`, `direction`, `volume_orign`, `volume_left`, `limit_price`, `last_msg`
+
+Trade:
+
+- futures: `trade_id`, `order_id`, `price`, `volume`, `direction`, `offset`, `trade_date_time`
+- stock: `trade_id`, `order_id`, `price`, `volume`, `balance`, `fee`, `direction`, `trade_date_time`
+
+## Multi-Account Patterns
+
+API-based pattern:
+
+```python
+from tqsdk import TqApi, TqAuth, TqAccount, TqKq, TqMultiAccount
+
+real_acc = TqAccount("H海通期货", "123456", "123456")
+sim_acc = TqKq()
+
+api = TqApi(TqMultiAccount([real_acc, sim_acc]), auth=TqAuth("快期账户", "账户密码"))
+account_info = api.get_account(account=sim_acc)
+position = api.get_position("DCE.m2505", account=sim_acc)
+orders = api.get_order(account=sim_acc)
+trades = api.get_trade(account=sim_acc)
+```
+
+Account-object pattern:
+
+```python
+account_info = sim_acc.get_account()
+position = sim_acc.get_position("DCE.m2505")
+orders = sim_acc.get_order()
+trades = sim_acc.get_trade()
+```
+
+## Repository Sources
+
+- `tqsdk/api.py`
+- `tqsdk/tradeable/mixin.py`
+- `tqsdk/demo/tutorial/t40.py`
+- `tqsdk/demo/download_orders.py`
+- `tqsdk/demo/multiaccount.py`

--- a/tqsdk-trading-and-data/references/error-faq.md
+++ b/tqsdk-trading-and-data/references/error-faq.md
@@ -1,0 +1,197 @@
+# Error FAQ
+
+## Use This Reference For
+
+- Common TqSdk error messages
+- "Why is nothing updating?"
+- "Why is my order or `TargetPosTask` not moving?"
+- Multi-account mistakes
+- Stock versus futures mistakes
+
+## Table Of Contents
+
+- No data, `NaN`, or empty fields
+- `insert_order()` or `cancel_order()` does nothing
+- `TargetPosTask` does not act
+- `TargetPosTask` and minimum open volume contracts
+- Multi-account errors
+- `offset` errors
+- Stock and futures mixed up
+- `wait_update()` blocks too long
+- Backtest behavior looks wrong
+- `DataDownloader` errors
+- "未初始化 TqApi"
+- Named exception classes
+- Error triage order
+
+## No Data, `NaN`, Or Empty Fields
+
+Typical cause:
+
+- the user created the object but did not keep calling `wait_update()`
+- the first data packet has not arrived yet
+- the symbol is expired or not the one they meant
+
+Check:
+
+1. Is the code still calling `api.wait_update()`?
+2. Is `quote.datetime` still empty?
+3. Did the user hardcode an expired contract?
+
+## `insert_order()` Or `cancel_order()` "Does Nothing"
+
+Typical cause:
+
+- the user called the API but never called `wait_update()` afterward
+
+Reuse this explanation:
+
+- "`insert_order()` and `cancel_order()` queue the request. The actual packet is sent on the next `wait_update()`."
+
+## `TargetPosTask` Does Not Act
+
+Typical causes:
+
+- no `wait_update()` after `set_target_volume()`
+- the user mixed `TargetPosTask` with manual `insert_order()` on the same symbol
+- the user created another `TargetPosTask` for the same account and symbol with different parameters
+- the task was canceled or already finished
+
+Relevant messages:
+
+- "已经结束的 TargetPosTask 实例不可以再设置手数。"
+- "您试图用不同的 ... 参数创建两个 ... 调仓任务"
+
+## `TargetPosTask` And Minimum Open Volume Contracts
+
+Typical cause:
+
+- the contract has `quote.open_min_market_order_volume > 1` or `quote.open_min_limit_order_volume > 1`
+- by default, `TargetPosTask` refuses these contracts during later `wait_update()` calls
+
+Fix:
+
+- if exact target-position adjustment is required, use manual order control instead
+- if approximate completion is acceptable, create the task with `support_open_min_volume=True`
+- judge completion with `abs(position.pos - target_volume) < quote.open_min_limit_order_volume`
+- if `min_volume` and `max_volume` are used, both must be at least `quote.open_min_limit_order_volume`
+- if the same account and symbol already has a `TargetPosTask`, cancel it before recreating it with a different `support_open_min_volume` value
+
+## Multi-Account Error: "需要指定账户实例 account"
+
+Typical cause:
+
+- the API was created with `TqMultiAccount`, but `account=` was omitted
+
+Fix:
+
+- pass `account=` to account-sensitive APIs
+- or switch to `account_obj.get_account()`, `account_obj.get_position()`, `account_obj.get_order()`, `account_obj.get_trade()`
+
+## `offset` Errors
+
+Typical causes:
+
+- futures code used an invalid `offset`
+- stock code wrongly set `offset`
+
+Fix:
+
+- futures: use `OPEN`, `CLOSE`, or `CLOSETODAY`
+- stock: do not pass `offset`
+
+## Stock And Futures Mixed Up
+
+Typical symptoms:
+
+- using futures fields on stock objects
+- expecting `TargetPosTask` to work for stock trading
+- expecting stock orders to accept futures-style `offset`
+
+Fix:
+
+- determine whether the account is futures-like or stock-like first
+- use `SecurityAccount`, `SecurityPosition`, `SecurityOrder`, `SecurityTrade` semantics for stock
+
+## `wait_update()` Blocks Too Long
+
+Typical cause:
+
+- the user expects polling behavior from a blocking update loop
+- the code is running in Jupyter and hangs waiting for updates
+- the first real-account `TqScenario` margin-rate lookup is waiting for OTG data synchronously
+
+Fix:
+
+- use `deadline=...` when the user truly needs a timeout
+- in Jupyter, prefer simple synchronous examples and explicitly mention the limitation
+- if the code uses `TqScenario(account=TqAccount(...))` or `TqScenario(account=TqKq())`, explain that the first uncached margin-rate lookup may block while TqSdk fetches the account-specific rate
+
+## Backtest Behavior Looks Wrong
+
+Typical confusion:
+
+- one `wait_update()` updates only order state
+- the next `wait_update()` advances time
+- multiple series advance in timestamp order
+
+Fix:
+
+- explain that backtest progression differs from live mode
+- point to subscribed series and `is_changing(...)` checks
+
+## `DataDownloader` Errors
+
+Common cases:
+
+- account does not have permission for historical download
+- tick download attempted with multiple symbols
+- unsupported `adj_type`
+- unsupported output argument types
+
+If the user asks about a download error, check `symbol_list`, `dur_sec`, `adj_type`, and whether the account has download permission.
+
+## "未初始化 TqApi"
+
+Typical cause:
+
+- the user called account-object getters before wiring the account into `TqApi`
+
+Fix:
+
+- create `api = TqApi(...)` first
+- only then call `account.get_account()` or similar account-object getters
+
+## Named Exception Classes
+
+These exception names are worth recognizing explicitly:
+
+- Top-level exports from `tqsdk.__init__`: `BacktestFinished`, `TqTimeoutError`, `TqBacktestPermissionError`, `TqRiskRuleError`
+- `TqContextManagerError`: context-manager misuse; import it from `tqsdk.exceptions` if the user is already using that name directly
+
+If the user reports one of these names directly, prefer explaining the meaning of the exception before proposing code changes.
+
+## Error Triage Order
+
+When debugging, check in this order:
+
+1. wrong account type
+2. missing `wait_update()`
+3. futures versus stock mismatch
+4. missing `account=` in multi-account mode
+5. wrong symbol or expired symbol
+6. wrong `offset`, `advanced`, or order-price mode
+7. unsupported target-position workflow
+
+## Repository Sources
+
+- `tqsdk/api.py`
+- `tqsdk/lib/utils.py`
+- `tqsdk/lib/target_pos_task.py`
+- `tqsdk/lib/target_pos_scheduler.py`
+- `tqsdk/tools/downloader.py`
+- `tqsdk/tradeable/mixin.py`
+- `tqsdk/exceptions.py`
+- `doc/usage/framework.rst`
+- `doc/usage/backtest.rst`
+- `doc/usage/jupyter.rst`

--- a/tqsdk-trading-and-data/references/example-map.md
+++ b/tqsdk-trading-and-data/references/example-map.md
@@ -1,0 +1,100 @@
+# Example Map
+
+Use this file when you need a concrete repository example or doc page before writing or revising an answer.
+
+## If The User Asks About `wait_update`
+
+- `doc/usage/framework.rst`
+  - core update-loop explanation
+- `doc/advanced/for_vnpy_user.rst`
+  - practical `wait_update` and `is_changing` framing for strategy users
+- `doc/usage/jupyter.rst`
+  - notebook caveats and `deadline`
+
+## If The User Asks About Market Data
+
+- `tqsdk/demo/tutorial/t10.py`
+  - minimal quote read
+- `tqsdk/demo/tutorial/t30.py`
+  - quote, tick, and K-line updates with `is_changing`
+- `tqsdk/demo/tutorial/underlying_symbol.py`
+  - main-contract `underlying_symbol`
+- `doc/usage/mddatas.rst`
+  - broader market-data usage patterns
+
+## If The User Asks About Funds, Positions, Orders, Or Trades
+
+- `tqsdk/demo/tutorial/t40.py`
+  - account, position, and order state in the update loop
+- `tqsdk/demo/download_orders.py`
+  - export orders and trades
+- `tqsdk/tradeable/mixin.py`
+  - account-object getter patterns
+
+## If The User Asks About Manual Orders
+
+- `tqsdk/demo/tutorial/t41.py`
+  - open then close with manual orders
+- `tqsdk/demo/tutorial/t60.py`
+  - strategy using `insert_order`
+- `tqsdk/api.py`
+  - exact `insert_order` and `cancel_order` semantics
+
+## If The User Asks About `TargetPosTask` Or Scheduled Execution
+
+- `tqsdk/demo/tutorial/t70.py`
+  - basic `TargetPosTask` strategy
+- `doc/usage/targetpostask.rst`
+  - `TargetPosTask` rules and caveats, including `support_open_min_volume`
+- `doc/advanced/targetpostask2.rst`
+  - `cancel()` and `is_finished()`
+- `doc/advanced/scheduler.rst`
+  - `TargetPosScheduler`
+- `design/target_pos_task_support_open_min_limit.md`
+  - design notes for contracts with minimum opening volume rules
+- `tqsdk/test/target_pos_task/test_open_min_volume.py`
+  - regression cases for `support_open_min_volume`
+
+## If The User Asks About Margin Trials Or `TqScenario`
+
+- `tqsdk/scenario/tqscenario.py`
+  - public `TqScenario` docstrings and method semantics
+- `design/scenario.md`
+  - scenario design, margin-rate source rules, and discount-model notes
+- `tqsdk/test/scenario/test_scenario.py`
+  - runnable what-if patterns for margin and risk changes
+- `tqsdk/test/scenario/test_pre_insert_order.py`
+  - real-account margin-rate lookup examples and expected values
+- `doc/reference/tqsdk.scenario.rst`
+  - public API reference entry
+
+## If The User Asks About Account Types Or Multi-Account
+
+- `doc/usage/shinny_account.rst`
+  - Quick account versus real account login
+- `tqsdk/demo/multiaccount.py`
+  - one API with multiple accounts
+- `doc/reference/tqsdk.multiaccount.rst`
+  - `TqMultiAccount`
+- `doc/reference/tqsdk.tqkq.rst`
+  - `TqKq` and `TqKqStock`
+- `doc/reference/tqsdk.sim.rst`
+  - `TqSim` and `TqSimStock`
+
+## If The User Asks About Backtest
+
+- `tqsdk/demo/tutorial/backtest.py`
+  - futures backtest setup
+- `doc/usage/backtest.rst`
+  - backtest behavior, wait-update progression, stock backtest notes
+
+## If The User Asks About Common Errors
+
+- `tqsdk/lib/utils.py`
+  - parameter validation errors
+- `tqsdk/lib/target_pos_task.py`
+  - `TargetPosTask` misuse and lifecycle errors
+- `tqsdk/tools/downloader.py`
+  - download permissions and parameter errors
+- `tqsdk/tradeable/mixin.py`
+  - "未初始化 TqApi" style errors

--- a/tqsdk-trading-and-data/references/market-data.md
+++ b/tqsdk-trading-and-data/references/market-data.md
@@ -1,0 +1,157 @@
+# Market Data
+
+## Use This Reference For
+
+- `get_quote`
+- `get_kline_serial`
+- `get_tick_serial`
+- `query_quotes`, `query_cont_quotes`, `query_symbol_info`, `get_trading_status`
+- `DataDownloader`
+
+## Table Of Contents
+
+- Session setup
+- Real-time quote
+- K-line and tick series
+- Contract discovery
+- Long-range historical download
+
+## Session Setup
+
+For read-only examples, this is usually enough:
+
+```python
+from tqsdk import TqApi, TqAuth
+
+api = TqApi(auth=TqAuth("快期账户", "账户密码"))
+```
+
+Notes:
+
+- `TqApi(auth=...)` defaults to a local `TqSim()` account.
+- Market-data questions usually do not require a real trading account.
+- Close the API explicitly or use a context manager.
+
+## Real-Time Quote
+
+```python
+from tqsdk import TqApi, TqAuth
+
+api = TqApi(auth=TqAuth("快期账户", "账户密码"))
+quote = api.get_quote("SHFE.au2504")
+
+while True:
+    api.wait_update()
+    if api.is_changing(quote, ["last_price", "ask_price1", "bid_price1"]):
+        print(quote.datetime, quote.last_price, quote.ask_price1, quote.bid_price1)
+```
+
+Recommended quote fields:
+
+- `datetime`
+- `last_price`
+- `ask_price1`, `bid_price1`
+- `volume`, `open_interest`
+- `price_tick`, `volume_multiple`
+- `instrument_name`, `ins_class`, `expired`
+- `underlying_symbol` for main contracts and options
+
+If the user wants "current price", do not hardcode expired delivery months.
+
+## K-Line And Tick Series
+
+K-line:
+
+```python
+klines = api.get_kline_serial("DCE.i2505", 60, data_length=200)
+
+while True:
+    api.wait_update()
+    if api.is_changing(klines.iloc[-1], "datetime"):
+        print("new bar", klines.iloc[-1].datetime, klines.iloc[-1].close)
+```
+
+Tick:
+
+```python
+ticks = api.get_tick_serial("DCE.i2505", data_length=200)
+
+while True:
+    api.wait_update()
+    if api.is_changing(ticks.iloc[-1], "datetime"):
+        print(ticks.iloc[-1].datetime, ticks.iloc[-1].last_price)
+```
+
+Important semantics:
+
+- Both APIs return pandas `DataFrame` objects that update in place.
+- `get_kline_serial(..., data_length=...)` and `get_tick_serial(..., data_length=...)` support up to 10000 rows per request.
+- For `get_kline_serial`, intraday durations can be arbitrary seconds; day-or-higher durations must be integer multiples of 86400, up to 28 days.
+- When `symbol` is a list in `get_kline_serial`, all secondary symbols align to the first symbol's timeline.
+- `adj_type` only matters for stock and fund contracts.
+
+Typical columns:
+
+- K-line: `datetime`, `open`, `high`, `low`, `close`, `volume`, `open_oi`, `close_oi`
+- Tick: `datetime`, `last_price`, `ask_price1`, `bid_price1`, `highest`, `lowest`, `volume`, `amount`, `open_interest`
+
+## Contract Discovery
+
+Use discovery APIs before writing "current contract" examples.
+
+- `api.query_quotes(...)`: broad filtering by contract class, exchange, product, expired flag, night session
+- `api.query_cont_quotes(...)`: main-contract lookup
+- `api.query_symbol_info(...)`: static metadata table, not a live object
+- `api.get_trading_status(symbol)`: current trading state
+
+Pattern:
+
+```python
+from tqsdk import TqApi, TqAuth
+
+with TqApi(auth=TqAuth("快期账户", "账户密码")) as api:
+    conts = api.query_cont_quotes(exchange_id="SHFE", product_id="au")
+    info = api.query_symbol_info(list(conts))
+    print(info[["instrument_id", "instrument_name", "ins_class", "price_tick", "volume_multiple"]])
+```
+
+## Long-Range Historical Download
+
+Use `DataDownloader` when the user wants CSV export or long date ranges.
+
+```python
+from contextlib import closing
+from datetime import date
+from tqsdk import TqApi, TqAuth
+from tqsdk.tools import DataDownloader
+
+api = TqApi(auth=TqAuth("快期账户", "账户密码"))
+task = DataDownloader(
+    api,
+    symbol_list="KQ.m@SHFE.rb",
+    dur_sec=60,
+    start_dt=date(2025, 1, 1),
+    end_dt=date(2025, 2, 1),
+    csv_file_name="rb_main_1m.csv",
+)
+
+with closing(api):
+    while not task.is_finished():
+        api.wait_update()
+        print(f"{task.get_progress():.2f}%")
+```
+
+Notes:
+
+- `dur_sec=0` means tick download.
+- `DataDownloader` is a paid or permission-gated feature.
+- Multi-symbol downloads align by the first symbol's trading calendar.
+
+## Repository Sources
+
+- `tqsdk/demo/tutorial/t10.py`
+- `tqsdk/demo/tutorial/t30.py`
+- `tqsdk/demo/tutorial/underlying_symbol.py`
+- `doc/usage/mddatas.rst`
+- `tqsdk/tools/downloader.py`
+- `tqsdk/api.py`

--- a/tqsdk-trading-and-data/references/object-fields.md
+++ b/tqsdk-trading-and-data/references/object-fields.md
@@ -1,0 +1,213 @@
+# Object Fields
+
+## Table Of Contents
+
+- How to use this reference
+- Quote, K-line, and Tick
+- Futures `Account`, `Position`, `Order`, `Trade`
+- Stock `SecurityAccount`, `SecurityPosition`, `SecurityOrder`, `SecurityTrade`
+- Practical answering rules
+
+## How To Use This Reference
+
+Use this file when the user asks what object fields mean.
+
+Rules:
+
+1. Identify whether the object is market data, futures trading, or stock trading.
+2. Explain the smallest relevant field set first.
+3. Mention whether the object is a live reference updated by `wait_update()`.
+4. Mention when a field is only meaningful for futures or only for stock.
+
+## Quote, K-line, And Tick
+
+`Quote` common fields:
+
+| Field | Meaning | Typical use |
+| --- | --- | --- |
+| `datetime` | exchange timestamp string | confirm freshness |
+| `last_price` | latest traded price | current price display |
+| `ask_price1`, `bid_price1` | best ask and best bid | spread, order pricing |
+| `ask_volume1`, `bid_volume1` | top-of-book volume | liquidity checks |
+| `volume` | cumulative traded volume | activity checks |
+| `open_interest` | open interest | futures participation |
+| `highest`, `lowest`, `open`, `close`, `average` | session statistics | intraday analysis |
+| `price_tick` | minimum price increment | order price calculation |
+| `volume_multiple` | contract multiplier | PnL and sizing |
+| `open_min_market_order_volume`, `open_min_limit_order_volume` | minimum opening order size for market or limit orders | decide whether `TargetPosTask(..., support_open_min_volume=True)` is needed |
+| `instrument_name`, `instrument_id`, `exchange_id`, `ins_class` | contract identity | explain what the symbol is |
+| `underlying_symbol` | underlying for main contracts and options | map derived contracts |
+| `expired` | whether the contract is expired | avoid stale examples |
+
+K-line row common fields:
+
+- `datetime`
+- `open`
+- `high`
+- `low`
+- `close`
+- `volume`
+- `open_oi`
+- `close_oi`
+
+Tick row common fields:
+
+- `datetime`
+- `last_price`
+- `ask_price1`, `bid_price1`
+- `highest`, `lowest`
+- `volume`
+- `amount`
+- `open_interest`
+
+## Futures `Account`
+
+Most useful fields:
+
+| Field | Meaning |
+| --- | --- |
+| `balance` | dynamic account equity |
+| `available` | available funds |
+| `margin` | margin in use |
+| `float_profit` | floating PnL versus open price |
+| `position_profit` | position PnL versus prior settlement |
+| `close_profit` | realized close PnL today |
+| `commission` | fees paid today |
+| `deposit`, `withdraw` | today's cash movement |
+| `risk_ratio` | margin divided by equity |
+| `market_value` | option market value |
+
+## Futures `Position`
+
+Most useful fields:
+
+| Field | Meaning |
+| --- | --- |
+| `pos` | net position |
+| `pos_long`, `pos_short` | long and short total lots |
+| `pos_long_today`, `pos_short_today` | today's long and short lots |
+| `pos_long_his`, `pos_short_his` | yesterday's long and short lots |
+| `float_profit` | floating PnL |
+| `position_profit` | position PnL |
+| `margin` | margin used by this position |
+| `open_price_long`, `open_price_short` | average open price |
+| `position_price_long`, `position_price_short` | average holding cost basis |
+
+Less preferred compatibility fields from the broker side:
+
+- `volume_long*`
+- `volume_short*`
+
+Prefer the `pos_*` fields in explanations unless the user explicitly needs the broker-returned compatibility values.
+
+## Futures `Order`
+
+| Field | Meaning |
+| --- | --- |
+| `order_id` | client order id |
+| `exchange_order_id` | exchange order id |
+| `direction` | `BUY` or `SELL` |
+| `offset` | `OPEN`, `CLOSE`, `CLOSETODAY` |
+| `volume_orign` | original order size |
+| `volume_left` | unfilled size |
+| `limit_price` | order limit price |
+| `price_type` | `ANY`, `LIMIT`, `BEST`, or `FIVELEVEL` depending on exchange behavior |
+| `volume_condition` | quantity condition |
+| `time_condition` | time condition |
+| `insert_date_time` | order timestamp in nanoseconds |
+| `status` | `ALIVE` or `FINISHED` |
+| `last_msg` | latest order-state message |
+| `is_dead` | definitely cannot trade anymore |
+| `is_online` | definitely accepted by exchange and waiting |
+| `is_error` | definitely a bad order |
+| `trade_price` | average traded price |
+
+Useful related property:
+
+- `order.trade_records`
+
+## Futures `Trade`
+
+| Field | Meaning |
+| --- | --- |
+| `trade_id` | trade id |
+| `order_id` | parent order id |
+| `price` | trade price |
+| `volume` | filled lots |
+| `direction` | `BUY` or `SELL` |
+| `offset` | open or close action |
+| `trade_date_time` | trade timestamp in nanoseconds |
+
+## Stock `SecurityAccount`
+
+| Field | Meaning |
+| --- | --- |
+| `asset` | total current assets |
+| `available` | current available cash |
+| `drawable` | cash that can be withdrawn |
+| `market_value` | current stock market value |
+| `cost` | current total buy cost |
+| `hold_profit` | holding profit |
+| `float_profit_today` | today's floating profit |
+| `real_profit_today` | today's realized profit |
+| `profit_today` | today's total profit |
+| `profit_rate_today` | today's profit rate |
+| `buy_frozen_balance`, `buy_frozen_fee` | cash and fee frozen by pending buy orders |
+
+## Stock `SecurityPosition`
+
+| Field | Meaning |
+| --- | --- |
+| `volume` | current shares |
+| `volume_his` | prior-day shares |
+| `last_price` | latest price |
+| `market_value` | current market value |
+| `cost` | current cost |
+| `hold_profit` | holding profit |
+| `profit_today` | today's total profit |
+| `profit_rate_today` | today's profit rate |
+| `real_profit_total` | accumulated realized profit |
+| `profit_total` | total profit |
+
+## Stock `SecurityOrder`
+
+| Field | Meaning |
+| --- | --- |
+| `order_id` | client order id |
+| `exchange_order_id` | exchange order id |
+| `direction` | `BUY` or `SELL` |
+| `volume_orign` | requested shares |
+| `volume_left` | unfilled shares |
+| `price_type` | price type |
+| `limit_price` | limit price |
+| `frozen_fee` | frozen fee |
+| `status` | current order state |
+| `last_msg` | latest order-state message |
+
+## Stock `SecurityTrade`
+
+| Field | Meaning |
+| --- | --- |
+| `trade_id` | trade id |
+| `order_id` | parent order id |
+| `direction` | `BUY`, `SELL`, `SHARED`, or `DEVIDEND` |
+| `volume` | shares or granted shares |
+| `price` | trade price |
+| `balance` | cash amount or dividend amount |
+| `fee` | fee |
+| `trade_date_time` | trade timestamp in nanoseconds |
+
+## Practical Answering Rules
+
+- Futures timestamps and stock timestamps are generally nanoseconds since Unix epoch on order and trade objects.
+- Market-data `datetime` is usually a human-readable string.
+- When the user asks "what fields should I print", prefer 4 to 8 fields, not the full object.
+- For "all orders" or "all trades", explain that the getter returns a dict-like collection keyed by id.
+- For "what traded under this order", prefer `order.trade_records`.
+- For "what orders belong to this position", mention `position.orders`.
+
+## Repository Sources
+
+- `tqsdk/objs.py`
+- `tqsdk/api.py`
+- `tqsdk/tradeable/mixin.py`

--- a/tqsdk-trading-and-data/references/order-functions-and-position-tools.md
+++ b/tqsdk-trading-and-data/references/order-functions-and-position-tools.md
@@ -1,0 +1,220 @@
+# Order Functions And Position Tools
+
+## Use This Reference For
+
+- `insert_order`
+- `cancel_order`
+- `TargetPosTask`
+- `TargetPosScheduler`
+- Choosing between manual order control, target-position control, and `TqScenario`
+
+## Table Of Contents
+
+- Manual orders
+- Cancel orders
+- When to use manual orders
+- `TargetPosTask`
+- `TargetPosTask` with exchange minimum open volume
+- `TargetPosScheduler`
+- `TqScenario` versus live execution tools
+- Advanced helpers beyond the default answer
+- Stock limitations
+
+## Manual Orders: `insert_order`
+
+`insert_order()` is the public API for direct order placement.
+
+Key parameters:
+
+- `symbol`
+- `direction`: `BUY` or `SELL`
+- `offset`: futures only, usually `OPEN`, `CLOSE`, `CLOSETODAY`
+- `volume`
+- `limit_price`
+- `advanced`: `FAK`, `FOK`, or `None`
+- `account`: required in multi-account mode
+
+Important behavior:
+
+- the order packet is actually sent on the next `wait_update()`
+- stock trading does not use `offset`
+- stock orders may omit `limit_price`; `limit_price=None` becomes `price_type="ANY"`
+
+Basic futures example:
+
+```python
+from tqsdk import TqApi, TqAuth
+
+api = TqApi(auth=TqAuth("快期账户", "账户密码"))
+quote = api.get_quote("SHFE.au2504")
+order = api.insert_order(
+    symbol="SHFE.au2504",
+    direction="BUY",
+    offset="OPEN",
+    volume=1,
+    limit_price=quote.ask_price1,
+)
+
+while order.status != "FINISHED":
+    api.wait_update()
+    print(order.status, order.volume_left, order.last_msg)
+```
+
+Advanced order modes:
+
+- `advanced="FAK"`: remaining quantity is canceled immediately
+- `advanced="FOK"`: all-or-kill
+- `limit_price="BEST"` or `"FIVELEVEL"`: only supported on CFFEX
+
+Do not recommend advanced combinations unless the exchange and contract class support them.
+
+## Cancel Orders: `cancel_order`
+
+```python
+api.cancel_order(order)
+api.wait_update()
+```
+
+Rules:
+
+- `cancel_order()` accepts an order object or order id
+- the cancel packet is also sent on the next `wait_update()`
+- in multi-account mode, pass `account=...` if needed
+
+## When To Use Manual Orders
+
+Prefer manual orders when the user wants:
+
+- explicit price control
+- explicit cancellation logic
+- partial-fill handling
+- exchange-specific order semantics
+- custom order chasing
+
+## `TargetPosTask`
+
+Use `TargetPosTask` when the user thinks in target net position, not individual orders.
+
+```python
+from tqsdk import TqApi, TqAuth, TargetPosTask
+
+api = TqApi(auth=TqAuth("快期账户", "账户密码"))
+target_pos = TargetPosTask(api, "DCE.m2505")
+target_pos.set_target_volume(5)
+
+while True:
+    api.wait_update()
+```
+
+Rules:
+
+- create one `TargetPosTask` per account and symbol
+- keep calling `wait_update()` after `set_target_volume()`
+- do not mix `TargetPosTask` and manual `insert_order()` on the same symbol
+- if you need a different `price`, `offset_priority`, `min_volume`, or `max_volume`, cancel the old task before creating a new one
+- by default, `TargetPosTask` rejects contracts whose `quote.open_min_market_order_volume` or `quote.open_min_limit_order_volume` is greater than 1
+
+Useful parameters:
+
+- `price`: `"ACTIVE"`, `"PASSIVE"`, or a custom price function
+- `offset_priority`
+- `min_volume` and `max_volume` for split execution
+- `account` in multi-account mode
+- `support_open_min_volume=True` for contracts with an exchange minimum opening size, with the limitations below
+
+Useful lifecycle APIs:
+
+- `target_pos.cancel()`
+- `target_pos.is_finished()`
+
+## `TargetPosTask` With Exchange Minimum Open Volume
+
+Use `support_open_min_volume=True` only when the user explicitly wants `TargetPosTask` on a contract where `quote.open_min_market_order_volume > 1` or `quote.open_min_limit_order_volume > 1`.
+
+Important limits:
+
+- exact target completion is not guaranteed; treat the task as complete when `abs(position.pos - target_volume) < quote.open_min_limit_order_volume`
+- if split execution is enabled, both `min_volume` and `max_volume` must be at least `quote.open_min_limit_order_volume`
+- when the remaining opening chase volume is below `quote.open_min_limit_order_volume`, that opening chase stops instead of sending another order
+- if the task can only open positions and the calculated opening size is already below `quote.open_min_limit_order_volume`, no order is sent and the task ends
+- `support_open_min_volume` is part of the singleton construction parameters; cancel the old task before recreating the same account and symbol with a different value
+
+Example completion check:
+
+```python
+from tqsdk import TqApi, TqAuth, TargetPosTask
+
+api = TqApi(auth=TqAuth("快期账户", "账户密码"))
+symbol = "GFEX.ps2704"
+target_volume = 20
+
+quote = api.get_quote(symbol)
+position = api.get_position(symbol)
+target_pos = TargetPosTask(api, symbol, support_open_min_volume=True)
+target_pos.set_target_volume(target_volume)
+
+while True:
+    api.wait_update()
+    if abs(position.pos - target_volume) < quote.open_min_limit_order_volume:
+        print("Target position task is complete enough for this contract rule.")
+        break
+
+api.close()
+```
+
+## `TargetPosScheduler`
+
+Use `TargetPosScheduler` when the user wants scheduled target-position execution instead of one immediate target.
+
+It is the public helper for time-table driven execution and works with:
+
+- a custom `time_table`
+- `twap_table(...)`
+- `vwap_table(...)`
+
+Common import:
+
+```python
+from tqsdk.algorithm import twap_table, vwap_table
+```
+
+It still depends on continuous `wait_update()` calls and must not be mixed with `TargetPosTask` or manual `insert_order()` for the same workflow.
+
+## `TqScenario` Versus Live Execution Tools
+
+Use `TqScenario` when the user wants synchronous trial calculation for futures margin or risk changes without sending live orders.
+
+Read [scenario-and-margin.md](scenario-and-margin.md) when the request is about:
+
+- how many lots can still be opened
+- how much margin can be released by reducing positions
+- what margin or risk ratio becomes after changing positions, balance, or margin rates
+
+Do not route live execution requests to `TqScenario`.
+
+## Advanced Helpers Beyond The Default Answer
+
+These exist, but should not be the first answer unless the user is already using them:
+
+- `InsertOrderTask`
+- `InsertOrderUntilAllTradedTask`
+- `tqsdk.algorithm.Twap`
+
+Explain them as advanced or specialized execution helpers, not as the default recommendation.
+
+## Stock Limitations
+
+- Stock trading does not use `offset`
+- `TargetPosTask` is not the right answer for stock trading
+- Stock order objects are `SecurityOrder`, not `Order`
+
+## Repository Sources
+
+- `tqsdk/api.py`
+- `doc/usage/targetpostask.rst`
+- `doc/advanced/targetpostask2.rst`
+- `doc/advanced/scheduler.rst`
+- `tqsdk/lib/target_pos_task.py`
+- `tqsdk/lib/target_pos_scheduler.py`
+- `tqsdk/algorithm/time_table_generater.py`
+- `tqsdk/algorithm/twap.py`

--- a/tqsdk-trading-and-data/references/scenario-and-margin.md
+++ b/tqsdk-trading-and-data/references/scenario-and-margin.md
@@ -1,0 +1,144 @@
+# Scenario And Margin
+
+## Use This Reference For
+
+- `TqScenario`
+- Real-account margin-rate lookup
+- Margin occupancy and risk-ratio what-if analysis
+- Questions such as "how many lots can I still open?" or "how much margin will I release?"
+
+## Table Of Contents
+
+- When to choose `TqScenario`
+- Core APIs
+- Snapshot inputs
+- Margin-rate sources
+- Limited margin discount behavior
+- Common patterns
+- Boundaries
+- Repository sources
+
+## When To Choose `TqScenario`
+
+Use `TqScenario` when the user wants synchronous "what if" analysis against a snapshot of current futures positions and funds.
+
+Typical requests:
+
+- max lots under a margin budget
+- how many lots to close to free a target amount of margin
+- margin or risk ratio after opening or reducing multiple futures symbols
+- risk ratio after changing a futures margin rate
+- risk ratio after keeping positions unchanged but changing starting equity
+
+Prefer live-order helpers such as `insert_order()` or `TargetPosTask` only when the user wants execution, not trial calculation.
+
+## Core APIs
+
+- `TqScenario(api, account=None, positions=None, init_balance=10000000.0)`
+- `scenario_insert_order(symbol, direction, offset, volume, limit_price)`
+- `scenario_set_margin_rate(symbol, margin_rate)`
+- `scenario_get_account()`
+
+Important behavior:
+
+- `TqScenario` creates an internal futures trading snapshot and updates it immediately after each `scenario_*` call.
+- `scenario_insert_order()` matches immediately at the passed `limit_price`.
+- `scenario_insert_order()` does not model partial fills. Read `status`, `volume_left`, and `last_msg`.
+- `scenario_get_account()` returns only `margin` and `risk_ratio`.
+- `scenario_set_margin_rate()` updates one futures symbol inside the scenario and recalculates account margin from `pre_settlement`.
+
+## Snapshot Inputs
+
+- Pass `positions=api.get_position()` to start from the current futures position snapshot.
+- Pass one `Position` object if the user only wants to trial one symbol.
+- Omit `positions` to start from an empty futures account.
+- Use `init_balance` to choose the starting equity for the scenario snapshot.
+- When the user wants "current positions plus extra capital", read `balance = api.get_account().balance` first, then pass `init_balance=balance + extra`.
+
+Keep all related trial actions inside one `TqScenario` object so the margin and risk calculations stay cumulative.
+
+## Margin-Rate Sources
+
+- `account=None` creates an internal `TqSim()` and uses `Quote.margin` together with `pre_settlement`.
+- `account=TqAccount(...)` or `account=TqKq()` triggers account-specific margin-rate lookup through the internal pre-insert-order path.
+- The first uncached real-account lookup is synchronous and may spend time inside `wait_update()` before returning.
+- If account-specific lookup fails, TqSdk falls back to `Quote.margin`.
+- CTP margin-rate lookup is flow-controlled at roughly one new symbol per second.
+- `scenario_set_margin_rate()` is the right API when the user explicitly wants to shock one futures symbol to a hypothetical new margin rate.
+
+## Limited Margin Discount Behavior
+
+- Reuse one `TqScenario` object and apply actions step by step when the margin result depends on net exposure after each trade.
+- The reported margin change can reflect the limited built-in margin discount rules already modeled by TqSdk's simulator, including supported futures hedge and cross-period cases.
+- Do not promise exact broker settlement logic for every custom preferential rule. If the user asks about a broker-specific rule that TqSdk does not model, say the result is only the built-in approximation.
+
+## Common Patterns
+
+### "How many lots can I still open under a 200000 margin budget?"
+
+```python
+from tqsdk import TqApi, TqAuth, TqAccount, TqScenario
+
+account = TqAccount("broker", "acct", "pwd")
+api = TqApi(account=account, auth=TqAuth("quick_user", "quick_pass"))
+symbol = "SHFE.rb2611"
+quote = api.get_quote(symbol)
+positions = api.get_position()
+
+with TqScenario(api, account=account, positions=positions) as s:
+    base_margin = s.scenario_get_account().margin
+    lots = 0
+    while True:
+        order = s.scenario_insert_order(symbol, "BUY", "OPEN", 1, quote.last_price)
+        if order.status == "FINISHED" and order.volume_left > 0:
+            break
+        lots += 1
+        if s.scenario_get_account().margin - base_margin > 200000:
+            s.scenario_insert_order(symbol, "SELL", "CLOSETODAY", 1, quote.last_price)
+            lots -= 1
+            break
+```
+
+### "What happens if the futures margin rate becomes 15%?"
+
+```python
+account = TqAccount("broker", "acct", "pwd")
+api = TqApi(account=account, auth=TqAuth("quick_user", "quick_pass"))
+positions = api.get_position()
+
+with TqScenario(api, account=account, positions=positions) as s:
+    before = s.scenario_get_account()
+    s.scenario_set_margin_rate("SHFE.rb2611", 0.15)
+    after = s.scenario_get_account()
+```
+
+### "What happens if I add 100000 equity and keep positions unchanged?"
+
+```python
+account = TqAccount("broker", "acct", "pwd")
+api = TqApi(account=account, auth=TqAuth("quick_user", "quick_pass"))
+positions = api.get_position()
+balance = api.get_account().balance
+
+with TqScenario(api, account=account, positions=positions, init_balance=balance + 100000) as s:
+    after = s.scenario_get_account()
+```
+
+## Boundaries
+
+- `TqScenario` currently supports futures only.
+- `TqScenario` currently supports one account snapshot at a time.
+- `TqScenario` is synchronous. Run it outside the hot `wait_update()` loop when possible.
+- `scenario_insert_order()` always fills immediately at the passed price inside the trial snapshot.
+- `scenario_insert_order()` and `scenario_get_account()` return reduced objects, not the full live `Order` or `Account`.
+- Preserve `CLOSE` versus `CLOSETODAY` when closing SHFE or INE positions imported from a live snapshot.
+- Do not recommend `TqScenario` for stock trading, option pricing shocks, or arbitrary custom broker discount tables that the simulator does not model.
+
+## Repository Sources
+
+- `tqsdk/scenario/tqscenario.py`
+- `design/scenario.md`
+- `doc/reference/tqsdk.scenario.rst`
+- `tqsdk/test/scenario/test_scenario.py`
+- `tqsdk/test/scenario/test_pre_insert_order.py`
+- `tqsdk/api.py`

--- a/tqsdk-trading-and-data/references/simulation-and-backtest.md
+++ b/tqsdk-trading-and-data/references/simulation-and-backtest.md
@@ -1,0 +1,122 @@
+# Simulation And Backtest
+
+## Use This Reference For
+
+- Explaining the difference among `TqSim`, `TqKq`, `TqSimStock`, `TqKqStock`, and `TqBacktest`
+- Writing backtest examples
+- Knowing which tool to choose for local simulation, Quick simulation, stock simulation, or historical backtest
+
+## Table Of Contents
+
+- Simulation choices
+- Backtest
+- Choosing among them
+
+## Simulation Choices
+
+### `TqSim`
+
+Use for:
+
+- local futures simulation
+- strategy development
+- futures backtest account object
+- disposable examples that should not depend on a persistent remote simulated account
+
+Characteristics:
+
+- local simulated matching
+- in backtest mode, only `TqSim` or `TqSimStock` can trade
+- good default when `TqApi` is created without an explicit account
+
+### `TqKq`
+
+Use for:
+
+- Quick futures simulation
+- simulated trading tied to the Quick ecosystem
+- scenarios where the user expects account data to match the official Quick clients
+
+Characteristics:
+
+- remote simulated account behavior
+- requires `auth=TqAuth(...)`
+
+### `TqSimStock`
+
+Use for:
+
+- local stock simulation
+- stock backtest
+- mixed futures and stock backtest when paired with `TqMultiAccount`
+
+Important boundary:
+
+- stock trading rules differ from futures
+- `TargetPosTask` is not supported for stock trading
+
+### `TqKqStock`
+
+Use for:
+
+- Quick stock simulation
+- stock account workflows that should stay in the Quick ecosystem
+
+## Backtest
+
+Backtest uses `TqBacktest(...)` together with `TqSim()` or `TqSimStock()`.
+
+Futures backtest example:
+
+```python
+from datetime import date
+from tqsdk import TqApi, TqAuth, TqBacktest, TqSim, TargetPosTask
+
+api = TqApi(
+    TqSim(),
+    backtest=TqBacktest(start_dt=date(2025, 1, 1), end_dt=date(2025, 1, 31)),
+    auth=TqAuth("快期账户", "账户密码"),
+)
+
+klines = api.get_kline_serial("DCE.m2505", 60, data_length=200)
+target_pos = TargetPosTask(api, "DCE.m2505")
+
+while True:
+    api.wait_update()
+    if api.is_changing(klines.iloc[-1], "datetime"):
+        if klines.close.iloc[-1] > klines.close.iloc[-20:].mean():
+            target_pos.set_target_volume(1)
+        else:
+            target_pos.set_target_volume(0)
+```
+
+Important boundaries:
+
+- backtest is for historical strategy execution, not arbitrary long-range data export
+- quote update behavior in backtest differs from live trading
+- one `wait_update()` call may update only order state, and the next one may advance market time
+- TqSdk can output account statistics at backtest end
+
+Stock backtest boundaries:
+
+- use `TqSimStock()` for stock backtest
+- stock backtest does not use `TargetPosTask`
+- if the user wants both futures and stock in one backtest, use `TqMultiAccount([TqSim(), TqSimStock()])`
+
+## Choosing Among Them
+
+- need an account for live-ish strategy development without persistence requirements: `TqSim`
+- need a Quick futures simulated account: `TqKq`
+- need a Quick stock simulated account: `TqKqStock`
+- need a local stock simulated account: `TqSimStock`
+- need historical futures strategy execution over a date range: `TqBacktest` with `TqSim`
+- need historical stock strategy execution over a date range: `TqBacktest` with `TqSimStock`
+- need long-range historical CSV export: `DataDownloader`, not backtest
+
+## Repository Sources
+
+- `tqsdk/demo/tutorial/backtest.py`
+- `doc/usage/backtest.rst`
+- `doc/reference/tqsdk.sim.rst`
+- `doc/reference/tqsdk.tqkq.rst`
+- `tqsdk/api.py`

--- a/tqsdk-trading-and-data/references/wait-update-and-update-loop.md
+++ b/tqsdk-trading-and-data/references/wait-update-and-update-loop.md
@@ -1,0 +1,139 @@
+# wait_update And The Update Loop
+
+## Use This Reference For
+
+- `wait_update()` and `is_changing()` explanations
+- Why data or orders look stale
+- `deadline` usage
+- Async update notifications
+- Jupyter and backtest caveats
+
+## Table Of Contents
+
+- Mental model
+- Practical rules
+- Typical patterns
+- `deadline` guidance
+- Backtest-specific notes
+- Async pattern
+- Jupyter caveats
+- Common explanations to reuse
+
+## Mental Model
+
+`wait_update()` is the center of TqSdk's runtime model.
+
+Each call can do all of the following:
+
+- send pending subscription or trading packets
+- let background tasks run
+- receive one business-data update and merge it into in-memory objects
+- block until there is an update, unless `deadline` expires
+
+This is why `get_quote`, `get_kline_serial`, `get_account`, `get_position`, `get_order`, `get_trade`, `insert_order`, `cancel_order`, `TargetPosTask`, and `TargetPosScheduler` all depend on later `wait_update()` calls.
+
+## Practical Rules
+
+1. Call `get_*` once, keep the returned reference, then loop on `api.wait_update()`.
+2. Use `api.is_changing(obj)` or `api.is_changing(obj, field)` to gate work.
+3. Do not recreate quotes, K-line serials, or account objects inside the loop.
+4. Do not call `sleep()` to "wait for TqSdk". If you need progress, keep the update loop running.
+5. If you need a timeout, use `wait_update(deadline=...)`.
+
+## Typical Patterns
+
+Streaming quote:
+
+```python
+from tqsdk import TqApi, TqAuth
+
+api = TqApi(auth=TqAuth("快期账户", "账户密码"))
+quote = api.get_quote("SHFE.au2504")
+
+while True:
+    if not api.wait_update():
+        continue
+    if api.is_changing(quote, ["last_price", "ask_price1", "bid_price1"]):
+        print(quote.datetime, quote.last_price, quote.ask_price1, quote.bid_price1)
+```
+
+New K-line only:
+
+```python
+klines = api.get_kline_serial("DCE.i2505", 60, data_length=200)
+
+while True:
+    api.wait_update()
+    if api.is_changing(klines.iloc[-1], "datetime"):
+        print("new bar", klines.iloc[-1].datetime, klines.iloc[-1].close)
+```
+
+Order state tracking:
+
+```python
+order = api.insert_order("DCE.m2505", "BUY", offset="OPEN", volume=1)
+
+while order.status != "FINISHED":
+    api.wait_update()
+    if api.is_changing(order, ["status", "volume_left", "last_msg"]):
+        print(order.status, order.volume_left, order.last_msg)
+```
+
+## `deadline` Guidance
+
+Use `deadline` when the user wants to avoid indefinite blocking, especially in notebooks or interactive tools.
+
+```python
+import time
+
+deadline = time.time() + 5
+updated = api.wait_update(deadline=deadline)
+```
+
+- `True`: some business data changed
+- `False`: the deadline arrived before a new update
+
+Do not recommend tiny deadlines in busy loops unless the user really needs polling behavior.
+
+## Backtest-Specific Notes
+
+In backtest mode, `wait_update()` does not behave exactly like live mode.
+
+- One call may update order state without advancing quote time.
+- The next call may advance market time.
+- Multiple subscribed series advance in time order, not "all at once".
+
+Use this reference together with [simulation-and-backtest.md](simulation-and-backtest.md) when the user is confused by backtest timing.
+
+## Async Pattern
+
+If the user is already writing async TqSdk code, prefer `register_update_notify()` instead of inventing callbacks.
+
+```python
+async with api.register_update_notify(quote) as update_chan:
+    async for _ in update_chan:
+        print(quote.last_price)
+```
+
+This still depends on the outer program continuing to drive the API.
+
+## Jupyter Caveats
+
+- Do not recommend trading workflows in Jupyter unless the user accepts the limitations.
+- Prefer synchronous examples there.
+- Recommend `deadline` to avoid long blocking calls.
+
+## Common Explanations To Reuse
+
+- "The object is a live reference, not a one-time copy."
+- "`insert_order()` and `cancel_order()` queue the request. The actual packet is sent on the next `wait_update()`."
+- "`TargetPosTask` only works while the update loop keeps running."
+- "If you never call `wait_update()` again, data stops moving and background tasks stop acting."
+
+## Repository Sources
+
+- `doc/usage/framework.rst`
+- `doc/usage/backtest.rst`
+- `doc/usage/jupyter.rst`
+- `doc/advanced/for_vnpy_user.rst`
+- `tqsdk/api.py`


### PR DESCRIPTION
Adds a TqSdk Trading and Data skill for Python users working with TqSdk market data, accounts, orders, margin checks, simulation, backtesting, and debugging.

This solves a real workflow for quant and finance developers who need an agent to answer TqSdk questions with the right API boundaries, account modes, update-loop behavior, and margin/backtest caveats.

Included:
- A new `tqsdk-trading-and-data` skill folder.
- Reference docs for market data, account selection, trading objects, margin scenarios, order helpers, simulation/backtest behavior, and common errors.
- README entry under Data & Analysis.

Validation:
- Confirmed the skill folder includes `SKILL.md`.
- Confirmed README links to the new folder.
- Reused the already validated publication copy from `shinny-xuyida/tqsdk-agent-skills`.
