### PR TITLE
Add NotFair (SEO, Google Ads & Meta Ads skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to audit traffic, find wasted spend, detect creative fatigue, and ship fixes directly to your codebase. *By [@nowork-studio](https://github.com/nowork-studio)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great resource.

I'd like to add **NotFair** ([nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)) under **Business & Marketing**.

NotFair is a set of open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. It connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Skills cover site analysis, keyword research, meta tag rewrites, schema markup, Google Ads audits and bid management, and Meta Ads performance analysis (ROAS, creative fatigue, audience overlap). It has around ~2.9k GitHub stars and an MIT license.

It fits squarely in Business & Marketing alongside Competitive Ads Extractor and Lead Research Assistant — it's focused on the same paid-ads and SEO workflows this section covers, but with live MCP-backed data access rather than static analysis.

Happy to reword the description, move it to a different spot, or trim anything that doesn't fit your style. Thanks for your time!