### PR TITLE
Add Outbound Pipeline skill to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Outbound Pipeline](https://github.com/SRKrukowski/outbound-pipeline-playbook) - Turns an ICP definition into personalized, research-backed cold-email drafts staged in Gmail for human review. Runs Exa research, Apollo enrichment, and Claude drafting from a single command, with a free dry-run and no auto-send. *By [@SRKrukowski](https://github.com/SRKrukowski)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds **Outbound Pipeline** to the Business & Marketing section.

**What it is:** an open-source Claude Code skill + install playbook that turns an ICP definition into personalized, research-backed cold-email drafts staged in Gmail for human review. One command runs Exa research, Apollo enrichment, and Claude drafting, with a free dry-run and no auto-send.

**Why it fits the guidelines:**
- Real use case, not hypothetical (built for and used in actual outbound work).
- Well-documented: a step-by-step `playbook.md` walkthrough, a `SKILL.md`, and example output in the README.
- Usable on free tiers (Exa free tier + Apollo free credits + dry-run mode), so it is not gated behind a paid subscription.
- Safe by design: drafts only, nothing sends without a human clicking Send.

Repo: https://github.com/SRKrukowski/outbound-pipeline-playbook