### PR TITLE
Add Unship skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [Unship](./unship/) - Compare AI agent-made UI variants locally in a real app, then keep one and clean up the rest.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 

--- a/unship/SKILL.md
+++ b/unship/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: unship
+description: Compare AI agent-made UI variants locally in a real app, then keep one and clean up the rest.
+---
+
+# Unship
+
+Unship helps AI coding assistants create temporary UI alternatives in real source code, let a human compare those alternatives in the local browser, and then remove the losing variants before shipping.
+
+Use this skill when a user wants to compare agent-made alternatives for UI sections, page layouts, copy treatments, product states, flows, design-system directions, rendered documentation, or developer experience surfaces.
+
+## When to Use This Skill
+
+- The user wants several UI directions instead of one generated result.
+- A coding agent is iterating on frontend work and the user needs to compare options side by side in the actual app.
+- The user has picked a variant and wants the unused temporary code removed.
+
+## What This Skill Does
+
+1. **Creates temporary variants**: Adds the smallest useful source-level comparison using Unship's `data-unship-pick` and `data-unship-option` markup.
+2. **Uses a local picker**: Installs or reuses the Unship browser picker so the user can flip between options in their running development preview.
+3. **Cleans up after selection**: Keeps the chosen option, removes losing alternatives, and verifies that no temporary Unship artifacts remain before shipping.
+
+## How to Use
+
+Install Unship in the project:
+
+```bash
+npx -y @unship/cli@latest init
+```
+
+Create a comparison:
+
+```text
+Use Unship to compare 4 hero directions for this page.
+```
+
+After the user chooses a visible option label, settle the comparison:
+
+```text
+Keep the Proof-led option and clean up the others.
+```
+
+For a final cleanup check, run:
+
+```bash
+npx -y @unship/cli@latest check --json
+```
+
+## Example
+
+**User**: "Use Unship to compare 3 pricing section directions."
+
+**Assistant workflow**:
+
+1. Inspect the existing pricing section and design system.
+2. Add one `data-unship-pick="Pricing"` group with three direct `data-unship-option` children.
+3. Reuse or install the local picker.
+4. Tell the user the option labels to compare in the browser.
+5. When the user chooses, keep that source and remove the temporary alternatives.
+
+## Tips
+
+- Keep variants local and temporary; Unship is not production A/B testing.
+- Prefer 2-4 meaningful options with short visible labels.
+- Avoid duplicate active IDs, global scripts, analytics side effects, focus traps, and submit controls inside inactive hidden variants.
+- Treat cleanup as part of the workflow, not an optional afterthought.
+
+**Inspired by:** Real frontend iteration loops where AI agents produce one design at a time and users need to compare multiple options in context.


### PR DESCRIPTION
## Summary

- Add an Unship skill folder and README entry under Development & Code Tools.
- The skill covers a real frontend iteration workflow: create temporary UI alternatives in source, compare them in the local browser, then keep one and clean up the rest.
- Unship is local comparison tooling for Claude Code and other coding agents, not production A/B testing.

## Use case

Developers using coding agents often get one UI version at a time and lose the previous option. Unship gives the agent a small local workflow for generating multiple variants, presenting them in the running app, and removing unused temporary code after the user chooses.

## Validation

- `git diff --check`
