### PR TITLE
Add InstaShare (share Claude Code sessions as public links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [InstaShare](https://github.com/Instafill/instashare-skill) - Uploads the current Claude Code session to instashare.to and returns a public, shareable link in one shell call — no account needed (anonymous-first, claim to a Google account later). A built-in secret-redaction classifier scrubs API keys, tokens, `Authorization`/`Cookie` headers, and PEM private keys before upload, so transcripts are safe to share. [Live example](https://instashare.to/c/YDXusM-verify-instafill-form-completion-and-data). *By [@Instafill](https://github.com/Instafill)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds **InstaShare** to *Development & Code Tools*.

InstaShare uploads your current Claude Code session to instashare.to and returns a public, shareable link in one shell call — no account required (anonymous-first; claim to a Google account later). Re-running updates the same link.

**Safe to share:** a built-in secret-redaction classifier scrubs API keys (Anthropic/OpenAI/AWS/GitHub/Slack/Stripe/Google), JWTs, `Authorization`/`Cookie` headers, PEM private keys, and `*_KEY/_TOKEN/_SECRET/_PASSWORD` env assignments before upload, so credentials never leave the machine.

- Repo: https://github.com/Instafill/instashare-skill (Apache-2.0)
- Install: `/plugin marketplace add Instafill/instashare-skill`
- Live example: https://instashare.to/c/YDXusM-verify-instafill-form-completion-and-data

Entry is placed alphabetically and follows the existing bullet format.