### PR TITLE
Add traffic-standards-kb: Chinese transportation standards knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [traffic-standards-kb](https://github.com/solvex-top/solvex-skills) - Chinese smart transportation standards knowledge base (GB/JT/GA) for solution writing and technical proposals. Install via `npx skills add solvex-top/solvex-skills@traffic-standards-kb -g -y`. *By [@solvex-top](https://github.com/solvex-top)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds [traffic-standards-kb](https://github.com/solvex-top/solvex-skills) — a skill for querying Chinese transportation standards (GB, JT, GA) via the Solvex API.

Install: npx skills add solvex-top/solvex-skills@traffic-standards-kb -g -y