### PR TITLE
Add gpt-image2-ppt-skills to Document Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Document Processing
 
 - [docx](https://github.com/anthropics/skills/tree/main/skills/docx) - Create, edit, analyze Word docs with tracked changes, comments, formatting.
+- [gpt-image2-ppt-skills](https://github.com/JuneYaooo/gpt-image2-ppt-skills) - Generates PPT slides via OpenAI `gpt-image-2` with 10 styles and template-clone mode for user-supplied `.pptx` files. *By [@JuneYaooo](https://github.com/JuneYaooo)*
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
-- [gpt-image2-ppt-skills](https://github.com/JuneYaooo/gpt-image2-ppt-skills) - Generates PPT slides via OpenAI `gpt-image-2` with 10 styles and template-clone mode for user-supplied `.pptx` files. *By [@JuneYaooo](https://github.com/JuneYaooo)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
+- [gpt-image2-ppt-skills](https://github.com/JuneYaooo/gpt-image2-ppt-skills) - Generates PPT slides via OpenAI `gpt-image-2` with 10 styles and template-clone mode for user-supplied `.pptx` files. *By [@JuneYaooo](https://github.com/JuneYaooo)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 


### PR DESCRIPTION
## Summary
- Add gpt-image2-ppt-skills to the Document Processing section
- Attribute the skill to @JuneYaooo using the existing README format

## Use case
This skill helps users generate presentation decks with OpenAI gpt-image-2, including curated visual styles and a template-clone mode for user-supplied .pptx files.

## Attribution
Source repository: https://github.com/JuneYaooo/gpt-image2-ppt-skills

Closes #724