### PR TITLE
Add Claude SEO GEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
+- [Claude SEO GEO](https://github.com/Thibaultbm/claude-seo-geo) - 15 SEO and GEO skills: full site audit, technical SEO, content for every page type, link building, local SEO, social amplification, AI visibility and tracking (ChatGPT, Perplexity, AI Overviews), plus an Obsidian company-knowledge layer. *By [@Thibaultbm](https://github.com/Thibaultbm)*
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.


### PR DESCRIPTION
Adds one entry to **Business & Marketing**: [Claude SEO GEO](https://github.com/Thibaultbm/claude-seo-geo), inserted in alphabetical order. No other lines touched.

**What it is**
- 15 skills covering the full SEO + GEO (Generative Engine Optimization) workflow: site audit, technical SEO, keyword and prompt research, content for blog, product, service and collection pages, internal linking, schema markup, backlinks, local SEO, social amplification, and AI visibility plus AI traffic tracking (ChatGPT, Perplexity, Google AI Overviews), with an Obsidian company-knowledge layer every skill reads before acting.
- Open Agent Skills format (SKILL.md + references), installable as a Claude Code plugin via `/plugin marketplace add Thibaultbm/claude-seo-geo`; also works in Cursor, Codex, and Gemini CLI.
- MIT licensed, zero dependencies, no API keys required: every workflow runs on free tools.
- Each of the 15 skills ships with its own evals folder, and a CI workflow validates the repo structure.

**Why it belongs here**: Business & Marketing has no standalone SEO/GEO toolkit yet; the closest entry (Brand Build Skills) is a broader brand library whose SEO audit suite relies on an Ahrefs MCP. This kit is complementary and runs without paid tools.

**Who uses it / example**: built from 115+ real agency audit calls. Typical use: "Audit example.com and give me a prioritized action plan" triggers the seo-geo-audit skill, which hands off to the specialized skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)