### PR TITLE
Add product-thinking-pack skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [product-thinking-pack](https://github.com/marsloting/product-thinking-pack) - Seven MIT-licensed product-thinking skills for JTBD, journey mapping, pre-mortems, RICE prioritization, story splitting, decision matrices, and root-cause analysis.
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Summary

Add `product-thinking-pack` to the Business & Marketing section.

## Real-world use case

AI agents often move into execution before framing the product problem clearly. This pack gives them reusable product-thinking workflows for JTBD, journey mapping, pre-mortems, RICE prioritization, story splitting, decision matrices, and root-cause analysis.

## Who uses this workflow

Product builders, PMs, founders, and agent users who want an assistant to reason through product decisions before acting.

## Example use

Ask an agent to apply the JTBD or decision-matrix skill before turning a rough product idea into prioritized next steps.
