### PR TITLE
Add Store-in-a-Box skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Store-in-a-Box](https://github.com/comil27/store-in-a-box) - Deploy a live, paid digital-product store from the terminal: Stripe checkout + Cloudflare Worker, instant auto-delivery, no dashboard. *By [@comil27](https://github.com/comil27)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds **[store-in-a-box](https://github.com/comil27/store-in-a-box)** to the list.

A Claude Code skill that deploys a live, paid digital-product store entirely from the terminal — Stripe checkout + a Cloudflare Worker, instant file auto-delivery, no dashboard clicking. Free and open-source, with a `SKILL.md`, and tested end-to-end in Claude Code.

Dropped into the most relevant existing category, single-line addition.