### PR TITLE
Add easetoolz-seo skill to Business & Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Business & Marketing
 
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
+- [easetoolz-seo](https://github.com/ariarihantmedia-bit/easetoolz-seo-skill) - Universal SEO + GEO skill for Claude Code. Technical audit, competitor gap analysis, schema generation, blog writing (Hindi+English), SERP clustering, AI search optimization. Built for tool sites & SaaS. *By [@ariarihantmedia-bit](https://github.com/ariarihantmedia-bit)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.


### PR DESCRIPTION
## New Skill: easetoolz-seo

- **Repository:** https://github.com/ariarihantmedia-bit/easetoolz-seo-skill
- **Category:** Business & Marketing / SEO
- **Author:** @ariarihantmedia-bit

9 sub-skills: audit, geo, schema, content, writing, local, cluster, competitor
Supports Hindi + English. MIT license. Free & open-source.
