### PR TITLE
Add Viral Cover Prompt Builder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [Viral Cover Prompt Builder](https://github.com/JackZhong2017/viral-cover-prompt-builder) - Generates viral, vertical (3:4) Xiaohongshu/Rednote cover prompts via a guided Q&A: 8 layout templates, fisheye "little planet" camera module, and color-theory-driven Morandi clash backgrounds. *Derived from [@panggungunvibe](https://github.com/panggungunvibe)'s atutun-xhs-cover*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
## What

Adds [Viral Cover Prompt Builder](https://github.com/JackZhong2017/viral-cover-prompt-builder) to the **Creative & Media** section.

## What it does

A Claude Skill that walks a user through a short Q&A flow (style choice, reference images, expression/pose, background/color-clash, font treatment, title, camera & composition) and outputs a ready-to-use Chinese-language prompt for generating viral, vertical (3:4) Xiaohongshu/Rednote cover images with image models (Midjourney, Nano Banana, Sora, etc.).

v2 highlights:
- New "Camera & Composition" question, including a fisheye "little planet" top-down module
- Color-clash background sub-flow with Morandi-palette derivation from the subject's dominant color
- A final normalization pass via the `prompt-architect` skill before output

## Who would use this

Content creators, marketers, and indie hackers producing Xiaohongshu/Rednote posts who want a consistent, high-click cover style without manually crafting image prompts each time.

## Attribution

This skill is a derivative of [panggungunvibe/atutun-xhs-cover](https://github.com/panggungunvibe/atutun-xhs-cover/blob/main/atutun-xhs-cover/SKILL.md), the original "Atutun" style skill. Credit and link to the original author are included in the repo's README.