### PR TITLE
Add corpspeak skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
+- [corpspeak](https://github.com/giorgiozamboni/corpspeak) - The anti-humanizer: rewrites any text into corporate/C-suite register without sounding AI-generated. Bilingual EN/IT, three intensity levels (light, medium, extreme). *By [@giorgiozamboni](https://github.com/giorgiozamboni)*
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*


### PR DESCRIPTION
Adds **corpspeak** to the Communication & Writing category.

### What it does
Rewrites any text into corporate / C-suite / business register while keeping it credible and NOT sounding AI-generated. It is the inverse of a humanizer: instead of stripping jargon it adds it on purpose, then runs a built-in anti-AI filter (removing em dashes, forced rule-of-three, significance inflation, motivational closers) so the result reads like a real manager wrote it, not a bot imitating one.

### Problem it solves
"Make this sound corporate" prompts usually produce text that smells like AI. corpspeak keeps the requested business jargon but removes the structural tells that give AI away.

### Who uses this workflow
Anyone polishing emails, slide decks, or LinkedIn posts. Three intensity levels (light / medium / extreme) cover everything from serious work documents to deliberate buzzword bingo. It is also genuinely bilingual, with specific tuning for Italian corporate "aziendalese" / itanglese, which most tools ignore.

### Example
Input: "we tried the new tool but it didn't really help the team work faster, so we should probably stop using it"

Output (medium): "Following the pilot, the new tool did not move the needle on team throughput. The recommendation is to discontinue adoption and reallocate the bandwidth to higher-impact solutions."

### Details
- Repo: https://github.com/giorgiozamboni/corpspeak (MIT)
- SKILL.md with YAML frontmatter, reference lexicons (IT/EN) and an anti-AI gate
- Tested with the Claude Code skill-creator benchmark

By [@giorgiozamboni](https://github.com/giorgiozamboni) (PlayMind Studio).
