### PR TITLE
Add Victory Methodology skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [Victory Methodology](https://github.com/rxdage/The-teacher) - A facts-first method that turns any messy real-world problem (work, money, family, a stuck life decision) into a concrete plan, with quick-decision, full battle-plan, setback-recovery, and postmortem modes. Bilingual English/中文. *By [@rxdage](https://github.com/rxdage)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adds **Victory Methodology** — a practical, de-ideologized decision-making method, packaged as a Claude Skill.

Most "decision" tools are written for founders and executives. This one isn't. It's for the worker who just got laid off, the small-shop owner watching the numbers go red, the family digging out of debt, the student with no direction, the parent lying awake over a child's schooling — and yes, the CTO planning a roadmap too. The same underlying method serves all of them, because it rests on one plain idea: **the people closest to a problem understand it best.** So the method belongs to ordinary people, and the language is kept plain on purpose — no jargon, no slogans, nothing you need an MBA to follow.

What it actually does: instead of pep talks, it runs a calm, facts-first sequence — separate what you *know* from what you're only assuming, find the one bottleneck that decides things right now, build a small base you can actually hold, put your strength on a single front, and stage the rest so you don't burn out. It has a setback-recovery mode that puts a person's safety before any strategy when they're in crisis, and a values mode that refuses to "compute" an answer to a question that was never a math problem.

It's bilingual (English + 中文), licensed CC BY-SA 4.0 so it stays an open commons no one can fence off, and it's built to get better through real use: anyone can bring back a real case — including the ones where it failed — and improve it for the next person facing the same hard night. Eval-tested and converged over a 6-case set; works on Claude.ai, Claude Code, and the API.

Not a product handed down from above — a tool ordinary people can pick up, use, and pass on.

Repo: https://github.com/rxdage/The-teacher

*By [@rxdage](https://github.com/rxdage)*
