### PR TITLE
Add ui-ux-audit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [ui-ux-audit](https://github.com/EnchStyle/ui-ux-audit-skill) - Scored UI/UX audits across 15 categories with a severity rubric, plus silent prevention of common AI UI failures (layout shift, text overflow, low contrast, undersized touch targets, accessibility) before they ship. *By [@EnchStyle](https://github.com/EnchStyle)*
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
Adds **ui-ux-audit** to the **Development & Code Tools** section (placed alphabetically), with a link back to the source repo — consistent with the other external-link entries in that section.

**Repository:** https://github.com/EnchStyle/ui-ux-audit-skill

**What problem it solves:** AI consistently ships UI with broken layouts, text overflow, low contrast, undersized touch targets, missing states, accessibility violations, and generic "AI slop" aesthetics. This skill catches them.

**Who uses it:** Anyone building or reviewing UI with Claude Code or Claude.ai.

**How it works:**
- **Audit mode** — scores any UI/screen/component/screenshot across 15 categories with a severity rubric and concrete, actionable fixes.
- **Prevention mode** — consulted automatically before generating UI code (React/JSX/HTML/CSS/Tailwind/React Native) so these failures never ship in the first place.

Tested across Claude Code and Claude.ai. Single addition, no deletions. Thanks for maintaining the list!