### PR TITLE
Add Novu Connect skill (Communication & Writing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [Novu Connect](https://github.com/iampearceman/novu-connect-skill) - Connect a customer-facing AI agent to the messaging channels users already use (Slack, Email, Telegram, WhatsApp, MS Teams) with Novu Connect (`npx novu connect`). *By [@iampearceman](https://github.com/iampearceman)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 
 ### Creative & Media


### PR DESCRIPTION
Adding the **Novu Connect** skill to Communication & Writing (placed alphabetically).

It teaches Claude to connect a customer-facing AI agent to the messaging channels users already use (Slack, Email, Telegram, WhatsApp, MS Teams) with Novu Connect, via `npx novu connect`. Real, documented use case grounded in Novu's published agent onboarding (https://novu.co/agents.md).

Skill repo: https://github.com/iampearceman/novu-connect-skill