### PR TITLE
Add vibe-creating-skill to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
+- [vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill) - Rewrites a rough idea into a model-ready text-to-video prompt using ByteDance's "Vibe Creating" paradigm (Seedance 2.0): describe the story, let the model handle the cinematography. Works with Seedance, Sora, Kling, Veo and more. Bilingual EN/中文. *By [@Alisa0808](https://github.com/Alisa0808)*
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*


### PR DESCRIPTION
## What is this?

[vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill) is an open-source, bilingual (EN/中文) Claude Skill (single `SKILL.md`, open standard) that implements ByteDance's "Vibe Creating" prompt paradigm — introduced alongside the Seedance 2.0 video model. Instead of over-specifying focal lengths, fps, and shot numbers, you describe the story/scene in plain language and let the model handle the cinematography. The skill is judgment-first: it decides whether your input even suits this style before rewriting, so it never flattens a shot list you actually wanted.

## Why it fits Creative & Media

The category already lists image/video generation skills (imagen, Video Downloader, Pixelbin-Media-Generation, etc.). This adds the text-to-video *prompting* layer — turning rough ideas into model-ready prompts for Seedance, Sora, Kling, Veo and more.

- Solves a real problem (prompting modern T2V models)
- Well-documented, bilingual EN/中文
- Portable: runs in Claude Code, Claude.ai, Codex, OpenClaw, Hermes via the `SKILL.md` standard
- Open source (MIT), public repo

I added one line to the Creative & Media section in alphabetical order, following the existing `[name](url) - description *By [@author]*` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)