### PR TITLE
Add session-teacher skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
+- [session-teacher](https://github.com/apxxrv/session-teacher) - Rigorous tutor that teaches incrementally, quizzes you, and won't end until you've demonstrated understanding. Based on a teaching prompt from the Anthropic team. *By [@apxxrv](https://github.com/apxxrv)*
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 


### PR DESCRIPTION
Adds [session-teacher](https://github.com/apxxrv/session-teacher) to the Productivity & Organization section.

A Claude skill that tutors you until you actually understand the work — incremental teaching, running checklist, quizzing, no nodding-along allowed. Based on a teaching prompt from the Anthropic team (shared by @trq212).