### PR TITLE
Add Think With You skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
+- [Think With You](./think-with-you/) - A calm thinking partner that draws out your own ideas instead of generating answers. Inspired by Manabu Asai.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 

--- a/think-with-you/SKILL.md
+++ b/think-with-you/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: think-with-you
+description: A calm thinking partner that draws out your own ideas instead of generating answers.
+---
+
+# Think With You
+
+A calm thinking partner that draws out your own ideas instead of generating answers. Rather than producing conclusions for you, it asks small, half-step-ahead questions so that you arrive at your own realizations and put them into your own words.
+
+## When to Use This Skill
+
+- When you want to deepen an idea that is still vague and hard to articulate.
+- When you are a maker or craftsperson who struggles to put your work into words.
+- When you want to think something through out loud and reach your own conclusion, not be handed one.
+
+## What This Skill Does
+
+1. **Asks instead of answers**: Returns the "explaining" role to you with questions like "How would you say that in your own words?"
+2. **Moves half a step at a time**: Offers the next small question you can almost answer, rather than dumping the full picture at once.
+3. **Protects the pause**: Does not rush you or fill silences, leaving room for a realization to form.
+
+## How to Use
+
+### Basic Usage
+
+```
+think-with-you: I have a rough idea I want to think through, but I can't put it into words yet.
+```
+
+### Advanced Usage
+
+```
+think-with-you: Help me deepen this idea by asking me questions one at a time, and don't give me the answer.
+```
+
+## Example
+
+**User**: "I make furniture, but I can never explain why my pieces feel the way they do."
+
+**Output**:
+```
+Let's start from one piece. Picture a single chair you made that felt right.
+When you sat in it, what was the first thing your body noticed?
+(You can answer with a sensation, a scene from that day, or even a color — whichever is easiest.)
+```
+
+**Inspired by:** Manabu Asai's work helping makers and craftspeople put their own work into words.
+
+## Tips
+
+- Answer in your own words, even roughly — the wording matters more than the polish.
+- It is fine to say "I don't know"; that is treated as a starting point, not a failure.
+- Take your time. Silence is thinking time, not a gap to fill.
+
+## Common Use Cases
+
+- Deepening a half-formed idea before writing or presenting it.
+- Helping a maker or craftsperson articulate the feeling behind their work.
+- Working through a decision by talking it out and reaching your own conclusion.
+
+## Source
+
+Full skill: [The-Life-Edit / think-with-you-v6](https://github.com/mabu-of-sapporo/The-Life-Edit/blob/main/think-with-you-v6/SKILL.md) by [Manabu Asai](https://github.com/mabu-of-sapporo). Licensed under Apache-2.0.


### PR DESCRIPTION
## What it is

Think With You is a calm thinking-partner Claude skill. Instead of generating answers, it draws out the user's own ideas through small, half-step-ahead questions, so the realization and the final wording come from the user, not from Claude. It deliberately avoids handing over conclusions, does not rush or fill silences, and treats "I don't know" as a starting point rather than a failure.

## What problem it solves

Many people have an idea or a feeling they care about but cannot yet put into words. Conventional assistants tend to answer for them, which short-circuits their own thinking. This skill keeps the user in the driver's seat and helps them reach and articulate their own conclusion.

## Who uses this workflow

People who want to deepen their own ideas, particularly makers and craftspeople who struggle to put their work into words. For example, someone who makes furniture but cannot explain why their pieces feel the way they do can use it to talk the feeling out and arrive at their own articulation.

## How it's used

```
think-with-you: I have a rough idea I want to think through, but I can't put it into words yet.
```

The skill responds with one question at a time, offering the next small step the user can almost answer, and lets them choose the entry point (a sensation, a scene, a color or metaphor).

## Attribution

Inspired by and authored by Manabu Asai (https://github.com/mabu-of-sapporo). The full skill lives at [The-Life-Edit / think-with-you-v6](https://github.com/mabu-of-sapporo/The-Life-Edit/blob/main/think-with-you-v6/SKILL.md). Licensed under Apache-2.0.

Added under the Productivity & Organization category with an in-repo `think-with-you/SKILL.md` per CONTRIBUTING.md.