### PR TITLE
Add Motion Graphics Skills to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,13 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Motion Graphics Skills](https://github.com/iart-ai/motion-skills) - 50 skills across 14 installable packs that teach agents to make motion graphics, animation & video — kinetic typography, data-driven charts, explainers, TikTok/Reels, 3D WebGL, and Manim math animation, each with a render→screenshot→self-check loop. *By [@iart-ai](https://github.com/iart-ai)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
-- [Motion Graphics Skills](https://github.com/iart-ai/motion-skills) - 50 skills across 14 installable packs that teach agents to make motion graphics, animation & video — kinetic typography, data-driven charts, explainers, TikTok/Reels, 3D WebGL, and Manim math animation, each with a render→screenshot→self-check loop. *By [@iart-ai](https://github.com/iart-ai)*
 
 ### Productivity & Organization
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [Motion Graphics Skills](https://github.com/iart-ai/motion-skills) - 50 skills across 14 installable packs that teach agents to make motion graphics, animation & video — kinetic typography, data-driven charts, explainers, TikTok/Reels, 3D WebGL, and Manim math animation, each with a render→screenshot→self-check loop. *By [@iart-ai](https://github.com/iart-ai)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds [motion-skills](https://github.com/iart-ai/motion-skills) to **Creative & Media**.

- 50 open-source skills across 14 installable packs
- Covers kinetic typography, data-viz charts, explainers, TikTok/Reels, 3D WebGL, and Manim math animation
- Each skill ships a render → screenshot → self-check loop (video via Remotion/Manim, web via standalone HTML)
- Built on Anthropic's open Skill format — works with Claude Code, Cursor, Codex, and 40+ agents
- MIT licensed