### PR TITLE
Add agent-self-audit — self-evolving agent health check skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+
+- [agent-self-audit](https://github.com/Xxt-XN/agent-self-audit) - The self-evolving agent health check skill with 3 self-evolution loops (error/skill/config), 13 check items across Quick/Full tiers, and zero-config bootstrap. Works on Claude Code, Codex CLI, Cursor, Windsurf, Gemini CLI.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis


### PR DESCRIPTION
## Summary
Adds [agent-self-audit](https://github.com/Xxt-XN/agent-self-audit) to the Development & Code Tools section.

## What It Does
Self-evolving health check for agent configurations. 13 check items across Quick (<500 tokens) and Full tiers. Three self-evolution loops: errors auto-promote to hard rules, stale skills get market comparison, configuration bloat gets surgical split/compress prescriptions.

## Why It Belongs Here
- Cross-platform: Claude Code, Codex CLI, Cursor, Windsurf, Gemini CLI
- Follows agentskills.io standard
- Zero-config bootstrap from new machine
- No existing skill in this list covers health-check / self-audit domain