### PR TITLE
Add withvibe-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [withvibe-skills](https://github.com/withvibe/withvibe-skills) - Two skills for the WithVibe shared AI dev environment: install-withvibe stands up the self-hosted stack, and withvibe-plugin-creator scaffolds a new WithVibe plugin (manifest, Dockerfile, HTTP server with health/UI/MCP endpoints). *By [@withvibe](https://github.com/withvibe)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds **withvibe-skills** to the Development & Code Tools section (alphabetical slot).

Two Claude Code skills for the WithVibe shared AI development environment: `install-withvibe` stands up the self-hosted stack for a first-time user, and `withvibe-plugin-creator` scaffolds a new WithVibe plugin (manifest, Dockerfile, HTTP server with health/UI/MCP endpoints). Apache-2.0.

- Repo: https://github.com/withvibe/withvibe-skills

Matches the existing `- [name](url) - description. *By [@handle](...)*` format.