### PR TITLE
Add vaara-governed-tool-call under Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [vaara-governed-tool-call](https://github.com/vaaraio/vaara/tree/main/examples/skills/vaara-governed-tool-call) - An EU AI Act Article 14 human-oversight checkpoint and Article 12 audit record in front of a high-risk tool call: gate to allow / escalate / deny, route escalations to a human, and export a signed, hash-chained record a regulator can verify offline. *By [@vaaraio](https://github.com/vaaraio)*
 
 ### Assistive Technology
 


### PR DESCRIPTION
Adds one entry under Security & Systems, linking to the skill in its own repo (same external-link pattern as threat-hunting-with-sigma-rules).

What it does: it puts a human-oversight checkpoint and an auditable record in front of a high-risk tool call, the kind of action a human should be able to stop and a regulator should be able to verify later (writing to a clinical or genomic database, submitting to a regulator, moving money, deleting data). It gates the call to allow, escalate, or deny, routes escalations to a human review queue, and appends every decision, escalation, resolution, and outcome to a hash-chained trail that exports to a signed package and verifies offline. It wraps the open-source vaara package (pip install vaara), no server needed.

Real use case: EU AI Act Article 14 (human oversight) and Article 12 (record-keeping) for agents running consequential actions. It drops in next to capability skills, a clinical or genomic database skill ships the action, this ships the oversight and the record. Tested in Claude Code against the package, and used to govern the development of the package itself.