### PR TITLE
Add Guster-Ducks — personal agent toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [Guster-Ducks](https://github.com/Lumos-789/Guster-Ducks) - Personal agent toolkit built on Claude Code. Markdown specs, zero infrastructure — paths, ducks, skills. Talk to Guster and manage the ducks. *By [@Lumos-789](https://github.com/Lumos-789)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
## Guster-Ducks

Personal agent toolkit built on Claude Code. Markdown specs, zero infrastructure — paths, ducks, skills. Talk to Guster and manage the ducks.

- **Repo**: https://github.com/Lumos-789/Guster-Ducks
- **Author**: [@Lumos-789](https://github.com/Lumos-789)

Added under the "Development & Code Tools" section, following the existing entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)