### PR TITLE
Add File Conversion (ChangeThisFile) skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
+- [File Conversion (ChangeThisFile)](https://github.com/aadilr/changethisfile-mcp) - Convert files between 999 routes — PDF↔Word, HEIC→JPG, MP4→MP3, CSV→JSON, EPUB→MOBI — via the free ChangeThisFile API. MCP-first with a zero-dependency script fallback; no API key required. *By [@aadilr](https://github.com/aadilr)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 


### PR DESCRIPTION
Adds the ChangeThisFile file-conversion skill to **Document Processing**.

- Repo: https://github.com/aadilr/changethisfile-mcp (MIT)
- Converts files between 999 routes (images, video, audio, documents, data, fonts, ebooks, archives) via the free changethisfile.com API — no API key or signup.
- Skill is MCP-first (`changethisfile:convert_file`) with a zero-dependency `curl` script fallback, so it works in Claude Code, Codex CLI, Cursor, Gemini CLI, etc.
- Install: `npx skills add aadilr/changethisfile-mcp`
- Tested end-to-end (md→pdf, csv→xlsx, error surfaces).