### PR TITLE
Add Asolytics ASO API skill (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
+- [Asolytics ASO API](https://github.com/Asolytics-Pro/asolytics-app-store-optimization-api) - App Store Optimization (ASO) skill for the Asolytics API: keyword research, app rankings, keyword metrics, live search top-50, recommended keywords, competitor analysis, install/revenue estimates, and top-500 store charts for the App Store and Google Play. *By [@Asolytics-Pro](https://github.com/Asolytics-Pro)*
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.


### PR DESCRIPTION
Adds the **Asolytics ASO API** skill under *Business & Marketing*.

It teaches a Claude/Codex agent to use the [Asolytics Public API](https://app.asolytics.pro/api/public-api/documentation) for App Store Optimization: keyword research & metrics, app rankings, live search top-50, recommended keywords, competitor analysis, install/revenue estimates, and top-500 store charts across the App Store and Google Play.

- Repo: https://github.com/Asolytics-Pro/asolytics-app-store-optimization-api
- Real use case (ASO research/automation), MIT-licensed, agent-neutral (Claude Code + Codex), bundled OpenAPI reference.
- Single alphabetical entry added to the Business & Marketing list; no other changes.