### PR TITLE
Add pentest-report-skill to Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [pentest-report-skill](https://github.com/KonstiJo/pentest-report-skill) - Compiles pentest findings into audit-ready reports (DE/EN) with compliance checks for BSI, OWASP, PCI-DSS, DiGA, and OSCP; ingests nmap/Burp/Nuclei/Nessus/BloodHound/Trivy output and renders Markdown, PDF, and SysReptor JSON. *By [@KonstiJo](https://github.com/KonstiJo)*
 
 ### Assistive Technology
 


### PR DESCRIPTION
Adds `pentest-report-skill` to the Security & Systems section.

A standards-compliance layer for pentest reports: takes findings or raw scanner output (nmap, Burp, Nuclei, Nessus, BloodHound, Trivy) and produces an audit-ready report in German or English, validated against a chosen standard (BSI, OWASP WSTG/ASVS, PTES, NIST 800-115, PCI-DSS v4, DiGA/BfArM, OSCP). Renders Markdown, PDF, and SysReptor import JSON. MIT-licensed.

Repo: https://github.com/KonstiJo/pentest-report-skill