### PR TITLE
Add motion-skills to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [motion-skills](https://github.com/iart-ai/motion-skills) - 50 motion-graphics, animation, and video skills across 14 installable packs covering kinetic typography, data-viz, explainers, TikTok/Reels, web animation, WebGL, and Manim, each with a deliver-and-verify loop. *By [@iart-ai](https://github.com/iart-ai)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
Adds **[motion-skills](https://github.com/iart-ai/motion-skills)** to *Creative & Media* — an open-source collection of **50 motion-graphics, animation, and video skills** across 14 installable packs (kinetic typography, data-viz, explainers, TikTok/Reels, web animation, WebGL, Manim).

- External-repo entry, placed **alphabetically**, **no emojis**, with `*By*` attribution — per CONTRIBUTING.
- Each pack installs via `npx skills add iart-ai/<pack>` or `/plugin marketplace add iart-ai/<pack>`, uses the canonical `skills/<name>/SKILL.md` layout, and ships a deliver-and-verify loop.

Thanks for maintaining this list!