### PR TITLE
Add fluid skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [fluid](https://github.com/Darcos-Loft/fluid) - A suite of 6 agent skills that gives an AI a committed brand identity, a house motion language, and a deterministic 23 rule slop detector that runs with no API call. *By [@Darcos-Loft](https://github.com/Darcos-Loft)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
-- [fluid](https://github.com/Darcos-Loft/fluid) - A suite of 6 agent skills that gives an AI a committed brand identity, a house motion language, and a deterministic 23 rule slop detector that runs with no API call. *By [@Darcos-Loft](https://github.com/Darcos-Loft)*
+- [fluid](https://github.com/Darcos-Loft/fluid) - A suite of 6 agent skills that gives an AI a committed brand identity, a house motion language, and a deterministic 25 rule slop detector that runs with no API call. *By [@Darcos-Loft](https://github.com/Darcos-Loft)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
Adds fluid to Creative & Media, in alphabetical order.

fluid is an open-source (MIT) suite of 6 agent skills that pushes AI frontends away from the generic default look. It gives an agent a committed brand identity, a house motion language, and a deterministic slop detector that runs with no API call, so it can gate CI. Works with any agent via plain SKILL.md files and pure CSS tokens.

Repo: https://github.com/Darcos-Loft/fluid