### PR TITLE
Add The Perfect Orchestrator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [The Perfect Orchestrator](https://github.com/daman8271/the-perfect-orchestrator) - Runs a fleet of autonomous Claude Code workers in tmux from one lead session, with workers adversarially cross-verifying each other's results before anything is reported back. Pure bash and tmux, no daemons or message brokers. *By [@daman8271](https://github.com/daman8271)*
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
## What problem it solves

Running several Claude Code sessions in parallel normally means babysitting each pane and taking every "done" at face value. The Perfect Orchestrator gives one **lead** Claude Code session a small CLI (`orch`) plus a lead-playbook skill to spawn N autonomous workers in tmux, brief them over a shared file-based message bus, and — the core design rule — have a *different* worker adversarially verify each completed result before it counts. Pure bash + tmux: no servers, no daemons, no message broker.

## Who uses this workflow

Built and used by me (@daman8271) for parallel repo audits, doc fact-checking, and build tasks. Full disclosure: this is a new project (v0.1.0, released June 2026, MIT) — I'm submitting it as such and making no popularity claims. To keep the claims evidence-based rather than hypothetical, the repo ships a fully recorded real fleet run ([docs/realrun-2026-06-06](https://github.com/daman8271/the-perfect-orchestrator/tree/main/docs/realrun-2026-06-06)): 3 workers audit a clean clone of the repo itself and cross-check each other's findings, with every terminal line in the demo video present verbatim in the bundle.

## Example of how it's used

```bash
# one-time: install the orch CLI
git clone https://github.com/daman8271/the-perfect-orchestrator && cd the-perfect-orchestrator
./install.sh

# optional: the Claude Code plugin ships the lead-playbook skill (the CLI itself comes from install.sh above)
claude plugin marketplace add daman8271/the-perfect-orchestrator
claude plugin install orchestrator@the-perfect-orchestrator

# then, inside a Claude Code session with the skill loaded:
# "Spawn a fleet of 4 workers to audit this repo; cross-verify all findings before reporting."
```

The lead spawns workers (`orch spawn audit 4`), dispatches briefs, watches the bus, and only accepts findings after a different worker has tried to tear them apart (e.g. the 3× cross-verify pattern: R1 audits → R2 refutes → R3 confirms).

## Attribution

Original work by [@daman8271](https://github.com/daman8271). Repo: https://github.com/daman8271/the-perfect-orchestrator · Site: https://the-perfect-orchestrator.vercel.app

## Checklist

- Real use case (recorded run in-repo), not hypothetical
- Tested on Claude Code (Linux/macOS, tmux ≥ 3.0)
- README documents all 7 commands, security posture, and requirements
- Entry added in alphabetical order under **Development & Code Tools**, matching the existing format (no emojis)
