### PR TITLE
Add Rarefriend CRM skills (6 skills — contacts, calendar, LinkedIn, Outlook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
 
 ### Productivity & Organization
+- [Find Outlook Emails](./find-outlook-emails/) - Search your Microsoft Outlook inbox and cross-reference emails with contact history — find any email instantly with full relationship context via Rarefriend. *By [Rarefriend](https://rarefriend.com)*
+- [Manage LinkedIn Network](./manage-linkedin-network/) - Turn your LinkedIn network into a searchable CRM — find who you know at any company, prep for meetings, and never lose context on a connection again. *By [Rarefriend](https://rarefriend.com)*
+- [Network and Relationship Manager](./network-and-relationship-manager/) - Never forget a person again — full personal CRM with contacts, notes, tags, Google/Microsoft calendar, and LinkedIn sync via Rarefriend. *By [Rarefriend](https://rarefriend.com)*
+- [Organize Google Contacts](./organize-google-contacts/) - Google Contacts supercharged with notes, tags, and relationship memory — find anyone instantly and remember every conversation. *By [Rarefriend](https://rarefriend.com)*
+- [Schedule with Google Calendar](./schedule-with-google-calendar/) - Schedule meetings, find free time, and manage Google Calendar — all connected to your contact network via Rarefriend. *By [Rarefriend](https://rarefriend.com)*
+- [Schedule with Outlook](./schedule-with-outlook/) - Manage Microsoft Outlook contacts and calendar — search contacts, schedule Teams meetings, and keep relationship notes all in one place. *By [Rarefriend](https://rarefriend.com)*
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.

--- a/find-outlook-emails/SKILL.md
+++ b/find-outlook-emails/SKILL.md
@@ -10,6 +10,7 @@ description: >
   Outlook inbox, check my email, find email, email history, what did they say, email thread,
   did I hear back, follow up email.
 license: MIT-0
+compatibility: Requires Rarefriend MCP (@rarefriend-ai/mcp). Works with Claude Code, Cursor, Codex, OpenClaw, Gemini CLI, and other Agent Skills-compatible clients.
 user-invocable: true
 argument-hint: '[setup|search|list|connect]'
 metadata:
@@ -29,6 +30,7 @@ metadata:
       - name: RAREFRIEND_CLIENT_SECRET
         required: true
         description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  category: productivity
   author: Rarefriend
   homepage: https://rarefriend.com
   repository: https://github.com/Whitefield-Labs/rarefriend-skills
@@ -47,7 +49,7 @@ Access it from your AI assistant, the web app at [rarefriend.com](https://rarefr
 1. Call `list_connected_integrations`.
    - **Tool not available → MCP not connected.** Present these steps inline to the user:
      1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
-     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     2. **Claude Code / Codex:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
      3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
      4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
      5. Restart the client, then try again
@@ -137,7 +139,7 @@ get_integration_sync_status("microsoft_email")
 
 ## References
 
-- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+- [MCP setup — all supported clients](references/SETUP.md)
 
 ---
 

--- a/find-outlook-emails/SKILL.md
+++ b/find-outlook-emails/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: find-outlook-emails
+description: >
+  Search your Microsoft Outlook inbox and cross-reference emails with your contact history
+  — find any email instantly and see full relationship context alongside it via Rarefriend.
+  Use when the user wants to: check recent Outlook emails, search for an email by subject or
+  sender, find emails from a specific person, look up what was discussed over email, cross-
+  reference email threads with CRM notes, or connect their Microsoft Outlook email account.
+  Triggers on: Outlook email, Microsoft email, inbox, email from, search email, recent emails,
+  Outlook inbox, check my email, find email, email history, what did they say, email thread,
+  did I hear back, follow up email.
+license: MIT-0
+user-invocable: true
+argument-hint: '[setup|search|list|connect]'
+metadata:
+  openclaw:
+    requires:
+      env:
+        - RAREFRIEND_CLIENT_ID
+        - RAREFRIEND_CLIENT_SECRET
+      primaryEnv: RAREFRIEND_CLIENT_ID
+    install:
+      - kind: node
+        package: '@rarefriend-ai/mcp'
+    envVars:
+      - name: RAREFRIEND_CLIENT_ID
+        required: true
+        description: OAuth client ID — rarefriend.com → Settings → Integrations → MCP
+      - name: RAREFRIEND_CLIENT_SECRET
+        required: true
+        description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  author: Rarefriend
+  homepage: https://rarefriend.com
+  repository: https://github.com/Whitefield-Labs/rarefriend-skills
+---
+
+## About Rarefriend
+
+Rarefriend brings your Outlook inbox into your contact network — search emails, see who said what, and connect every thread to the relationship notes and context already in your CRM.
+
+Access it from your AI assistant, the web app at [rarefriend.com](https://rarefriend.com), or Hops — Rarefriend's AI on WhatsApp.
+
+---
+
+## Setup Detection Protocol
+
+1. Call `list_connected_integrations`.
+   - **Tool not available → MCP not connected.** Present these steps inline to the user:
+     1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
+     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
+     4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
+     5. Restart the client, then try again
+   - `microsoft_email` not in the list → offer to connect: `connect_integration("microsoft_email")`.
+   - `microsoft_email` present → proceed directly.
+
+---
+
+## Core Workflows
+
+### List recent emails
+
+```
+list_microsoft_emails(limit?, startDate?, endDate?, folderId?)
+  limit:     number of emails to return (default 10, max 50)
+  startDate: ISO 8601 — only emails after this date
+  endDate:   ISO 8601 — only emails before this date
+  folderId:  specific folder (default: inbox)
+```
+
+- "Show my last 10 emails" → `list_microsoft_emails(limit=10)`
+- "What emails did I get this week?" → `list_microsoft_emails(startDate="2026-06-02")`
+- "Check emails from yesterday" → `list_microsoft_emails(startDate="2026-06-05", endDate="2026-06-06")`
+
+### Search emails
+
+```
+search_microsoft_emails(query*, limit?, startDate?, endDate?)
+  query: matches subject, body snippet, sender name, or sender email
+```
+
+- "Find emails from Alice" → `search_microsoft_emails("Alice")`
+- "Search for emails about the contract" → `search_microsoft_emails("contract")`
+- "Find emails from john@acme.com" → `search_microsoft_emails("john@acme.com")`
+
+### Cross-reference with contacts
+
+After finding an email, look up the sender in Rarefriend:
+
+```
+search_contacts("sender name or email", searchMode="exact")
+→ get_contact(contactId)     — full CRM profile
+→ list_notes(contactId)      — past notes about this person
+→ create_note(contactId, ...) — log context from the email thread
+```
+
+**Pattern — "What's the history with this person?"**
+
+1. `search_microsoft_emails("person name")` → find relevant threads
+2. `search_contacts("person name", searchMode="exact")` → find them in CRM
+3. `list_notes(contactId)` → review relationship notes
+4. Summarise email history + CRM notes together
+
+### Connect Microsoft Email
+
+```
+connect_integration("microsoft_email")
+```
+
+Returns a `connectUrl`. Present as a clickable link:
+
+> _"Open this link in your browser to connect Microsoft Outlook email. It expires in 15 minutes."_
+
+After connecting:
+
+```
+get_integration_sync_status("microsoft_email")
+```
+
+---
+
+## Quick Reference
+
+| Tool                          | When to use                                            |
+| ----------------------------- | ------------------------------------------------------ |
+| `list_connected_integrations` | Always check first — detects MCP and integration state |
+| `list_microsoft_emails`       | Browse recent inbox emails                             |
+| `search_microsoft_emails`     | Find emails by subject, sender, or keyword             |
+| `search_contacts`             | Find a sender in Rarefriend CRM                        |
+| `get_contact`                 | Full CRM profile for a sender                          |
+| `list_notes`                  | Relationship notes for a contact                       |
+| `create_note`                 | Log context after reviewing an email thread            |
+| `connect_integration`         | Connect Microsoft Outlook email                        |
+| `get_integration_sync_status` | Check sync state                                       |
+
+---
+
+## References
+
+- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+
+---
+
+## Other capabilities (outside this skill)
+
+- **Outlook contacts and calendar** — search Outlook contacts, schedule Teams meetings. Install `schedule-with-outlook`.
+- **Google Contacts and Calendar** — Install `organize-google-contacts` and `schedule-with-google-calendar`.
+- **LinkedIn sync** — requires the Rarefriend Chrome extension. Go to rarefriend.com → Settings → Integrations → LinkedIn.
+- **Hops on WhatsApp** — same contacts and notes accessible via Rarefriend's WhatsApp AI assistant.
+- **Full feature set in one skill** — install `network-and-relationship-manager`.

--- a/find-outlook-emails/references/SETUP.md
+++ b/find-outlook-emails/references/SETUP.md
@@ -8,7 +8,7 @@
 
 ## Step 2 — Connect MCP
 
-### Claude Code
+### Claude Code / Codex
 
 ```bash
 claude mcp add rarefriend \

--- a/find-outlook-emails/references/SETUP.md
+++ b/find-outlook-emails/references/SETUP.md
@@ -1,0 +1,65 @@
+# Setup — Rarefriend Microsoft Email
+
+## Step 1 — Get API credentials
+
+1. Sign in at [rarefriend.com](https://rarefriend.com)
+2. Go to **Settings → Integrations → MCP**
+3. Click **Manage → Generate OAuth Client** — copy the Client ID and Client Secret (shown once)
+
+## Step 2 — Connect MCP
+
+### Claude Code
+
+```bash
+claude mcp add rarefriend \
+  -e RAREFRIEND_CLIENT_ID=your_client_id \
+  -e RAREFRIEND_CLIENT_SECRET=your_client_secret \
+  -- npx -y @rarefriend-ai/mcp
+```
+
+### Cursor (`~/.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+or `~/.config/Claude/claude_desktop_config.json` (Linux):
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+## Step 3 — Connect Microsoft Email
+
+Once MCP is running, ask the assistant:
+
+```
+Connect my Outlook email to Rarefriend
+```
+
+The assistant will call `connect_integration("microsoft_email")` and return a link. Open it in your browser and sign in with your Microsoft/Office 365 account. Sync takes a few minutes — ask the assistant to check when it's done.

--- a/manage-linkedin-network/SKILL.md
+++ b/manage-linkedin-network/SKILL.md
@@ -11,6 +11,7 @@ description: >
   network, warm intro, notes about someone, tag contacts, relationship context, find contact,
   network management, LinkedIn sync, intro, reach out, who to contact.
 license: MIT-0
+compatibility: Requires Rarefriend MCP (@rarefriend-ai/mcp). Works with Claude Code, Cursor, Codex, OpenClaw, Gemini CLI, and other Agent Skills-compatible clients.
 user-invocable: true
 argument-hint: '[setup|sync|search|notes|tags|connect]'
 metadata:
@@ -30,6 +31,7 @@ metadata:
       - name: RAREFRIEND_CLIENT_SECRET
         required: true
         description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  category: productivity
   author: Rarefriend
   homepage: https://rarefriend.com
   repository: https://github.com/Whitefield-Labs/rarefriend-skills
@@ -48,7 +50,7 @@ Access it from your AI assistant, the web app at [rarefriend.com](https://rarefr
 1. Call `list_connected_integrations`.
    - **Tool not available → MCP not connected.** Present these steps inline to the user:
      1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
-     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     2. **Claude Code / Codex:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
      3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
      4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
      5. Restart the client, then try again
@@ -226,4 +228,4 @@ connect_integration("microsoft_calendar")
 
 ## References
 
-- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+- [MCP setup — all supported clients](references/SETUP.md)

--- a/manage-linkedin-network/SKILL.md
+++ b/manage-linkedin-network/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: manage-linkedin-network
+description: >
+  Turn your LinkedIn network into a searchable, annotated CRM — find who you know at any
+  company, prep for meetings, and never lose context on a connection again. Powered by
+  Rarefriend. Use when the user wants to: search LinkedIn connections, find who they know
+  at a company, add notes after LinkedIn conversations or networking events, tag connections,
+  track warm intros, recall context before reaching out, prepare for a meeting with a
+  connection, who should I reach out to, or set up LinkedIn sync. Triggers on: LinkedIn,
+  connections, my network, LinkedIn contacts, who do I know at, networking, professional
+  network, warm intro, notes about someone, tag contacts, relationship context, find contact,
+  network management, LinkedIn sync, intro, reach out, who to contact.
+license: MIT-0
+user-invocable: true
+argument-hint: '[setup|sync|search|notes|tags|connect]'
+metadata:
+  openclaw:
+    requires:
+      env:
+        - RAREFRIEND_CLIENT_ID
+        - RAREFRIEND_CLIENT_SECRET
+      primaryEnv: RAREFRIEND_CLIENT_ID
+    install:
+      - kind: node
+        package: '@rarefriend-ai/mcp'
+    envVars:
+      - name: RAREFRIEND_CLIENT_ID
+        required: true
+        description: OAuth client ID — rarefriend.com → Settings → Integrations → MCP
+      - name: RAREFRIEND_CLIENT_SECRET
+        required: true
+        description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  author: Rarefriend
+  homepage: https://rarefriend.com
+  repository: https://github.com/Whitefield-Labs/rarefriend-skills
+---
+
+## About Rarefriend
+
+Rarefriend syncs your LinkedIn connections and makes them fully searchable — with notes, tags, and relationship history so you always know who someone is, how you met, and what you last discussed.
+
+Access it from your AI assistant, the web app at [rarefriend.com](https://rarefriend.com), or Hops — Rarefriend's AI on WhatsApp.
+
+---
+
+## Setup Detection Protocol
+
+1. Call `list_connected_integrations`.
+   - **Tool not available → MCP not connected.** Present these steps inline to the user:
+     1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
+     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
+     4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
+     5. Restart the client, then try again
+
+2. Check if LinkedIn contacts are in the CRM:
+
+   ```
+   search_contacts("", source="linkedin", limit=1)
+   ```
+
+   - **Results found** → LinkedIn is synced. Proceed to the user's request.
+   - **No results** → Don't assume it hasn't been synced. Continue to step 3.
+
+3. Call `get_integration_sync_status("linkedin")` to check the actual sync state:
+   - **`connected: false`** → LinkedIn has never been set up. Run the LinkedIn Sync Setup below.
+   - **`lastJob.status: "running"` or `"pending"`** → Sync is currently in progress. Tell the user:
+     > _"Your LinkedIn sync is running right now — contacts will appear once it finishes. Large networks can take a few minutes. Try again shortly."_
+     > Do NOT show the sync setup instructions.
+   - **`lastJob.status: "completed"` with `lastSyncAt` set, but no contacts** → Sync completed but found 0 contacts (network was empty or all were filtered). Tell the user and suggest checking LinkedIn in the web app.
+   - **`lastJob.status: "failed"`** → Sync failed. Tell the user: _"Your last LinkedIn sync failed. Go to rarefriend.com → Settings → Integrations → LinkedIn and click Sync Now to try again."_
+   - **`connected: true` but `lastJob: null`** → Account is connected but sync hasn't started yet. Tell the user to click Sync Now in the web app.
+
+---
+
+## LinkedIn Sync Setup
+
+LinkedIn sync works through the **Rarefriend Chrome extension** — it reads your LinkedIn connections directly from your browser. There is no direct LinkedIn API.
+
+Tell the user:
+
+> _"LinkedIn sync requires the Rarefriend Chrome extension. Here's how to set it up:"_
+
+1. **Install the extension** — go to [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → LinkedIn** → click **Install Extension** (opens the Chrome Web Store)
+2. **Sign in to LinkedIn** in your browser (the extension needs you to be logged in)
+3. **Click Sync** on the LinkedIn card in Settings → Integrations
+4. Sync runs in the background — large networks can take a few minutes
+5. Once done, come back here — all your connections will be searchable
+
+After sync, LinkedIn contacts are labelled `source: "linkedin"` (extension) or `source: "linkedin_csv"` (CSV import) in search results.
+
+---
+
+## Core Workflows
+
+### Search LinkedIn connections
+
+```
+search_contacts(query, searchMode?, tag?, source?, limit?, offset?)
+  source:     'linkedin'     — synced via Chrome extension
+              'linkedin_csv' — imported via CSV
+  searchMode: 'all' | 'name' | 'company' | 'role' | 'email' | 'exact'
+  tag:        filter by tag (e.g. "investor", "founder")
+```
+
+- "Who do I know at Stripe?" → `search_contacts("Stripe", searchMode="company", source="linkedin")`
+- "Find all VCs in my network" → `search_contacts("", tag="vc")`
+- "Find Alice Zhang" → `search_contacts("Alice Zhang", searchMode="exact")`
+- "Show all LinkedIn connections" → `search_contacts("", source="linkedin")`
+
+**Source attribution:** Each contact includes `sourceLabel`. Always mention it — e.g. _"Found Alice Wang — LinkedIn (extension), PM at Stripe"_ or _"John Smith — LinkedIn (CSV import)"_.
+
+Paginate with `offset + limit` when `hasMore` is true.
+
+### Recall context before reaching out
+
+Before any call, message, or meeting with a connection:
+
+```
+get_contact(contactId)     — full profile: company, role, location, emails
+list_notes(contactId)      — full note history for this person
+search_notes(query)        — search across all contacts by keyword
+get_recent_notes(limit?)   — latest notes, any contact
+```
+
+**Meeting prep pattern:**
+
+1. `search_contacts("Marcus Johnson", searchMode="exact")`
+2. `get_contact(contactId)` — see their current company, role
+3. `list_notes(contactId)` — review past conversations, intros given, context
+4. Summarise: last interaction, key context, anything to follow up on
+
+### Log relationship context
+
+After every LinkedIn conversation, networking event, intro, or call:
+
+```
+create_note(contactId, content, isPinned?)
+update_note(noteId, content?, isPinned?)
+delete_note(noteId)
+list_notes(contactId, limit?, offset?)
+get_note(noteId)
+pin_note(noteId, pinned)           — pin for critical context (intro given, hot deal, key connection)
+search_notes(query, limit?)
+get_recent_notes(limit?)
+```
+
+Use `isPinned: true` for notes the user should always see first — intro'd to a key person, active deal, close mentor relationship.
+
+### Manage contacts
+
+Update details after getting new info about a connection:
+
+```
+get_contact(contactId)              — check current values first
+update_contact(contactId, company?, role?, location?, bio?, emails?, phones?)
+create_contact(displayName*, ...)   — manually add someone not yet in CRM
+```
+
+### Organise with tags
+
+```
+list_tags()
+add_tag(contactId, tag)
+remove_tag(contactId, tag)
+rename_tag(oldTag, newTag)
+```
+
+**Suggested tag conventions:**
+
+- Source: `linkedin-2024`, `event-founders-summit`, `cold-outreach`
+- Relationship: `warm-intro`, `mentor`, `investor`, `advisor`
+- Status: `active-deal`, `follow-up`, `dormant`, `met-once`
+- Type: `founder`, `vc`, `customer`, `recruiter`, `engineer`
+
+**Bulk tagging:** "Tag all Andreessen Horowitz connections as vc"
+
+1. `search_contacts("Andreessen Horowitz", searchMode="company", source="linkedin")`
+2. Loop `add_tag(contactId, "vc")` for each result
+
+### Cross-sync with Google or Microsoft
+
+Once LinkedIn is synced, optionally connect Google or Microsoft to see calendar events, emails, and phone contacts alongside your LinkedIn network:
+
+```
+connect_integration("google_contacts")
+connect_integration("google_calendar")
+connect_integration("microsoft_contacts")
+connect_integration("microsoft_calendar")
+```
+
+---
+
+## Quick Reference
+
+| Tool                          | When to use                                              |
+| ----------------------------- | -------------------------------------------------------- |
+| `list_connected_integrations` | Always check first — detect MCP state and synced sources |
+| `search_contacts`             | Find connections by name, company, role, tag, or source  |
+| `get_contact`                 | Full profile before reaching out or preparing a meeting  |
+| `create_contact`              | Manually add someone not yet in CRM                      |
+| `update_contact`              | Update details for an existing contact                   |
+| `create_note`                 | Log a conversation, event, intro, or call                |
+| `update_note`                 | Edit a note                                              |
+| `delete_note`                 | Remove a note                                            |
+| `list_notes`                  | All notes for one contact                                |
+| `get_note`                    | Full note content                                        |
+| `pin_note`                    | Mark critical relationship context                       |
+| `search_notes`                | Find context by keyword across all contacts              |
+| `get_recent_notes`            | Recent networking activity                               |
+| `list_tags`                   | See all tags in use                                      |
+| `add_tag` / `remove_tag`      | Categorise connections                                   |
+| `rename_tag`                  | Rename a tag everywhere                                  |
+| `connect_integration`         | Connect Google or Microsoft for cross-sync               |
+
+---
+
+## Other capabilities (outside this skill)
+
+- **LinkedIn sync setup** — must be done in the web app via the Chrome extension (rarefriend.com → Settings → Integrations → LinkedIn). The extension syncs connections automatically; re-run Sync Now to refresh.
+- **Google Contacts and Calendar** — install `organize-google-contacts` and `schedule-with-google-calendar` to schedule meetings with connections and cross-reference networks.
+- **Microsoft Outlook** — install `schedule-with-outlook`.
+- **Hops on WhatsApp** — same contacts and notes accessible via Rarefriend's WhatsApp AI assistant.
+- **Reminders** — set follow-up reminders on contacts in the web app at rarefriend.com.
+- **Full feature set in one skill** — install `network-and-relationship-manager`.
+
+## References
+
+- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)

--- a/manage-linkedin-network/references/SETUP.md
+++ b/manage-linkedin-network/references/SETUP.md
@@ -8,7 +8,7 @@
 
 ## Step 2 — Connect MCP
 
-### Claude Code
+### Claude Code / Codex
 
 ```bash
 claude mcp add rarefriend \

--- a/manage-linkedin-network/references/SETUP.md
+++ b/manage-linkedin-network/references/SETUP.md
@@ -1,0 +1,59 @@
+# Setup — Rarefriend LinkedIn CRM
+
+## Step 1 — Get API credentials
+
+1. Sign in at [rarefriend.com](https://rarefriend.com)
+2. Go to **Settings → Integrations → MCP**
+3. Click **copy the Client ID and Client Secret** — copy the Client ID and Client Secret
+
+## Step 2 — Connect MCP
+
+### Claude Code
+
+```bash
+claude mcp add rarefriend \
+  -e RAREFRIEND_CLIENT_ID=your_client_id \
+  -e RAREFRIEND_CLIENT_SECRET=your_client_secret \
+  -- npx -y @rarefriend-ai/mcp
+```
+
+### Cursor (`~/.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+or `~/.config/Claude/claude_desktop_config.json` (Linux):
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+## Step 3 — Import LinkedIn connections
+
+No OAuth needed for LinkedIn. Export your connections from LinkedIn and paste the rows into the assistant. See [LINKEDIN_IMPORT.md](LINKEDIN_IMPORT.md) for the full export guide.

--- a/network-and-relationship-manager/SKILL.md
+++ b/network-and-relationship-manager/SKILL.md
@@ -12,6 +12,7 @@ description: >
   who do I know, who do I know at, relationship, networking, person, people, meeting notes,
   who should I reach out to, warm intro, remind me about, what do I know about.
 license: MIT-0
+compatibility: Requires Rarefriend MCP (@rarefriend-ai/mcp). Works with Claude Code, Cursor, Codex, OpenClaw, Gemini CLI, and other Agent Skills-compatible clients.
 user-invocable: true
 argument-hint: '[setup|contacts|notes|tags|calendar|import|integrations]'
 metadata:
@@ -31,6 +32,7 @@ metadata:
       - name: RAREFRIEND_CLIENT_SECRET
         required: true
         description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  category: productivity
   author: Rarefriend
   homepage: https://rarefriend.com
   repository: https://github.com/Whitefield-Labs/rarefriend-skills
@@ -53,7 +55,7 @@ Access it from your AI assistant, the web app at [rarefriend.com](https://rarefr
 1. Call `list_connected_integrations` with no arguments.
    - **If the tool is not available → MCP is not connected.** Present these steps inline to the user:
      1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
-     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     2. **Claude Code / Codex:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
      3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
      4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
      5. Restart the client, then try again
@@ -220,7 +222,7 @@ get_integration_sync_status(integration)
 
 ## References
 
-- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+- [MCP setup — all supported clients](references/SETUP.md)
 - [Full tool parameter reference](references/TOOLS.md)
 
 ## Other capabilities (outside this MCP)

--- a/network-and-relationship-manager/SKILL.md
+++ b/network-and-relationship-manager/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: network-and-relationship-manager
+description: >
+  Never forget a person again — search your entire professional network, recall exactly
+  what you discussed, and always know who you know at any company. Powered by Rarefriend
+  personal CRM. Use when the user wants to: search contacts, find who they know at a company,
+  add meeting notes or call summaries, tag and organise contacts, schedule or check calendar
+  events, import LinkedIn connections, bulk import contacts, connect Google Contacts or
+  Microsoft Outlook, track relationship context, log an interaction, or do anything related
+  to contacts, networking, or relationship management. Triggers on: contact, contacts, CRM,
+  notes, my network, schedule, calendar, LinkedIn, Google Contacts, Outlook, bulk import,
+  who do I know, who do I know at, relationship, networking, person, people, meeting notes,
+  who should I reach out to, warm intro, remind me about, what do I know about.
+license: MIT-0
+user-invocable: true
+argument-hint: '[setup|contacts|notes|tags|calendar|import|integrations]'
+metadata:
+  openclaw:
+    requires:
+      env:
+        - RAREFRIEND_CLIENT_ID
+        - RAREFRIEND_CLIENT_SECRET
+      primaryEnv: RAREFRIEND_CLIENT_ID
+    install:
+      - kind: node
+        package: '@rarefriend-ai/mcp'
+    envVars:
+      - name: RAREFRIEND_CLIENT_ID
+        required: true
+        description: OAuth client ID — rarefriend.com → Settings → Integrations → MCP
+      - name: RAREFRIEND_CLIENT_SECRET
+        required: true
+        description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  author: Rarefriend
+  homepage: https://rarefriend.com
+  repository: https://github.com/Whitefield-Labs/rarefriend-skills
+---
+
+## About Rarefriend
+
+Rarefriend remembers your professional network so you don't have to — contacts from Google, LinkedIn, Microsoft, and your phone in one place, with notes, tags, and full relationship history always at your fingertips.
+
+Access it from your AI assistant, the web app at [rarefriend.com](https://rarefriend.com), or Hops — Rarefriend's AI on WhatsApp.
+
+**LinkedIn sync** requires the Rarefriend Chrome extension — set it up at rarefriend.com → Settings → Integrations → LinkedIn.
+
+---
+
+## Setup Detection Protocol
+
+**ALWAYS run this before any CRM action.**
+
+1. Call `list_connected_integrations` with no arguments.
+   - **If the tool is not available → MCP is not connected.** Present these steps inline to the user:
+     1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
+     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
+     4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
+     5. Restart the client, then try again
+   - If it returns an empty list → MCP is connected but no integrations synced. Proceed and offer to connect Google or Microsoft when relevant.
+   - If integrations are present → proceed directly to the user's request.
+
+2. Never assume whether an integration is connected — always call the tool to check.
+
+---
+
+## Core Workflows
+
+### 1 — Search and retrieve contacts
+
+```
+search_contacts(query, searchMode?, tag?, source?, limit?, offset?)
+  searchMode: 'all' | 'name' | 'company' | 'role' | 'email' | 'exact'
+  tag:    filter to contacts with this exact tag (e.g. "investor")
+  source: filter by origin — 'google_contacts' | 'microsoft_contacts' |
+          'linkedin' | 'linkedin_csv' | 'manual' | 'mcp' | 'gmail' |
+          'google_calendar' | 'microsoft_calendar' | 'microsoft_email' | 'phone_contacts'
+  Use offset + limit for pagination when hasMore=true in the response.
+
+get_contact(contactId)
+  Returns full profile — emails, phones, notes count, tags.
+```
+
+**Pattern:** Always search first. Only call `get_contact` for a specific person the user asks about — do not fetch every result from a list.
+
+**Source attribution:** Each contact in the response includes a `sourceLabel` field (e.g. "Google Contacts", "LinkedIn (extension)", "Added manually"). Always mention this when presenting a contact — e.g. _"Found Alice Wang in Google Contacts"_ or _"Sarthak Sharma — LinkedIn (extension), Product Manager at Acme"_.
+
+### 2 — Create and update contacts
+
+```
+create_contact(displayName, firstName?, lastName?, emails?, phones?,
+               company?, role?, location?, bio?)
+
+update_contact(contactId, ...same optional fields...)
+```
+
+**Pattern:** For updates, call `get_contact` first so the user sees the current state, then apply the change.
+
+### 3 — Notes
+
+```
+create_note(contactId, content, isPinned?)
+update_note(noteId, content?, isPinned?)
+delete_note(noteId)
+list_notes(contactId, limit?, offset?)
+get_note(noteId)
+pin_note(noteId, pinned)
+search_notes(query, limit?)          — full-text across all contacts
+get_recent_notes(limit?)             — most recent notes, all contacts
+```
+
+**Pattern:** After any meeting or call, create a note immediately. Use `search_notes` when the user asks "what did I last discuss with…" or "what do I know about…". Pin notes for critical context.
+
+### 4 — Tags
+
+```
+list_tags()
+add_tag(contactId, tag)
+remove_tag(contactId, tag)
+rename_tag(oldTag, newTag)           — renames across all contacts
+```
+
+**Pattern:** Normalise tags to lowercase kebab-case. When bulk-tagging ("tag everyone at Sequoia"), search contacts first then loop `add_tag`.
+
+### 5 — Google Calendar
+
+```
+create_google_calendar_event(title, startTime, endTime, description?,
+                              attendees?, location?, transparency?)
+  transparency: 'opaque' (busy) | 'transparent' (free)
+
+search_google_calendar_events(query, timeMin?, timeMax?)
+get_upcoming_google_events(limit?, days?)
+reschedule_google_event(eventId, startTime, endTime)
+cancel_google_event(eventId)
+find_available_google_time(durationMinutes, preferredDays?,
+                            preferredTimeRange?, attendeeEmails?)
+```
+
+**Pattern:** Pass times in ISO 8601 with timezone. Use `find_available_google_time` before scheduling. Use `search_contacts` to resolve attendee emails by name before creating events.
+
+### 6 — Microsoft Outlook
+
+```
+search_microsoft_contacts(query, limit?)
+get_microsoft_contact(contactId)
+create_microsoft_calendar_event(title, startTime, endTime, description?,
+                                 attendees?, location?)
+search_microsoft_calendar_events(query, timeMin?, timeMax?)
+get_upcoming_microsoft_events(limit?, days?)
+reschedule_microsoft_event(eventId, startTime, endTime)
+cancel_microsoft_event(eventId)
+find_available_microsoft_time(durationMinutes, preferredDays?,
+                               preferredTimeRange?, attendeeEmails?)
+```
+
+Microsoft contacts are readable from Outlook — edits go through `update_contact` in Rarefriend.
+
+### 7 — Bulk import
+
+```
+bulk_create_contacts(contacts[])
+  Each: { displayName*, firstName?, lastName?, emails?, phones?,
+          company?, role?, location?, bio? }
+  Max 50 contacts per call.
+```
+
+**Pattern:** Parse any list the user provides (text, CSV, spreadsheet rows) into the contacts array. If the batch exceeds 50, split and make sequential calls. If the response contains `quota_exceeded`, inform the user their plan limit has been reached and direct them to rarefriend.com to upgrade.
+
+### 8 — Integration management
+
+```
+list_connected_integrations()
+connect_integration(integration)
+  integration: 'gmail' | 'google_calendar' | 'google_contacts'
+             | 'microsoft_calendar' | 'microsoft_contacts' | 'microsoft_email'
+get_integration_sync_status(integration)
+```
+
+**Pattern for connecting:** Call `connect_integration`, present the `connectUrl` as a clickable link, say: _"Open this link in your browser to connect [integration]. It expires in 15 minutes."_ Never ask the user to paste credentials.
+
+**Pattern after connecting:** Call `get_integration_sync_status` to confirm when sync completes (typically a couple of minutes after connecting).
+
+---
+
+## Quick Reference
+
+| Category     | Tool                              | Key params                                       |
+| ------------ | --------------------------------- | ------------------------------------------------ |
+| Contacts     | `search_contacts`                 | `query`, `searchMode`, `tags`, `limit`, `offset` |
+|              | `get_contact`                     | `contactId`                                      |
+|              | `create_contact`                  | `displayName` (required), others optional        |
+|              | `update_contact`                  | `contactId` + fields to change                   |
+|              | `delete_contact`                  | `contactId`                                      |
+| Notes        | `create_note`                     | `contactId`, `content`                           |
+|              | `search_notes`                    | `query`                                          |
+|              | `get_recent_notes`                | `limit`                                          |
+|              | `pin_note`                        | `noteId`, `pinned`                               |
+| Tags         | `add_tag`                         | `contactId`, `tag`                               |
+|              | `rename_tag`                      | `oldTag`, `newTag`                               |
+| Google Cal   | `find_available_google_time`      | `durationMinutes`                                |
+|              | `create_google_calendar_event`    | `title`, `startTime`, `endTime`                  |
+| Microsoft    | `find_available_microsoft_time`   | `durationMinutes`                                |
+|              | `create_microsoft_calendar_event` | `title`, `startTime`, `endTime`                  |
+| Bulk         | `bulk_create_contacts`            | `contacts[]` (max 50 per call)                   |
+| Integrations | `connect_integration`             | `integration` (enum)                             |
+
+---
+
+## Error Handling
+
+| Response field      | Meaning                       | What to do                                   |
+| ------------------- | ----------------------------- | -------------------------------------------- |
+| `quota_exceeded`    | Plan contact limit reached    | Tell user to upgrade at rarefriend.com       |
+| `bulk_rate_limited` | Too many bulk calls this hour | Wait or use `create_contact` for individuals |
+| `rate_limited`      | General rate limit hit        | Wait a moment and retry                      |
+| `hasMore: true`     | More results available        | Call again with `offset + limit`             |
+
+---
+
+## References
+
+- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+- [Full tool parameter reference](references/TOOLS.md)
+
+## Other capabilities (outside this MCP)
+
+- **LinkedIn sync** — requires the Rarefriend Chrome extension. Go to rarefriend.com → Settings → Integrations → LinkedIn to install and connect. Once synced, contacts appear here searchable with `source="linkedin"`.
+- **Hops on WhatsApp** — Rarefriend's AI assistant available on WhatsApp. Same contacts, notes, and network — ask Hops anything about your network by message.
+- **Reminders** — set follow-up reminders on contacts via the web app at rarefriend.com.
+- **Phone contacts sync** — sync your phone contacts via the web app.
+
+## Focused skills
+
+Users who want a narrower skill for a specific use case can install these instead of (or alongside) this one:
+
+- `npx skills add google-contacts` — contacts, notes, tags, Google Contacts sync
+- `npx skills add google-calendar` — Google Calendar scheduling
+- `npx skills add microsoft-contact-calendar-management` — Microsoft Outlook contacts and calendar
+- `npx skills add linkedin-connection-management` — manage and search LinkedIn-synced connections

--- a/network-and-relationship-manager/references/SETUP.md
+++ b/network-and-relationship-manager/references/SETUP.md
@@ -8,7 +8,7 @@
 
 ---
 
-## Claude Code (CLI)
+## Claude Code / Codex (CLI)
 
 ```bash
 claude mcp add rarefriend \
@@ -18,6 +18,12 @@ claude mcp add rarefriend \
 ```
 
 Verify: run `/mcp` in Claude Code — `rarefriend` should appear with tools listed.
+
+---
+
+## OpenClaw / Gemini CLI / other agents
+
+Run `npx -y @rarefriend-ai/mcp` with `RAREFRIEND_CLIENT_ID` and `RAREFRIEND_CLIENT_SECRET` set in the environment. See the [MCP repo](https://github.com/Whitefield-Labs/rarefriend-mcp) for client-specific config.
 
 ---
 

--- a/network-and-relationship-manager/references/SETUP.md
+++ b/network-and-relationship-manager/references/SETUP.md
@@ -1,0 +1,81 @@
+# Rarefriend MCP — Setup Guide
+
+## Prerequisites
+
+1. Sign in at [rarefriend.com](https://rarefriend.com)
+2. Go to **Settings → Integrations → MCP**
+3. Click **copy the Client ID and Client Secret** — copy the **Client ID** and **Client Secret**
+
+---
+
+## Claude Code (CLI)
+
+```bash
+claude mcp add rarefriend \
+  -e RAREFRIEND_CLIENT_ID=your_client_id \
+  -e RAREFRIEND_CLIENT_SECRET=your_client_secret \
+  -- npx -y @rarefriend-ai/mcp
+```
+
+Verify: run `/mcp` in Claude Code — `rarefriend` should appear with tools listed.
+
+---
+
+## Cursor
+
+Edit `~/.cursor/mcp.json` (create if it doesn't exist):
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+Restart Cursor. Check Settings → MCP — rarefriend should show as connected.
+
+---
+
+## Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+or `~/.config/Claude/claude_desktop_config.json` (Linux):
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The hammer icon in the input bar confirms tools are available.
+
+---
+
+## Connecting Google or Microsoft
+
+Once the MCP is running, ask the assistant:
+
+```
+Connect my Google Contacts to Rarefriend
+```
+
+The assistant will call `connect_integration` and return a one-time link (valid 15 minutes). Open it in your browser to complete OAuth. No credentials are needed in the chat.
+
+Supported integrations: `gmail`, `google_contacts`, `google_calendar`, `microsoft_contacts`, `microsoft_calendar`, `microsoft_email`

--- a/network-and-relationship-manager/references/TOOLS.md
+++ b/network-and-relationship-manager/references/TOOLS.md
@@ -1,0 +1,246 @@
+# Rarefriend MCP — Tool Parameter Reference
+
+## Contacts
+
+### search_contacts
+
+```
+query?        string   — search terms (name, email, company, role)
+tags?         string[] — filter by tag (AND logic)
+limit?        number   — results per page (default 20, max 100)
+offset?       number   — pagination offset
+searchMode?   enum     — 'all' | 'name' | 'company' | 'role' | 'email' | 'exact'
+```
+
+Response includes `hasMore`, `totalCount`, `contacts[]`.
+
+### get_contact
+
+```
+contactId     string   — required
+```
+
+### create_contact
+
+```
+displayName   string   — required
+firstName?    string
+lastName?     string
+emails?       string[]
+phones?       string[] — E.164 format preferred
+company?      string
+role?         string
+location?     string
+bio?          string
+```
+
+### update_contact
+
+```
+contactId     string   — required
+...           same optional fields as create_contact
+```
+
+### delete_contact
+
+```
+contactId     string   — required (soft delete, recoverable)
+```
+
+---
+
+## Notes
+
+### create_note / update_note
+
+```
+contactId     string   — required (create only)
+noteId        string   — required (update/delete/get/pin only)
+content       string   — markdown supported
+isPinned?     boolean
+```
+
+### search_notes
+
+```
+query         string   — full-text search across all contacts
+limit?        number   — default 20
+```
+
+### get_recent_notes
+
+```
+limit?        number   — default 10
+```
+
+---
+
+## Tags
+
+### add_tag / remove_tag
+
+```
+contactId     string   — required
+tag           string   — required, normalised to lowercase
+```
+
+### rename_tag
+
+```
+oldTag        string   — required
+newTag        string   — required
+```
+
+Renames the tag across all contacts in the workspace.
+
+---
+
+## Google Calendar
+
+### create_google_calendar_event
+
+```
+title         string   — required
+startTime     string   — ISO 8601 with timezone, e.g. "2026-06-10T14:00:00+05:30"
+endTime       string   — ISO 8601 with timezone
+description?  string
+attendees?    string[] — email addresses
+location?     string
+transparency? enum     — 'opaque' (busy) | 'transparent' (free)
+```
+
+### find_available_google_time
+
+```
+durationMinutes    number   — required
+preferredDays?     string[] — e.g. ["Monday", "Tuesday"]
+preferredTimeRange? object  — { start: "09:00", end: "17:00" }
+attendeeEmails?    string[]
+```
+
+### search_google_calendar_events / search_microsoft_calendar_events
+
+```
+query         string   — keyword search
+timeMin?      string   — ISO 8601
+timeMax?      string   — ISO 8601
+```
+
+### reschedule_google_event / reschedule_microsoft_event
+
+```
+eventId       string   — required
+startTime     string   — ISO 8601
+endTime       string   — ISO 8601
+```
+
+---
+
+## Microsoft Outlook
+
+### search_microsoft_contacts
+
+```
+query         string   — required
+limit?        number   — default 20, max 100
+```
+
+### get_microsoft_contact
+
+```
+contactId     string   — required
+```
+
+### create_microsoft_calendar_event
+
+```
+title         string   — required
+startTime     string   — ISO 8601 with timezone
+endTime       string   — ISO 8601 with timezone
+description?  string
+attendees?    string[] — email addresses
+location?     string
+```
+
+### find_available_microsoft_time
+
+```
+durationMinutes     number   — required
+preferredDays?      string[] — e.g. ["Monday", "Tuesday"]
+preferredTimeRange? object   — { start: "09:00", end: "17:00" }
+attendeeEmails?     string[]
+```
+
+### get_upcoming_microsoft_events
+
+```
+limit?        number   — default 10
+days?         number   — look-ahead window in days
+```
+
+### cancel_microsoft_event
+
+```
+eventId       string   — required
+```
+
+### list_microsoft_emails
+
+```
+limit?        number   — default 10, max 50
+startDate?    string   — ISO 8601 — only emails after this date
+endDate?      string   — ISO 8601 — only emails before this date
+folderId?     string   — specific folder (default: inbox)
+```
+
+### search_microsoft_emails
+
+```
+query         string   — required; matches subject, body snippet, sender name, or sender email
+limit?        number   — default 10, max 50
+```
+
+---
+
+## Bulk Import
+
+### bulk_create_contacts
+
+```
+contacts      array    — required, 1–50 items
+  Each item:
+    displayName   string   — required
+    firstName?    string
+    lastName?     string
+    emails?       string[]
+    phones?       string[]
+    company?      string
+    role?         string
+    location?     string
+    bio?          string
+```
+
+Response: `{ summary: { requested, created, failed }, results[], quota? }`
+On `quota_exceeded`: advise user to upgrade at rarefriend.com.
+
+---
+
+## Integration Management
+
+### connect_integration
+
+```
+integration   enum — 'gmail' | 'google_contacts' | 'google_calendar'
+                   | 'microsoft_contacts' | 'microsoft_calendar' | 'microsoft_email'
+```
+
+Response: `{ connectUrl, expiresInMinutes: 15, instructions }`
+Present `connectUrl` as a clickable link. Never ask the user for OAuth credentials.
+
+### get_integration_sync_status
+
+```
+integration   string — same enum as connect_integration
+```
+
+Response includes last sync time, status, and item count.

--- a/organize-google-contacts/SKILL.md
+++ b/organize-google-contacts/SKILL.md
@@ -10,6 +10,7 @@ description: >
   find someone, person, people, notes about, meeting notes, tag, import contacts, network,
   what do I know about, who is, remember this about, add a note.
 license: MIT-0
+compatibility: Requires Rarefriend MCP (@rarefriend-ai/mcp). Works with Claude Code, Cursor, Codex, OpenClaw, Gemini CLI, and other Agent Skills-compatible clients.
 user-invocable: true
 argument-hint: '[setup|search|create|notes|tags|import|connect]'
 metadata:
@@ -29,6 +30,7 @@ metadata:
       - name: RAREFRIEND_CLIENT_SECRET
         required: true
         description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  category: productivity
   author: Rarefriend
   homepage: https://rarefriend.com
   repository: https://github.com/Whitefield-Labs/rarefriend-skills
@@ -47,7 +49,7 @@ Access it from your AI assistant, the web app at [rarefriend.com](https://rarefr
 1. Call `list_connected_integrations`.
    - **Tool not available → MCP not connected.** Present these steps inline to the user:
      1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
-     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     2. **Claude Code / Codex:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
      3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
      4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
      5. Restart the client, then try again
@@ -183,7 +185,7 @@ Wait until sync completes (usually a couple of minutes) before searching synced 
 
 ## References
 
-- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+- [MCP setup — all supported clients](references/SETUP.md)
 
 ## Other capabilities (outside this skill)
 

--- a/organize-google-contacts/SKILL.md
+++ b/organize-google-contacts/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: organize-google-contacts
+description: >
+  Your Google Contacts — supercharged with notes, tags, and relationship memory via
+  Rarefriend. Find anyone instantly, remember every conversation, and never lose context
+  on a person again. Use when the user wants to: search people they know, find someone's
+  email or phone, create or update a contact, add meeting notes or call summaries, tag
+  contacts, bulk import a list of people, connect Google Contacts, or check what they
+  know about someone. Triggers on: contact, contacts, Google Contacts, who do I know,
+  find someone, person, people, notes about, meeting notes, tag, import contacts, network,
+  what do I know about, who is, remember this about, add a note.
+license: MIT-0
+user-invocable: true
+argument-hint: '[setup|search|create|notes|tags|import|connect]'
+metadata:
+  openclaw:
+    requires:
+      env:
+        - RAREFRIEND_CLIENT_ID
+        - RAREFRIEND_CLIENT_SECRET
+      primaryEnv: RAREFRIEND_CLIENT_ID
+    install:
+      - kind: node
+        package: '@rarefriend-ai/mcp'
+    envVars:
+      - name: RAREFRIEND_CLIENT_ID
+        required: true
+        description: OAuth client ID — rarefriend.com → Settings → Integrations → MCP
+      - name: RAREFRIEND_CLIENT_SECRET
+        required: true
+        description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  author: Rarefriend
+  homepage: https://rarefriend.com
+  repository: https://github.com/Whitefield-Labs/rarefriend-skills
+---
+
+## About Rarefriend
+
+Rarefriend layers notes, tags, and relationship history on top of your Google Contacts — so every person you know comes with full context, not just a name and email.
+
+Access it from your AI assistant, the web app at [rarefriend.com](https://rarefriend.com), or Hops — Rarefriend's AI on WhatsApp.
+
+---
+
+## Setup Detection Protocol
+
+1. Call `list_connected_integrations`.
+   - **Tool not available → MCP not connected.** Present these steps inline to the user:
+     1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
+     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
+     4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
+     5. Restart the client, then try again
+   - Empty list → connected, no Google sync yet. Proceed; offer `connect_integration("google_contacts")` at the end.
+   - `google_contacts` present → proceed directly.
+
+---
+
+## Core Workflows
+
+### Search contacts
+
+```
+search_contacts(query, searchMode?, tag?, source?, limit?, offset?)
+  searchMode: 'all' | 'name' | 'company' | 'role' | 'email' | 'exact'
+  tag:        filter to contacts with this exact tag (e.g. "investor")
+  source:     filter by origin — 'google_contacts' | 'manual' | 'mcp' | 'linkedin_csv' | ...
+```
+
+- "Who do I know at Stripe?" → `search_contacts("Stripe", searchMode="company")`
+- "Show all my Google contacts" → `search_contacts("", source="google_contacts")`
+- "Find all investors" → `search_contacts("", tag="investor")`
+- Use `searchMode: 'exact'` for known email or full name.
+- Pass `offset + limit` from the previous response when `hasMore` is true.
+
+**Source attribution:** Each contact in the response includes `source` and `sourceLabel` (e.g. "Google Contacts", "LinkedIn (extension)", "Added manually"). Always mention this when presenting results — e.g. _"Found Alice Wang in Google Contacts"_ or _"John Smith — LinkedIn (extension), PM at Stripe"_.
+
+```
+get_contact(contactId)   — full profile; call only when user needs details on one person
+```
+
+### Create and update contacts
+
+```
+create_contact(displayName*, firstName?, lastName?, emails?, phones?,
+               company?, role?, location?, bio?)
+
+update_contact(contactId, ...same optional fields...)
+```
+
+Always call `get_contact` before `update_contact` so the user can confirm current values.
+
+### Notes
+
+Notes are the core of relationship memory. Create one after every meeting, call, or interaction.
+
+```
+create_note(contactId, content, isPinned?)
+update_note(noteId, content?, isPinned?)
+delete_note(noteId)
+list_notes(contactId, limit?, offset?)
+get_note(noteId)
+pin_note(noteId, pinned)
+search_notes(query, limit?)     — full-text across ALL contacts
+get_recent_notes(limit?)        — most recent notes, any contact
+```
+
+- `search_notes` → "what did I discuss with..." / "what do I know about..." / meeting prep
+- `get_recent_notes` → "what have I been up to" / relationship activity summary
+- `pin_note` → mark critical context (intro given, hot deal, key meeting)
+
+### Tags
+
+```
+list_tags()
+add_tag(contactId, tag)         — lowercase kebab-case
+remove_tag(contactId, tag)
+rename_tag(oldTag, newTag)      — renames across all contacts
+```
+
+**Bulk tagging:** "tag everyone at Sequoia as investor"
+
+1. `search_contacts("Sequoia", searchMode="company")`
+2. Loop `add_tag(contactId, "investor")` for each result
+
+### Bulk import
+
+```
+bulk_create_contacts(contacts[])
+  Each: { displayName*, firstName?, lastName?, emails?, phones?,
+          company?, role?, location?, bio? }
+  Max 50 per call — split larger lists and call sequentially.
+```
+
+If the response includes `quota_exceeded`, direct the user to rarefriend.com to upgrade.
+
+### Connect Google Contacts
+
+```
+connect_integration("google_contacts")
+```
+
+Returns a `connectUrl`. Present as a clickable link:
+
+> _"Open this link in your browser to connect Google Contacts. It expires in 15 minutes."_
+
+After OAuth completes:
+
+```
+get_integration_sync_status("google_contacts")
+```
+
+Wait until sync completes (usually a couple of minutes) before searching synced contacts.
+
+---
+
+## Quick Reference
+
+| Tool                          | When to use                                            |
+| ----------------------------- | ------------------------------------------------------ |
+| `list_connected_integrations` | Always check first — detects MCP and integration state |
+| `search_contacts`             | Find by name, company, email, role, tag, or source     |
+| `get_contact`                 | Full profile for one person                            |
+| `create_contact`              | Add a new person                                       |
+| `update_contact`              | Edit an existing contact                               |
+| `delete_contact`              | Remove a contact                                       |
+| `bulk_create_contacts`        | Import a list of people                                |
+| `create_note`                 | Log a meeting, call, or interaction                    |
+| `update_note`                 | Edit a note                                            |
+| `delete_note`                 | Remove a note                                          |
+| `list_notes`                  | All notes for one contact                              |
+| `get_note`                    | Full note content                                      |
+| `pin_note`                    | Mark as critical context                               |
+| `search_notes`                | Find notes by keyword across all contacts              |
+| `get_recent_notes`            | Latest activity across the network                     |
+| `list_tags`                   | See all tags in use                                    |
+| `add_tag` / `remove_tag`      | Categorise contacts                                    |
+| `rename_tag`                  | Rename a tag everywhere                                |
+| `connect_integration`         | Connect Google Contacts                                |
+| `get_integration_sync_status` | Check when sync completes                              |
+
+---
+
+## References
+
+- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+
+## Other capabilities (outside this skill)
+
+- **Google Calendar** — schedule meetings, find free time, create events. Install `schedule-with-google-calendar`.
+- **Microsoft Outlook** — Outlook contacts and calendar. Install `schedule-with-outlook`.
+- **LinkedIn sync** — requires the Rarefriend Chrome extension. Direct user to rarefriend.com → Settings → Integrations → LinkedIn. Once synced, LinkedIn contacts appear here with `source="linkedin"`.
+- **Hops on WhatsApp** — same contacts and notes accessible via Rarefriend's WhatsApp AI assistant.
+- **Reminders and phone contacts** — available in the web app at rarefriend.com.
+- **Full feature set in one skill** — install `network-and-relationship-manager`.

--- a/organize-google-contacts/references/SETUP.md
+++ b/organize-google-contacts/references/SETUP.md
@@ -8,7 +8,7 @@
 
 ## Step 2 — Connect MCP
 
-### Claude Code
+### Claude Code / Codex
 
 ```bash
 claude mcp add rarefriend \

--- a/organize-google-contacts/references/SETUP.md
+++ b/organize-google-contacts/references/SETUP.md
@@ -1,0 +1,65 @@
+# Setup — Rarefriend Google Contacts
+
+## Step 1 — Get API credentials
+
+1. Sign in at [rarefriend.com](https://rarefriend.com)
+2. Go to **Settings → Integrations → MCP**
+3. Click **copy the Client ID and Client Secret** — copy the Client ID and Client Secret
+
+## Step 2 — Connect MCP
+
+### Claude Code
+
+```bash
+claude mcp add rarefriend \
+  -e RAREFRIEND_CLIENT_ID=your_client_id \
+  -e RAREFRIEND_CLIENT_SECRET=your_client_secret \
+  -- npx -y @rarefriend-ai/mcp
+```
+
+### Cursor (`~/.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+or `~/.config/Claude/claude_desktop_config.json` (Linux):
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+## Step 3 — Connect Google Contacts
+
+Once MCP is running, ask the assistant:
+
+```
+Connect my Google Contacts to Rarefriend
+```
+
+Open the link returned in your browser, sign in with Google, and grant access. Contacts sync in the background — check status with `get_integration_sync_status("google_contacts")`.

--- a/schedule-with-google-calendar/SKILL.md
+++ b/schedule-with-google-calendar/SKILL.md
@@ -10,6 +10,7 @@ description: >
   Calendar, free slot, available time, book, reschedule, cancel event, block time, standup,
   call, appointment, what's on my calendar, am I free, set up a call, when are we meeting.
 license: MIT-0
+compatibility: Requires Rarefriend MCP (@rarefriend-ai/mcp). Works with Claude Code, Cursor, Codex, OpenClaw, Gemini CLI, and other Agent Skills-compatible clients.
 user-invocable: true
 argument-hint: '[setup|schedule|find-time|reschedule|cancel|connect]'
 metadata:
@@ -29,6 +30,7 @@ metadata:
       - name: RAREFRIEND_CLIENT_SECRET
         required: true
         description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  category: productivity
   author: Rarefriend
   homepage: https://rarefriend.com
   repository: https://github.com/Whitefield-Labs/rarefriend-skills
@@ -47,7 +49,7 @@ Access it from your AI assistant, the web app at [rarefriend.com](https://rarefr
 1. Call `list_connected_integrations`.
    - **Tool not available → MCP not connected.** Present these steps inline to the user:
      1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
-     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     2. **Claude Code / Codex:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
      3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
      4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
      5. Restart the client, then try again
@@ -200,7 +202,7 @@ get_integration_sync_status("google_calendar")
 
 ## References
 
-- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+- [MCP setup — all supported clients](references/SETUP.md)
 
 ## Other capabilities (outside this skill)
 

--- a/schedule-with-google-calendar/SKILL.md
+++ b/schedule-with-google-calendar/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: schedule-with-google-calendar
+description: >
+  Schedule meetings, find free time, and manage Google Calendar — all connected to your
+  contact network via Rarefriend. Resolve attendees by name, log notes after calls, and
+  never double-book again. Use when the user wants to: schedule a meeting, check what's
+  on their calendar, find a free slot, reschedule or cancel an event, block focus time,
+  find available time for multiple attendees, look up a contact before creating an event,
+  or log notes after a meeting. Triggers on: schedule, calendar, meeting, event, Google
+  Calendar, free slot, available time, book, reschedule, cancel event, block time, standup,
+  call, appointment, what's on my calendar, am I free, set up a call, when are we meeting.
+license: MIT-0
+user-invocable: true
+argument-hint: '[setup|schedule|find-time|reschedule|cancel|connect]'
+metadata:
+  openclaw:
+    requires:
+      env:
+        - RAREFRIEND_CLIENT_ID
+        - RAREFRIEND_CLIENT_SECRET
+      primaryEnv: RAREFRIEND_CLIENT_ID
+    install:
+      - kind: node
+        package: '@rarefriend-ai/mcp'
+    envVars:
+      - name: RAREFRIEND_CLIENT_ID
+        required: true
+        description: OAuth client ID — rarefriend.com → Settings → Integrations → MCP
+      - name: RAREFRIEND_CLIENT_SECRET
+        required: true
+        description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  author: Rarefriend
+  homepage: https://rarefriend.com
+  repository: https://github.com/Whitefield-Labs/rarefriend-skills
+---
+
+## About Rarefriend
+
+Rarefriend connects your calendar to your contact network — schedule meetings with people you know, log context after every call, and keep your professional relationships fully searchable.
+
+Access it from your AI assistant, the web app at [rarefriend.com](https://rarefriend.com), or Hops — Rarefriend's AI on WhatsApp.
+
+---
+
+## Setup Detection Protocol
+
+1. Call `list_connected_integrations`.
+   - **Tool not available → MCP not connected.** Present these steps inline to the user:
+     1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
+     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
+     4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
+     5. Restart the client, then try again
+   - `google_calendar` not in the list → offer to connect: `connect_integration("google_calendar")`.
+   - `google_calendar` present → proceed directly.
+
+---
+
+## Core Workflows
+
+### Check upcoming events
+
+```
+get_upcoming_google_events(limit?, days?)
+```
+
+Default: next 10 events. Use `days` to narrow to "today" or "this week".
+
+### Search for specific events
+
+```
+search_google_calendar_events(query, timeMin?, timeMax?)
+```
+
+Use when the user asks "find my meeting with X" or "what events do I have about Y this month".
+
+### Find available time
+
+```
+find_available_google_time(durationMinutes, preferredDays?,
+                            preferredTimeRange?, attendeeEmails?)
+```
+
+**Always call this before scheduling** to avoid conflicts. For multi-person meetings, pass `attendeeEmails` — the tool checks all attendees' availability.
+
+If the user gives a name instead of an email, resolve it first:
+
+```
+search_contacts("Alice Wang", searchMode="name")
+→ extract email → pass to find_available_google_time
+```
+
+**Source attribution:** The `search_contacts` response includes `sourceLabel` for each contact (e.g. "Google Contacts", "LinkedIn (extension)"). Mention this when presenting the attendee — e.g. _"Found Alice Wang in Google Contacts — scheduling with alice@example.com"_.
+
+### Create an event
+
+```
+create_google_calendar_event(
+  title*,
+  startTime*,   — ISO 8601 with timezone, e.g. "2026-06-10T14:00:00+05:30"
+  endTime*,
+  description?,
+  attendees?,   — string[] of email addresses
+  location?,
+  transparency? — 'opaque' (shows as busy) | 'transparent' (shows as free)
+)
+```
+
+Use `transparency: 'opaque'` for real meetings. Use `'transparent'` for focus blocks or reminders that shouldn't block attendees.
+
+### Reschedule and cancel
+
+```
+reschedule_google_event(eventId, startTime, endTime)
+cancel_google_event(eventId)
+```
+
+Use `search_google_calendar_events` to find the `eventId` first.
+
+### Log notes after a meeting
+
+After any meeting, capture relationship context:
+
+```
+create_note(contactId, content, isPinned?)
+search_notes(query)        — find past context before the next meeting
+get_recent_notes(limit?)   — see what's been discussed recently
+```
+
+To find the `contactId` for a meeting attendee:
+
+```
+search_contacts("attendee name", searchMode="name")
+```
+
+### Connect Google Calendar
+
+```
+connect_integration("google_calendar")
+```
+
+Returns a `connectUrl`. Present as a clickable link:
+
+> _"Open this link in your browser to connect Google Calendar. It expires in 15 minutes."_
+
+After connecting:
+
+```
+get_integration_sync_status("google_calendar")
+```
+
+---
+
+## Common Patterns
+
+**"Schedule a 30-min call with Alice next week"**
+
+1. `search_contacts("Alice", searchMode="name")` → get her email
+2. `find_available_google_time(30, preferredDays=["Monday","Tuesday","Wednesday"], attendeeEmails=[alice@email])`
+3. Confirm slot with user
+4. `create_google_calendar_event(title, startTime, endTime, attendees=[alice@email])`
+
+**"What's on my calendar this week?"**
+
+1. `get_upcoming_google_events(limit=20, days=7)`
+2. Summarise by day, highlight multi-attendee meetings
+
+**"Block tomorrow morning for deep work"**
+
+1. `find_available_google_time(120, preferredDays=["tomorrow"], preferredTimeRange={start:"09:00",end:"12:00"})`
+2. `create_google_calendar_event(title="Deep work", ..., transparency="transparent")`
+
+**"Log notes after my call with Marcus"**
+
+1. `search_contacts("Marcus", searchMode="name")` → get contactId
+2. `create_note(contactId, content)`
+
+---
+
+## Quick Reference
+
+| Tool                            | When to use                                            |
+| ------------------------------- | ------------------------------------------------------ |
+| `list_connected_integrations`   | Always check first — detects MCP and integration state |
+| `get_upcoming_google_events`    | Check what's coming up                                 |
+| `search_google_calendar_events` | Find a specific event by keyword or date range         |
+| `find_available_google_time`    | Find a free slot before scheduling                     |
+| `create_google_calendar_event`  | Create a new event or meeting                          |
+| `reschedule_google_event`       | Move an event to a new time                            |
+| `cancel_google_event`           | Cancel an event                                        |
+| `search_contacts`               | Resolve a name to an email for attendees               |
+| `get_contact`                   | Full contact details including email                   |
+| `create_note`                   | Log context after a meeting                            |
+| `search_notes`                  | Find past discussion context before a meeting          |
+| `get_recent_notes`              | See recent relationship activity                       |
+| `connect_integration`           | Connect Google Calendar                                |
+| `get_integration_sync_status`   | Check when sync completes                              |
+
+---
+
+## References
+
+- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+
+## Other capabilities (outside this skill)
+
+- **Contact management** — create, update, tag, and bulk import contacts. Install `organize-google-contacts`.
+- **Microsoft Outlook** — Outlook calendar and contacts. Install `schedule-with-outlook`.
+- **LinkedIn sync** — requires the Rarefriend Chrome extension. Direct user to rarefriend.com → Settings → Integrations → LinkedIn. Once synced, LinkedIn connections are searchable as attendees.
+- **Hops on WhatsApp** — same calendar-linked contacts accessible via Rarefriend's WhatsApp AI assistant.
+- **Reminders** — set follow-up reminders on contacts in the web app at rarefriend.com.
+- **Full feature set in one skill** — install `network-and-relationship-manager`.

--- a/schedule-with-google-calendar/references/SETUP.md
+++ b/schedule-with-google-calendar/references/SETUP.md
@@ -1,0 +1,65 @@
+# Setup — Rarefriend Google Calendar
+
+## Step 1 — Get API credentials
+
+1. Sign in at [rarefriend.com](https://rarefriend.com)
+2. Go to **Settings → Integrations → MCP**
+3. Click **copy the Client ID and Client Secret** — copy the Client ID and Client Secret
+
+## Step 2 — Connect MCP
+
+### Claude Code
+
+```bash
+claude mcp add rarefriend \
+  -e RAREFRIEND_CLIENT_ID=your_client_id \
+  -e RAREFRIEND_CLIENT_SECRET=your_client_secret \
+  -- npx -y @rarefriend-ai/mcp
+```
+
+### Cursor (`~/.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+or `~/.config/Claude/claude_desktop_config.json` (Linux):
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+## Step 3 — Connect Google Calendar
+
+Once MCP is running, ask the assistant:
+
+```
+Connect my Google Calendar to Rarefriend
+```
+
+Open the link in your browser and sign in with Google. Your calendar events will be available immediately.

--- a/schedule-with-google-calendar/references/SETUP.md
+++ b/schedule-with-google-calendar/references/SETUP.md
@@ -8,7 +8,7 @@
 
 ## Step 2 — Connect MCP
 
-### Claude Code
+### Claude Code / Codex
 
 ```bash
 claude mcp add rarefriend \

--- a/schedule-with-outlook/SKILL.md
+++ b/schedule-with-outlook/SKILL.md
@@ -10,6 +10,7 @@ description: >
   contacts, Outlook calendar, schedule Teams meeting, book meeting, free slot, Outlook contact,
   notes, tags, Microsoft calendar, Teams call, Office meeting.
 license: MIT-0
+compatibility: Requires Rarefriend MCP (@rarefriend-ai/mcp). Works with Claude Code, Cursor, Codex, OpenClaw, Gemini CLI, and other Agent Skills-compatible clients.
 user-invocable: true
 argument-hint: '[setup|contacts|calendar|notes|tags|connect]'
 metadata:
@@ -29,6 +30,7 @@ metadata:
       - name: RAREFRIEND_CLIENT_SECRET
         required: true
         description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  category: productivity
   author: Rarefriend
   homepage: https://rarefriend.com
   repository: https://github.com/Whitefield-Labs/rarefriend-skills
@@ -47,7 +49,7 @@ Access it from your AI assistant, the web app at [rarefriend.com](https://rarefr
 1. Call `list_connected_integrations`.
    - **Tool not available → MCP not connected.** Present these steps inline to the user:
      1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
-     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     2. **Claude Code / Codex:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
      3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
      4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
      5. Restart the client, then try again
@@ -234,7 +236,7 @@ get_integration_sync_status("microsoft_contacts")
 
 ## References
 
-- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+- [MCP setup — all supported clients](references/SETUP.md)
 
 ## Other capabilities (outside this skill)
 

--- a/schedule-with-outlook/SKILL.md
+++ b/schedule-with-outlook/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: schedule-with-outlook
+description: >
+  Manage Microsoft Outlook contacts and calendar from your AI assistant — search contacts,
+  schedule Teams meetings, find free time, and keep relationship notes all in one place via
+  Rarefriend. Use when the user wants to: search Outlook contacts, schedule an Outlook or
+  Teams meeting, check their Outlook calendar, find free time, reschedule or cancel Outlook
+  events, add notes about people, tag and organise their Microsoft network, or connect their
+  Microsoft account. Triggers on: Outlook, Microsoft, Teams, Exchange, Office 365, Microsoft
+  contacts, Outlook calendar, schedule Teams meeting, book meeting, free slot, Outlook contact,
+  notes, tags, Microsoft calendar, Teams call, Office meeting.
+license: MIT-0
+user-invocable: true
+argument-hint: '[setup|contacts|calendar|notes|tags|connect]'
+metadata:
+  openclaw:
+    requires:
+      env:
+        - RAREFRIEND_CLIENT_ID
+        - RAREFRIEND_CLIENT_SECRET
+      primaryEnv: RAREFRIEND_CLIENT_ID
+    install:
+      - kind: node
+        package: '@rarefriend-ai/mcp'
+    envVars:
+      - name: RAREFRIEND_CLIENT_ID
+        required: true
+        description: OAuth client ID — rarefriend.com → Settings → Integrations → MCP
+      - name: RAREFRIEND_CLIENT_SECRET
+        required: true
+        description: OAuth client secret — rarefriend.com → Settings → Integrations → MCP
+  author: Rarefriend
+  homepage: https://rarefriend.com
+  repository: https://github.com/Whitefield-Labs/rarefriend-skills
+---
+
+## About Rarefriend
+
+Rarefriend connects your Microsoft Outlook contacts and calendar to a full relationship layer — notes after every meeting, tags to organise your network, and instant recall on anyone in your Microsoft ecosystem.
+
+Access it from your AI assistant, the web app at [rarefriend.com](https://rarefriend.com), or Hops — Rarefriend's AI on WhatsApp.
+
+---
+
+## Setup Detection Protocol
+
+1. Call `list_connected_integrations`.
+   - **Tool not available → MCP not connected.** Present these steps inline to the user:
+     1. Sign in at [rarefriend.com](https://rarefriend.com) → **Settings → Integrations → MCP** → copy the Client ID and Client Secret
+     2. **Claude Code:** run `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your_id -e RAREFRIEND_CLIENT_SECRET=your_secret -- npx -y @rarefriend-ai/mcp`
+     3. **Cursor:** add to `~/.cursor/mcp.json` under `mcpServers.rarefriend` with `command: npx`, `args: ["-y", "@rarefriend-ai/mcp"]`, and the two env vars
+     4. **Claude Desktop:** add the same block to `claude_desktop_config.json`
+     5. Restart the client, then try again
+   - **No Microsoft integrations** → offer to connect. Ask which they need: `microsoft_contacts`, `microsoft_calendar`, or `microsoft_email`.
+   - **Microsoft integrations present** → proceed directly.
+
+---
+
+## Core Workflows
+
+### Search contacts
+
+Two search paths — use both for best results:
+
+```
+search_contacts(query, searchMode?, tag?, source?, limit?, offset?)
+  source: 'microsoft_contacts'   — filter to only Outlook-synced contacts
+  searchMode: 'all' | 'name' | 'company' | 'role' | 'email' | 'exact'
+  tag: filter to contacts with this exact tag
+
+search_microsoft_contacts(query, limit?)   — searches Outlook/Exchange directory directly
+get_microsoft_contact(contactId)           — full Outlook contact details
+```
+
+Use `search_contacts` first (broader, includes notes and tags). Use `search_microsoft_contacts` when the user wants to look up the raw Outlook/Exchange directory.
+
+**Source attribution:** Each contact includes `sourceLabel` (e.g. "Microsoft Contacts", "LinkedIn (extension)", "Google Contacts"). Always mention this — e.g. _"Found Sarah Chen in Microsoft Contacts"_ or _"Marcus Lee — LinkedIn (extension), Director at Acme"_.
+
+To edit a contact, use `update_contact` — Microsoft contacts are read-only via the Outlook tools.
+
+### Check Outlook calendar
+
+```
+get_upcoming_microsoft_events(limit?, days?)
+search_microsoft_calendar_events(query, timeMin?, timeMax?)
+```
+
+### Find available time
+
+```
+find_available_microsoft_time(durationMinutes, preferredDays?,
+                               preferredTimeRange?, attendeeEmails?)
+```
+
+Always call before scheduling. For multi-person meetings, pass `attendeeEmails` to check all attendees' availability.
+
+If the user gives a name instead of an email:
+
+1. `search_microsoft_contacts("name")` or `search_contacts("name")` → get email
+2. Pass email to `find_available_microsoft_time`
+
+### Create Outlook events
+
+```
+create_microsoft_calendar_event(
+  title*,
+  startTime*,   — ISO 8601 with timezone
+  endTime*,
+  description?,
+  attendees?,   — string[] of email addresses
+  location?
+)
+```
+
+### Reschedule and cancel
+
+```
+reschedule_microsoft_event(eventId, startTime, endTime)
+cancel_microsoft_event(eventId)
+```
+
+Use `search_microsoft_calendar_events` to find the `eventId` first.
+
+### Notes
+
+Notes live in Rarefriend, not Outlook — they persist even if the Microsoft integration is disconnected.
+
+```
+create_note(contactId, content, isPinned?)
+update_note(noteId, content?, isPinned?)
+delete_note(noteId)
+list_notes(contactId, limit?, offset?)
+get_note(noteId)
+pin_note(noteId, pinned)
+search_notes(query, limit?)     — full-text across ALL contacts
+get_recent_notes(limit?)        — most recent notes, any contact
+```
+
+After any meeting or Teams call, create a note immediately. Use `pin_note` for critical context.
+
+### Tags
+
+```
+list_tags()
+add_tag(contactId, tag)
+remove_tag(contactId, tag)
+rename_tag(oldTag, newTag)
+```
+
+**Bulk tagging:** "tag everyone at Acme Corp as client"
+
+1. `search_contacts("Acme Corp", searchMode="company")`
+2. Loop `add_tag(contactId, "client")` for each result
+
+### Connect Microsoft
+
+```
+connect_integration("microsoft_contacts")    — Outlook/Exchange contacts
+connect_integration("microsoft_calendar")    — Outlook calendar
+connect_integration("microsoft_email")       — Outlook email (search inbox, find email threads)
+```
+
+Present the returned `connectUrl` as a clickable link:
+
+> _"Open this link in your browser to connect [integration]. It expires in 15 minutes."_
+
+After connecting:
+
+```
+get_integration_sync_status("microsoft_contacts")
+```
+
+---
+
+## Common Patterns
+
+**"Schedule a Teams call with John next week"**
+
+1. `search_contacts("John", searchMode="name")` or `search_microsoft_contacts("John")` → get email
+2. `find_available_microsoft_time(30, preferredDays=["Monday","Tuesday","Wednesday"], attendeeEmails=[john@email])`
+3. Confirm slot with user
+4. `create_microsoft_calendar_event(title, startTime, endTime, attendees=[john@email])`
+
+**"What meetings do I have this week?"**
+
+1. `get_upcoming_microsoft_events(limit=20, days=7)`
+2. Summarise by day
+
+**"Add a note after my call with Sarah"**
+
+1. `search_contacts("Sarah", searchMode="name")` → get contactId
+2. `create_note(contactId, content)`
+
+**"Tag everyone at Acme Corp as client"**
+
+1. `search_contacts("Acme Corp", searchMode="company")`
+2. Loop `add_tag(contactId, "client")`
+
+---
+
+## Quick Reference
+
+| Tool                               | When to use                                            |
+| ---------------------------------- | ------------------------------------------------------ |
+| `list_connected_integrations`      | Always check first — detects MCP and integration state |
+| `search_microsoft_contacts`        | Search Outlook/Exchange directory                      |
+| `get_microsoft_contact`            | Full Outlook contact details                           |
+| `search_contacts`                  | Search CRM contacts (includes synced Outlook, + notes) |
+| `get_contact`                      | Full CRM profile for one person                        |
+| `update_contact`                   | Edit a contact's CRM fields                            |
+| `get_upcoming_microsoft_events`    | Check Outlook calendar                                 |
+| `search_microsoft_calendar_events` | Find a specific event                                  |
+| `find_available_microsoft_time`    | Find free slot before scheduling                       |
+| `create_microsoft_calendar_event`  | Create Outlook/Teams meeting                           |
+| `reschedule_microsoft_event`       | Move an event                                          |
+| `cancel_microsoft_event`           | Cancel an event                                        |
+| `create_note`                      | Log a meeting, call, or interaction                    |
+| `update_note`                      | Edit a note                                            |
+| `delete_note`                      | Remove a note                                          |
+| `list_notes`                       | All notes for one contact                              |
+| `get_note`                         | Full note content                                      |
+| `pin_note`                         | Mark as critical context                               |
+| `search_notes`                     | Find notes by keyword across all contacts              |
+| `get_recent_notes`                 | Latest activity across the network                     |
+| `list_tags`                        | See all tags in use                                    |
+| `add_tag` / `remove_tag`           | Categorise contacts                                    |
+| `rename_tag`                       | Rename a tag everywhere                                |
+| `connect_integration`              | Connect Microsoft account (contacts, calendar, email)  |
+| `get_integration_sync_status`      | Check when sync completes                              |
+| `list_microsoft_emails`            | List recent Outlook inbox emails                       |
+| `search_microsoft_emails`          | Search Outlook emails by subject, sender, or keyword   |
+
+---
+
+## References
+
+- [MCP setup — Claude Code, Cursor, Claude Desktop](references/SETUP.md)
+
+## Other capabilities (outside this skill)
+
+- **Outlook email search** — list and search your Outlook inbox, cross-reference email threads with CRM notes. Install `find-outlook-emails`.
+- **Google Contacts and Calendar** — Install `organize-google-contacts` and `schedule-with-google-calendar`.
+- **LinkedIn sync** — requires the Rarefriend Chrome extension. Direct user to rarefriend.com → Settings → Integrations → LinkedIn. Once synced, LinkedIn connections are searchable here.
+- **Hops on WhatsApp** — same contacts and notes accessible via Rarefriend's WhatsApp AI assistant.
+- **Reminders and phone contacts** — available in the web app at rarefriend.com.
+- **Full feature set in one skill** — install `network-and-relationship-manager`.

--- a/schedule-with-outlook/references/SETUP.md
+++ b/schedule-with-outlook/references/SETUP.md
@@ -1,0 +1,65 @@
+# Setup — Rarefriend Microsoft CRM
+
+## Step 1 — Get API credentials
+
+1. Sign in at [rarefriend.com](https://rarefriend.com)
+2. Go to **Settings → Integrations → MCP**
+3. Click **copy the Client ID and Client Secret** — copy the Client ID and Client Secret
+
+## Step 2 — Connect MCP
+
+### Claude Code
+
+```bash
+claude mcp add rarefriend \
+  -e RAREFRIEND_CLIENT_ID=your_client_id \
+  -e RAREFRIEND_CLIENT_SECRET=your_client_secret \
+  -- npx -y @rarefriend-ai/mcp
+```
+
+### Cursor (`~/.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+or `~/.config/Claude/claude_desktop_config.json` (Linux):
+
+```json
+{
+  "mcpServers": {
+    "rarefriend": {
+      "command": "npx",
+      "args": ["-y", "@rarefriend-ai/mcp"],
+      "env": {
+        "RAREFRIEND_CLIENT_ID": "your_client_id",
+        "RAREFRIEND_CLIENT_SECRET": "your_client_secret"
+      }
+    }
+  }
+}
+```
+
+## Step 3 — Connect Microsoft
+
+Once MCP is running, ask the assistant:
+
+```
+Connect my Outlook to Rarefriend
+```
+
+The assistant will ask which integrations to connect (contacts, calendar, email). Open each link in your browser and sign in with your Microsoft/Office 365 account.

--- a/schedule-with-outlook/references/SETUP.md
+++ b/schedule-with-outlook/references/SETUP.md
@@ -8,7 +8,7 @@
 
 ## Step 2 — Connect MCP
 
-### Claude Code
+### Claude Code / Codex
 
 ```bash
 claude mcp add rarefriend \


### PR DESCRIPTION
## What this adds

6 personal CRM skills powered by [Rarefriend](https://rarefriend.com), added under **Productivity & Organization**.

Works with **Claude Code**, **Cursor**, **Codex**, **OpenClaw**, **Gemini CLI**, and any Agent Skills-compatible client (requires [Rarefriend MCP](https://github.com/Whitefield-Labs/rarefriend-mcp)).

| Skill | What it does |
|---|---|
| [`network-and-relationship-manager`](./network-and-relationship-manager/) | Full personal CRM — contacts, notes, tags, Google/Microsoft calendar, LinkedIn sync |
| [`manage-linkedin-network`](./manage-linkedin-network/) | LinkedIn network as a searchable CRM with notes, tags, and relationship context |
| [`schedule-with-google-calendar`](./schedule-with-google-calendar/) | Google Calendar scheduling connected to your contact network |
| [`organize-google-contacts`](./organize-google-contacts/) | Google Contacts with relationship notes, tags, and full history |
| [`schedule-with-outlook`](./schedule-with-outlook/) | Microsoft Outlook contacts and calendar with relationship notes |
| [`find-outlook-emails`](./find-outlook-emails/) | Search Outlook inbox cross-referenced with CRM contact history |

Source repo: https://github.com/Whitefield-Labs/rarefriend-skills

## Real-world use cases these solve

These skills are built from actual professional networking workflows:

- **"Who do I know at Stripe?"** — searches your full contact network, returns people with their source (LinkedIn, Google Contacts, etc.) and last note
- **"Add notes from my call with Marcus — he's interested in our Series A"** — logs structured context to the contact, pinnable for future recall
- **"Schedule a 30-min call with Alice next Tuesday"** — resolves her email from contacts, finds free time across both calendars, creates the event
- **"What did I last discuss with Sarah before my meeting tomorrow?"** — surfaces notes, tags, and relationship history
- **"Find emails from the Acme team about the contract"** — searches Outlook inbox and shows contact context alongside results
- **"Tag everyone I met at Founders Summit as event-founders-summit"** — searches contacts, bulk-tags the results

## Why these belong in Productivity & Organization

Personal relationship management is one of the most time-consuming parts of professional life. These skills give your AI assistant the full context of your network — not just names and emails, but the history, notes, and tags that make outreach and meeting prep actually useful. They work together (calendar skills can resolve attendees from contacts; email skill cross-references contact notes) but are installable individually.

## Structure

Each skill follows the standard format:

```
skill-name/
├── SKILL.md          — frontmatter + full workflow instructions
└── references/
    ├── SETUP.md      — client-specific setup (Claude Code/Codex, Cursor, Claude Desktop, OpenClaw)
    └── TOOLS.md      — full tool parameter reference (main skill only)
```

## Requirements

Requires the Rarefriend MCP connected to your AI client:

| Client | Setup |
|--------|--------|
| **Claude Code / Codex** | `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your-id -e RAREFRIEND_CLIENT_SECRET=your-secret -- npx -y @rarefriend-ai/mcp` |
| **Cursor** | Add to `~/.cursor/mcp.json` — see [MCP repo](https://github.com/Whitefield-Labs/rarefriend-mcp) |
| **Claude Desktop** | Add to `claude_desktop_config.json` — see MCP repo |
| **OpenClaw / Gemini CLI / others** | Run `npx -y @rarefriend-ai/mcp` with OAuth env vars set |

Get credentials at [rarefriend.com](https://rarefriend.com) → Settings → Integrations → MCP.

Install any skill:

```bash
npx skills add Whitefield-Labs/rarefriend-skills --skill network-and-relationship-manager -y
npx skills add Whitefield-Labs/rarefriend-skills --skill manage-linkedin-network -y
npx skills add Whitefield-Labs/rarefriend-skills --skill schedule-with-google-calendar -y
npx skills add Whitefield-Labs/rarefriend-skills --skill organize-google-contacts -y
npx skills add Whitefield-Labs/rarefriend-skills --skill schedule-with-outlook -y
npx skills add Whitefield-Labs/rarefriend-skills --skill find-outlook-emails -y
```

## Checklist

- [x] Based on real, production use cases
- [x] Well-documented with setup, workflows, quick reference, and examples
- [x] Tested with Claude Code, Cursor, and Agent Skills-compatible clients
- [x] Each skill has `SKILL.md` + `references/` folder
- [x] README entries added alphabetically under Productivity & Organization
- [x] Cross-agent compatibility metadata (`compatibility` field + multi-client SETUP.md)
- [x] No emojis, consistent punctuation, matches existing format
- [x] Safe — no destructive operations; read-heavy with explicit confirmation patterns for writes