### PR TITLE
Add Ariadne Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop/tree/main/skills/ariadne-loop) - Write verifiable loop specs, gates, and handoff packets for Claude Code, Codex, and OpenClaw.
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds Ariadne Loop to Development & Code Tools.

Ariadne Loop is a Claude/Codex/OpenClaw skill for writing verifiable loop specs, gates, and handoff packets for AI coding agents. It links directly to the skill folder and keeps the README change to a single external bullet.

Validation: git diff --check; checked against README-only and alphabetical rules in label-ready-skill workflow.