### PR TITLE
Add Codex Small Business Skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
+- [Codex Small Business Skills](https://github.com/simongonzalezdc/codex-small-business-skills) - Apache-2.0 Codex port of Anthropic's Small Business skills for cash flow, invoices, CRM cleanup, customer support, lead triage, content strategy, hiring, and weekly business workflows. *By [@simongonzalezdc](https://github.com/simongonzalezdc)*
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.


### PR DESCRIPTION
## Summary
- Adds Codex Small Business Skills to Business & Marketing.
- This is an external multi-skill collection, following the README's existing external-link pattern for community skill repositories.
- The project is an Apache-2.0 Codex port of Anthropic's public Small Business skills.

## What problem it solves
Small business owners and operators often need repeatable AI-assisted workflows for cash flow, overdue invoices, CRM cleanup, lead triage, customer support, content planning, hiring packets, and weekly operating rhythm without letting an agent directly take risky business actions.

## Who uses this workflow
Owner-operators, consultants, agencies, local businesses, and operators supporting small businesses.

## Attribution / inspiration source
The skills are ported from Anthropic's public Apache-2.0 Small Business skills, with upstream attribution and modification notes documented in the linked repo.

## Example use
A user can ask an agent for a cash-flow snapshot, overdue invoice chase draft, lead triage pass, CRM cleanup plan, or weekly business brief. The skills keep customer, money, CRM, contract, and publishing actions approval-gated.

## Checks
- Public repository link works.
- License, attribution, and modification notes are documented in the linked repo.
- Risky business actions are approval-gated in the skill guidance.