### PR TITLE
Add Fiverr Gig Optimizer (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [Fiverr Gig Optimizer](https://github.com/Ahad690/fiverr-gig-optimizer) - Builds a research-backed Fiverr gig catalog (titles, tags, 3-tier pricing, descriptions, launch plan) with every competition and pricing number computed deterministically in Python — no guessed figures. Free sample data, opt-in live research, and a community dataset. *By [@Ahad690](https://github.com/Ahad690)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
Adds **Fiverr Gig Optimizer** under **Business & Marketing**.

- Repo: https://github.com/Ahad690/fiverr-gig-optimizer (MIT, public)
- A Claude Code skill that turns a freelancer's services into a research-backed Fiverr gig catalog — titles, tags, 3-tier pricing, descriptions, and a phased launch plan.
- Distinctive angle: **every competition/demand/pricing number is computed by deterministic Python scripts, never guessed by the model.** Works free out of the box (bundled sample data), with opt-in live research and a community dataset.

Real use case, no duplicate found, entry placed alphabetically in the existing section.