### PR TITLE
Add agent-historian skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [agent-historian](https://github.com/adlternative/agent-historian) - Lets coding agents search and re-read their own past sessions (OpenCode, Claude Code, and more) before doing fresh research. Read-only, no memory layer, index, or network. *By [@adlternative](https://github.com/adlternative)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds **agent-historian** to *Development & Code Tools* (alphabetical order).

[agent-historian](https://github.com/adlternative/agent-historian) is a read-only CLI (`ochist`) plus an Agent Skill that lets coding agents search and re-read their own past conversation history (OpenCode, Claude Code, and other locally detected agents) before redoing research.

- Reads transcripts the agents already persist locally — no memory layer, embeddings, index, daemon, or network calls.
- Project- or global-scoped search; subagent-aware; zero runtime dependencies (Node's built-in `node:sqlite`).
- Ships a SKILL.md so the agent checks history first.

Checked: real use case, no duplicate, alphabetical placement, existing format (no emojis, consistent punctuation).