### PR TITLE
Add trip-planner (verification-first travel itinerary skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [trip-planner](https://github.com/Eric6286/trip-planner) - 把“网上抄来的攻略”变成查证过的单文件 HTML 行程页：内嵌 Leaflet 地图、携程/飞猪/高德浏览器实价与双信源评论、数据诚信契约（查不到就标注、绝不编造）、移动端适配。支持 Claude Code / Claude.ai。 *By [@Eric6286](https://github.com/Eric6286)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
## What

Adds **[trip-planner](https://github.com/Eric6286/trip-planner)** under **Productivity & Organization**.

It turns "attractions copied off the web" into a **fact-checked, single-file HTML itinerary**:
embedded Leaflet/OSM map, **browser-verified** flight & hotel prices and **dual-source** reviews
(Ctrip / Fliggy / Amap), point-to-point transit timed via Amap, a per-day budget, and a
localStorage checklist.

Its core differentiator is a **data-integrity contract**: every concrete number is either verified
this session (with a source marker) or written as a hedge — **never fabricated** — enforced by an
11-check static output validator (`scripts/check_html.py`).

## Quick-contribution checklist
- **Real use case** ✅ — planning real trips; the example output is a real run.
- **No duplicate** ✅ — there was no travel / trip / itinerary skill in the list.
- **Structure** ✅ — SKILL.md + references + scripts + evals + LICENSE (MIT).
- **Tested** ✅ — Claude Code; with/without-skill benchmark + 5 live test rounds in the repo.
- **Clear docs** ✅ — README with demo GIF, triggers, safety boundary, comparison.