### PR TITLE
Add AgentCall skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,13 +201,13 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Collaboration & Project Management
 
+- [AgentCall](https://github.com/pattern-ai-labs/agentcall) - Let AI agents join Google Meet, Zoom, and Teams calls via voice — TTS, live transcripts, screenshare, and avatar. *By [@pattern-ai-labs](https://github.com/pattern-ai-labs)*
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [mercury-mcp](https://www.teamoffsite.ai/proton/docs/skill) - Cheatsheet for the Mercury (Proton) MCP tools. Message agent teammates, manage threads, create tasks, and schedule automations across coordinated agent teams. *By [Mercury](https://mercury.build)*
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
-- [AgentCall](https://github.com/pattern-ai-labs/agentcall) - Let AI agents join Google Meet, Zoom, and Teams calls via voice — TTS, live transcripts, screenshare, and avatar. *By [@pattern-ai-labs](https://github.com/pattern-ai-labs)*
 
 ### Security & Systems
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
+- [AgentCall](https://github.com/pattern-ai-labs/agentcall) - Let AI agents join Google Meet, Zoom, and Teams calls via voice — TTS, live transcripts, screenshare, and avatar. *By [@pattern-ai-labs](https://github.com/pattern-ai-labs)*
 
 ### Security & Systems
 


### PR DESCRIPTION
AgentCall lets any AI agent join Google Meet, Zoom, and Microsoft Teams — speaking, listening, and collaborating like a real teammate

What it solves: Lets an AI coding agent join a live video meeting (Google Meet, Teams, Zoom) as a participant — speaking via TTS, reading live transcripts, sharing its screen, and showing an avatar. unlocks a new level of collaborative experience in ai agent enhanced meetings.

Who uses it: Developers on Claude Code, Cursor, Codex, Gemini CLI, etc. who want their agent to attend a call, take notes, present, or answer when addressed.

Example: "Join this Google Meet and fix this bug" → the agent joins the call via AgentCall and participates.

Attribution: Original open-source skill by Pattern AI Labs (agentcall.dev).