### PR TITLE
Add auto-skill-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Development & Code Tools
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
+- [auto-skill-manager](https://github.com/VovikP/auto-skill-manager) - Auto-discovers, installs, and activates the right skills for any task across Claude Code & Cowork. Cross-platform, zero manual steps. *By [@VovikP](https://github.com/VovikP)*
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## Adds `auto-skill-manager`

A meta-skill that auto-discovers, installs, and activates the right skills for any task — **zero manual steps**.

- Works in **Claude Code** and **Claude.ai / Cowork**
- **Cross-platform**: Windows, macOS, Linux (ships a recursive, OS-aware skill scanner)
- MIT licensed, includes README + .skill bundle

Repo: https://github.com/VovikP/auto-skill-manager

Thanks for maintaining this list!