### PR TITLE
Add ui-craft to Creative & Media section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [ui-craft](https://github.com/educlopez/ui-craft) - Anti-slop design engineering skill with outcome recipes, 4 production theme presets, scored heuristic critique, and 26 domain references. Works with Claude Code, Codex, Cursor, Gemini CLI, and OpenCode. *By [@educlopez](https://github.com/educlopez)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
**What is ui-craft?**
[ui-craft](https://github.com/educlopez/ui-craft) is a design engineering skill for AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, OpenCode). It ships anti-slop rules, outcome recipes (`/craft` commands), 4 production theme presets, scored heuristic critique, and 26 domain references — stack-agnostic.

Docs: https://skills.smoothui.dev

**Why it fits Creative & Media:**
It teaches agents *how* to produce craft-level UI/design output rather than generic AI slop — aligns with the section's design/visual tools.

**Format compliance:**
- Follows the existing list format: `- [Name](link) - description. *By [@handle](link)*`
- Added at end of section (matches recent-addition pattern in the list)
- Links verified and working