### PR TITLE
Add whoami skill (Development & Code Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [whoami](https://github.com/luckeyfaraday/whoami) - Scans the developer's machine and interviews them to build a portable profile, giving any AI coding agent instant context about who the user is and what they work on. Runs locally, redacts secrets, and outputs a single Markdown profile. *By [@luckeyfaraday](https://github.com/luckeyfaraday)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds **whoami** to *Development & Code Tools*.

[whoami](https://github.com/luckeyfaraday/whoami) is an open-source Claude Code skill that scans a developer's machine and interviews them to build a portable profile, so any AI coding agent can load instant context about who the user is and what they work on instead of starting cold.

- Runs entirely locally with zero network calls; redacts secrets and never prints personal-document contents.
- Reads AI-agent session history across Claude Code, Codex, Droid, OpenCode, Gemini, and Qwen, plus git/toolchain/shell signals.
- Outputs a single Markdown profile (`~/.whoami/profile.md`) usable by any LLM agent.
- MIT licensed.

Entry added alphabetically under Development & Code Tools with author attribution.