### PR TITLE
Add a-share-skill skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [a-share-skill](https://github.com/shouldnotappearcalm/a-share-skill) - China A-share stock data, technical indicators, events, and paper trading for AI agents. *By [@shouldnotappearcalm](https://github.com/shouldnotappearcalm)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
Adds **a-share-skill** to the **Data & Analysis** category.

**What problem it solves:** Lets an AI agent (Claude Code, Cursor, Codex, Qoder) work with the China A-share market — query real-time quotes, historical K-line, technical indicators, events and industry data, and run a paper-trading account (create accounts, place/cancel simulated orders, track positions and P&L, simple backtests).

**Who uses this workflow:** Chinese A-share retail investors and quant developers who want to do stock analysis and paper trading directly through an AI agent instead of writing scripts.

**Real usage:** Public project with 160+ stars and 26 forks, MIT licensed, two core skills (`a-share-data`, `a-share-paper-trading`) plus several strategy skills, each with a `SKILL.md` and install docs for multiple agent platforms.

**Link:** https://github.com/shouldnotappearcalm/a-share-skill

Entry follows the existing format and is placed alphabetically within the section.