### PR TITLE
Add Crawlora skill to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [Crawlora](https://github.com/Crawlora-org/crawlora-skills) - Structured public web data (search/SERP, marketplaces, social, finance, app stores, media) as clean JSON via the Crawlora REST API; includes job-recipe skills for price research, SERP keyword research, YouTube research, and app-review mining. *By [@Crawlora-org](https://github.com/Crawlora-org)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds **Crawlora** under **Data & Analysis**.

Crawlora is a hosted web-data API that returns clean JSON for public data across search/SERP, marketplaces, social, finance, app stores and media. The repo ships outcome-oriented Agent Skills (job recipes) rather than a single generic call — `product-price-research`, `serp-keyword-research`, `youtube-research`, `app-review-mining`, plus an umbrella catalog skill.

- Repo (MIT): https://github.com/Crawlora-org/crawlora-skills
- Install: `npx skills add github.com/Crawlora-org/crawlora-skills --skill <name>` or `/plugin marketplace add Crawlora-org/crawlora-skills`

One bullet added under Data & Analysis, following the existing entry format.