### PR TITLE
Add remote-server skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
+- [remote-server](https://github.com/kengerlwl/remote-server-skill) - SSH-based remote toolkit CLI that wraps Claude Code-style primitives (bash/read/write/edit/ls/grep/glob/download/upload) to operate remote servers over SSH with predictable, escaping-safe behavior. *By [@kengerlwl](https://github.com/kengerlwl)*
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 
 ### Assistive Technology


### PR DESCRIPTION
## What it is

`remote-server` is an SSH-based remote toolkit CLI that wraps Claude Code-style primitive tools — bash, read, write, edit, ls, grep, glob, download, upload — and executes them over SSH on a remote server.

## What problem it solves

Driving a remote server by having an agent hand-write `ssh host "..."` is fragile: quoting/encoding hell, no line-numbered reads, no atomic edits, no structured output. This skill transfers every payload via base64 (no escaping issues) and reproduces Claude Code's tool contracts (unique-match edit, ripgrep-style grep with content/files/count modes, mtime-sorted glob, background bash with log tailing).

## Who uses it

Anyone driving remote servers from an AI coding agent (Claude Code / Codex / Cursor / Gemini CLI), or as a standalone CLI. Multi-target config supports direct host/user/port, `~/.ssh/config` aliases, and Windows (PowerShell) targets.

## Details

- Repo: https://github.com/kengerlwl/remote-server-skill
- Zero dependencies (pure Node.js + system `ssh`/`scp`), MIT licensed.
- Tested across real Linux servers.
- Category: Security & Systems (added in alphabetical order).
