### PR TITLE
Add TempGuru event staffing to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
-- [TempGuru Event Staffing](https://github.com/kissmyabs32/tempguru-agent-skills) - Order W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, sporting events, and brand activations across 300+ US/CA markets. Live MCP tools for city coverage, roles, all-inclusive rate ranges, availability, and state-by-state compliance checks. *By [@kissmyabs32](https://github.com/kissmyabs32)*
+- [TempGuru Event Staffing](https://github.com/tempguru-co/tempguru-agent-skills) - Order W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, sporting events, and brand activations across 300+ US/CA markets. Live MCP tools for city coverage, roles, all-inclusive rate ranges, availability, and state-by-state compliance, plus an opt-in request_quote submission. *By [@tempguru-co](https://github.com/tempguru-co)*
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
+- [TempGuru Event Staffing](https://github.com/kissmyabs32/tempguru-agent-skills) - Order W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, sporting events, and brand activations across 300+ US/CA markets. Live MCP tools for city coverage, roles, all-inclusive rate ranges, availability, and state-by-state compliance checks. *By [@kissmyabs32](https://github.com/kissmyabs32)*
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.


### PR DESCRIPTION
Adds TempGuru Event Staffing to the **Business & Marketing** section.

Covers hiring W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, sporting events, and brand activations across 300+ US/CA markets — with live MCP tools for city coverage, roles, all-inclusive rate ranges, availability, and state-by-state compliance.

Two SKILL.md files: ordering + compliance. Read-only MCP, no auth, no scripts, MIT licensed. Source: https://github.com/kissmyabs32/tempguru-agent-skills