### PR TITLE
Add pm-claude-skills — 205 eval-scored professional Agent Skills across 21 professions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- - [pm-claude-skills](https://github.com/mohitagw15856/pm-claude-skills) — 205 professional Agent Skills (PRDs, sprint plans, exec updates, contracts, pitch decks, health scorecards, GTM plans...) across 21 professions, 28 bundles. Run free in the browser with your own Claude/OpenAI/Gemini/Ollama key, install via `npx`, `pip install pm-skills`, local or hosted MCP, or the Claude Code marketplace. 196 of 205 skills eval-scored by an LLM judge — avg 4.8/5, with a public leaderboard. Includes Workflow Recipes that chain skills end-to-end (`/ship-a-feature`, `/close-the-quarter`, `/rescue-an-account`), Skill Memory for personalised output, and a Workflow Canvas. *By [@mohitagw15856](https://github.com/mohitagw15856)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adding pm-claude-skills to the Business & Marketing section as a multi-profession skill library. 205 professional SKILL.md files across 21 professions, 28 bundles, covering PM, engineering, customer success, legal, finance, HR, sales, design, social media, and more. Placed near Brand Build Skills as the most similar structural entry (multi-skill library vs single skill). MIT licensed, 1,000+ stars, 183 forks. Live Playground at mohitagw15856.github.io/pm-claude-skills. 196 of 205 skills independently eval-scored at avg 4.8/5.