### PR TITLE
Add CreatorSkills to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators (YouTube scripting, sponsorship analysis, audience growth)
 
 ### Inspiration & Use Cases
 


### PR DESCRIPTION
## What's being added

[CreatorSkills](https://creatorskills.co) — Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.

Added to the **Community Resources** section alongside the official Skills Marketplace.

## Why it fits

CreatorSkills is a third-party marketplace specifically for downloadable Claude-compatible skills targeting content creators — a niche complement to the official claude.ai/marketplace. It provides curated, domain-specific skill packages for a segment (content creators) who may not find what they need in general skill directories.