### PR TITLE
Add frontend-design-research-zh to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
+- [frontend-design-research-zh](https://github.com/0505ttt/frontend-design-research-zh) - 中文母语前端设计调研方法论 Skill — 反 AI 味陷阱（Tailwind 紫色根因）+ 三文档输出 + v0/bolt/lovable 协作 + 中文 AI 生图生态（即梦/通义万相/可灵/豆包 + Codex 工程化）。支持 Claude Code / Cursor / Codex / ChatGPT。 *By [@0505ttt](https://github.com/0505ttt)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
 
 ### Productivity & Organization


### PR DESCRIPTION
## What skill are you adding?

**[frontend-design-research-zh](https://github.com/0505ttt/frontend-design-research-zh)** — 中文母语前端设计调研方法论 Claude Code Skill

### Core features
- 反 AI 味陷阱（5 大陷阱 + Tailwind indigo-500 紫色根因）
- 三文档输出（design_research + image_prompts + implementation_plan）
- v0/bolt/lovable 协作模板 + 多轮调教
- 中文 AI 生图生态（即梦/通义万相/可灵/豆包 + Codex 工程化）
- 反馈分类精确迭代（8 类策略）
- 支持 Claude Code / Cursor / Codex / ChatGPT

### Placement
Added to **Creative & Media** section (alongside similar skills like `swiftui-design-skill`).

### Why here
- 中文社区缺少结构化前端设计方法论 skill
- 反 AI 味是 2025-2026 设计热点
- 与英文 `anydesign` / `swiftui-design-skill` 互补（中文方法论 + 中文 AI 工具生态）

### Checklist
- [x] Public on GitHub
- [x] MIT licensed
- [x] Follows existing list format with By attribution