### PR TITLE
Add One Person Company OS skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Business & Marketing
 
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
+- [One Person Company OS](https://github.com/living-hi/one-person-company-os) - Visual operating cockpit for AI-native solo founders across promise, buyer, product, delivery, cash, learning, and assets. *By [-hi](https://github.com/living-hi)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.


### PR DESCRIPTION
Adds One Person Company OS, a visual operating cockpit skill for AI-native solo founders.

Repository: https://github.com/living-hi/one-person-company-os
ClawHub install: `clawhub install one-person-company-os`