### PR TITLE
Add claude-dnd-skill under Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [claude-dnd-skill](https://github.com/neuralinitiative/claude-dnd-skill) - Persistent D&D 5e Dungeon Master: campaign, character, combat, and NPC state across sessions, real dice, 2014 + 2024 rules, and an optional cinematic display companion for couch co-op. *By [@neuralinitiative](https://github.com/neuralinitiative)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds **claude-dnd-skill** to the **Creative & Media** section.

- **Repo:** https://github.com/neuralinitiative/claude-dnd-skill
- **What it is:** a persistent D&D 5e Dungeon Master for Claude Code — campaign/character/combat/NPC state across sessions, real dice rolls, both 2014 and 2024 rulesets, and an optional cinematic display companion for couch co-op play.
- **License:** AGPL-3.0-or-later
- **Packaging:** ships as a Claude Code plugin (`/plugin marketplace add neuralinitiative/claude-dnd-skill` → `/plugin install dm@neural-initiative`); manifests pass `claude plugin validate`.

Checked against CONTRIBUTING.md: real, actively-used skill (not hypothetical), no existing duplicate in the list, alphabetical placement within Creative & Media, tested in Claude Code.