### PR TITLE
Add weco-skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [weco-skill](https://github.com/WecoAI/weco-skill) - The Claude Code / Cursor packaging of the `weco` CLI: runs an automated experiment loop on your code, proposing and keeping only edits that measurably improve a target metric like latency, accuracy, or cost.
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds [weco-skill](https://github.com/WecoAI/weco-skill) under Development & Code Tools — the Claude Code / Cursor packaging of the open-source `weco` CLI, which runs an automated optimize-evaluate loop on your code (propose a change, evaluate against a metric, keep or revert). Single-sentence entry, placed alphabetically. Thanks!