### PR TITLE
Add Equity Comp Tax (OptionsAhoy) skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [Equity Comp Tax (OptionsAhoy)](https://github.com/AlvisoOculus/optionsahoy-mcp/tree/main/integrations/agent-kits/claude-skill/equity-comp-tax) - Routes US equity-compensation tax questions (ISO/AMT exercise timing, NSO, RSU sell-vs-hold, QSBS eligibility, single-stock concentration, protective puts, and funding a cash goal from equity) to a free, keyless MCP server and REST API covering the full federal tax code plus all 50 states and DC. *By [@AlvisoOculus](https://github.com/AlvisoOculus)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
## What it does

Teaches Claude to handle US equity-compensation tax questions: ISO exercise timing under the alternative minimum tax (AMT), non-qualified stock options (NSOs), restricted stock unit (RSU) sell-vs-hold, qualified small business stock (QSBS) eligibility, single-stock concentration, protective puts, and funding a cash goal from equity. When a user asks one of these, the skill routes the question to a free, keyless MCP server and REST API that computes against the full federal tax code plus all 50 states and DC, and returns an optimal after-tax schedule.

## Who uses it

Employees and advisors at startups and public tech companies making real exercise and sell decisions, where the multi-year, multi-state AMT math is easy to get wrong by hand or in-context.

## Why it is substantive, not promotional

- Free and keyless: the MCP server and REST API need no signup, no API key, and no paid tier to return answers.
- It targets a measured failure mode. A reproducible benchmark shows five leading LLMs all overshoot the optimal after-tax outcome by 2-20x doing ISO/AMT timing math unaided: https://github.com/AlvisoOculus/llm-iso-benchmark
- The numbers are independently verifiable. Every constant is checked against IRS publications, and calculations reproduce to the cent against two independent open-source tax engines (PSL Tax-Calculator and OpenTaxSolver): https://optionsahoy.com/verification

## Entry

One bullet added to README.md under Productivity & Organization, linking to the SKILL.md folder. Only README.md changes; the bullet links to an external https URL and is placed in alphabetical order within the category.
