### PR TITLE
Add anti-slop skill to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Communication & Writing
 
+- [anti-slop](https://github.com/DavidMusijenko/anti-slop) - Strips AI-speak and corporate filler ("leverage", "seamlessly", "cutting-edge", "unlock your potential") from any text before it goes out. Returns the cleaned version only — no commentary.
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.


### PR DESCRIPTION
## New skill: anti-slop

**What it does:** Strips AI-speak and corporate filler from any text before it goes out. Returns only the cleaned version — no commentary, no list of changes, just the text.

**Removes:** "leverage", "seamlessly", "cutting-edge", "empower", "unlock", "revolutionize", "game-changing", "in today's fast-paced landscape", "it's important to note", and similar filler.

**Example:**

Input (61 words):
> "We leverage cutting-edge artificial intelligence to seamlessly empower solopreneurs to unlock their full potential and revolutionize the way they approach business in today's fast-paced landscape."

Output (19 words):
> "We use AI to help solopreneurs run their businesses faster."

**Repo:** https://github.com/DavidMusijenko/anti-slop  
**Install:** `curl -o ~/.claude/skills/anti-slop.md https://raw.githubusercontent.com/DavidMusijenko/anti-slop/main/anti-slop.md`  
**License:** MIT