### PR TITLE
Add AugmentClaude to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [AugmentClaude](https://augmentclaude.com) - Hand-picked marketplace of Claude skills
 
 ### Inspiration & Use Cases
 


### PR DESCRIPTION
One-line addition to **Resources → Community Resources**, description kept short to match the section's style.

[AugmentClaude](https://augmentclaude.com) is a free, hand-picked marketplace of Claude Code skills, bundles, MCP servers, and agents — every entry credited to its original author with a GitHub source link.

Disclosure: I'm the founder. Happy to adjust wording or placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)