### PR TITLE
Add Three-Pillar Personal Finance skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [Three-Pillar Personal Finance](https://github.com/nontravis/personal-finance-whitepaper) - A reasoning-lens skill that makes any AI advise through the Three-Pillar system (Income − Expenses = Freedom Fund; Cashflow, Investment, Savings; discipline over strategy). MIT. *By [@nontravis](https://github.com/nontravis)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adds the **Three-Pillar Personal Finance** skill to the **Productivity & Organization** section of the list.

The skill is a reasoning-lens instruction set that teaches any AI agent to frame financial advice through the Three-Pillar system (Income − Expenses = Freedom Fund; Cashflow, Investment, Savings; discipline over strategy). It is available at https://github.com/nontravis/personal-finance-whitepaper, licensed MIT, and installable in Claude Code via `--plugin-dir` or degit.

The entry follows the existing community-skill bullet format (`- [Name](URL) - Description. *By [@author](url)*`) and is inserted alphabetically within the section.