### PR TITLE
Add ltx2-vidgen-skill skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [ltx2-vidgen-skill](https://github.com/patraxo/ltx2-vidgen-skill) - Self-hosted LTX-2.3 (22B) AI video in Claude Code — deploys your own Modal serverless-GPU backend, then generates text/image/keyframe/video-to-video plus canny/depth/pose control with synced audio. *By [@patraxo](https://github.com/patraxo)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
Adds **ltx2-vidgen-skill** to Creative & Media (alphabetical, external-link format with attribution).

**What it solves:** hosted AI-video APIs charge per clip and rate-limit you, which kills iteration. This is a Claude Code skill that deploys your *own* LTX-2.3 (22B) video backend to your Modal serverless-GPU account, then drives it from Claude Code — drop a photo (or a prompt), get a video. Your GPU, your bill, no per-clip meter.

**Who uses it:** creators making reels/shorts who want to explore a prompt many ways cheaply (`--variations N`) and keep the best take for a few cents.

**Modes:** text-to-video, image-to-video, keyframe interpolation, video-to-video (retake/restyle), and IC-LoRA canny/depth/pose control — with synced audio. Reel/YouTube/square format presets.

**Example:** in Claude Code — *"turn this photo into a video, subtle natural motion, vertical reel"* → saves the `.mp4` + a preview frame.

Install: `npx skills add patraxo/ltx2-vidgen-skill`. Public, v1.0.0, CI-linted SKILL.md, demo in the README: https://github.com/patraxo/ltx2-vidgen-skill

Author submission. Single-line addition; external-repo entry matching the existing Creative & Media format (e.g. anydesign, imagen, Pixelbin).