### PR TITLE
Add AccInt Solve skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [AccInt Solve](https://github.com/maxbaluev/accreted-intelligence/tree/main/plugins/claude/skills/solve) - Routes coding agents through AccInt's MCP-backed memory loop: retrieve prior work, open solve commitments, resolve continuation frames, and record outcome feedback. *By [@maxbaluev](https://github.com/maxbaluev)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
## What changed

Adds AccInt Solve to the Development & Code Tools section as an external Claude skill entry.

## Why

AccInt is a local-first MCP memory server and agent workflow layer for coding agents. The Solve skill gives Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and similar runtimes a concrete workflow for retrieving prior outcomes, opening solve commitments, resolving continuation frames, and recording verified feedback after tests, PR review, deployment, or other reality signals.

## Real-world use case

Teams running long-lived coding-agent work can keep agent decisions tied to prior repository history and close the loop when a fix, PR, or deployment succeeds or fails.

## Validation

- `git diff --check`
- Local replay of the repository README-only PR label workflow passed
- AccInt Solve link returns HTTP 200
