### PR TITLE
Add 'Animated Diagrams' to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
-- [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages.
+- [Animated Diagrams](https://github.com/omkamal/animated-diagrams-skill.git) - A very visually pleasing animated diagrams including concept diagrams, sequence diagrams, python walkthrough diagrams, process flow diagrams. Output is generated in MP4, SVG, and GIF.
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Added a new entry for 'Animated Diagrams' to the README.

- [Animated Diagrams](https://github.com/omkamal/animated-diagrams-skill.git) - A very visually pleasing animated diagrams including concept diagrams, sequence diagrams, python walkthrough diagrams, process flow diagrams. Output is generated in MP4, SVG, and GIF.