### PR TITLE
Add app-it under Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [app-it](https://github.com/Christian-Katzmann/app-it) - Turns a local web project into an installed, Dock-launchable macOS desktop app with a native WebKit window, app icon, and clean start/stop lifecycle — no Electron, Tauri, or rewrite. Windows support is in beta. *By [@Christian-Katzmann](https://github.com/Christian-Katzmann)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds **app-it** to Development & Code Tools.

app-it is a Claude Code / Codex skill that turns a local web project into an installed, Dock-launchable macOS desktop app — native WebKit window, real app icon, and a clean start/stop lifecycle — without Electron, Tauri, or a rewrite. It's local-only (no network calls, no telemetry), additive, and reversible, and writes a report of every change it makes. macOS is stable; Windows is in beta. MIT licensed.

Repo: https://github.com/Christian-Katzmann/app-it