### PR TITLE
Add tracedocs skill (Development & Code Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [tracedocs](./tracedocs/) - Turns any codebase into evidence-grounded study docs plus a machine-readable index.json; every claim cites its source and deployment steps are never invented.
 
 ### Data & Analysis
 

--- a/tracedocs/SKILL.md
+++ b/tracedocs/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: tracedocs
+description: Turn any codebase into evidence-grounded Markdown study docs plus a machine-readable index.json, where every claim cites its source and deployment steps are never invented.
+---
+
+# tracedocs
+
+tracedocs turns any codebase into a durable, evidence-grounded documentation
+package — operation, deployment, learning, architecture, API/data,
+troubleshooting, and maintenance manuals — plus a machine-readable `index.json`
+for AI agents. Every operational or deployment claim cites the source file it
+came from and carries a confidence label (`Verified` / `Inferred` / `Unknown` /
+`Needs confirmation`), and the skill refuses to invent steps it cannot source.
+
+Full skill, references, templates, and a validated sample output:
+https://github.com/wxggzz/tracedocs (MIT).
+
+## When to Use This Skill
+
+- Onboarding to, or documenting, an unfamiliar codebase
+- Producing durable in-repo docs for operation, deployment, and maintenance
+- Preparing an AI-agent-ready knowledge handoff (with `index.json`)
+- Turning a repo into a study guide whose claims are traceable to source
+
+## What This Skill Does
+
+1. **Analyze**: reads the stack, scripts, entry points, environment-variable names, deployment signals, and tests.
+2. **Evidence map**: records a source map, assumptions, and a generation log with confidence labels.
+3. **Write**: produces the Markdown manuals and an `index.json` manifest — never inventing deployment steps.
+4. **Quality check**: verifies paths exist, commands are sourced, no secret values leak, and gaps are documented.
+
+## How to Use
+
+### Basic Usage
+
+```
+Use tracedocs to generate evidence-grounded study docs for this repository. Write the output to study-docs/.
+```
+
+### Advanced Usage
+
+```
+Use tracedocs to document https://github.com/owner/repo. Emphasize deployment and operations, and produce index.json for agent handoff.
+```
+
+## Example
+
+**User**: "Document ./my-app with tracedocs"
+
+**Output**:
+```
+study-docs/
+  00-project-overview.md ... 10-maintenance-and-contribution.md
+  index.json            # machine-readable manifest
+  _evidence/            # source-map, assumptions, generation-log
+```
+
+Each operational claim cites its source and confidence; anything unverifiable
+(for example, "no deployment configuration found") is stated, not guessed.
+
+## Tips
+
+- Treat anything not labelled `Verified` as a prompt to check the source.
+- Commit `study-docs/` so docs diff in PRs and stay current.
+- Feed `index.json` to other agents for a structured project handoff.
+
+## Common Use Cases
+
+- New-hire / contributor onboarding
+- Operations and deployment runbooks grounded in the actual repo
+- AI-agent handoff with a machine-readable manifest


### PR DESCRIPTION
Adds the **tracedocs** skill (`tracedocs/SKILL.md`) and a README entry under *Development & Code Tools*.

tracedocs turns any codebase into an evidence-grounded Markdown documentation package plus a machine-readable `index.json` for AI agents. Every operational/deployment claim cites its source file and carries a confidence label (Verified / Inferred / Unknown / Needs confirmation); it never invents deployment steps and documents gaps instead.

- Real, tested use case: a complete validated sample is committed at `examples/study-docs/` in the source repo
- Portable: plain `SKILL.md` + references; works in Claude Code, Codex, and other agents; also packaged as a Claude Code plugin
- Source: https://github.com/wxggzz/tracedocs (MIT)

Followed the SKILL.md template in CONTRIBUTING (When to Use / What This Skill Does / How to Use / Example / Tips / Common Use Cases).