### PR TITLE
Add okf to Document Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
+- [okf](https://github.com/mattjoyce/okf-skill) - Authors and validates Open Knowledge Format (OKF) bundles — vendor-neutral knowledge as a directory of markdown files with YAML frontmatter. *By [@mattjoyce](https://github.com/mattjoyce)*
 
 ### Development & Code Tools
 


### PR DESCRIPTION
Adds **okf** to the Document Processing category.

- **Repo:** https://github.com/mattjoyce/okf-skill
- **What it does:** Authors and validates Open Knowledge Format (OKF) bundles — vendor-neutral knowledge represented as a directory of markdown files with YAML frontmatter (no schema registry, no SDK required).
- **Real use case:** Building a knowledge bundle/catalog as markdown, authoring concept documents, and checking OKF conformance. Documented (README + SKILL.md), open source (Apache-2.0).