### PR TITLE
Add Notta MCP skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Notta MCP](https://github.com/mindcruiser/notta-mcp-skill) - Transcribe local audio and video files with Notta, then check status, retrieve transcripts, and search Notta records. *By [@mindcruiser](https://github.com/mindcruiser)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
## What problem it solves

This skill helps Claude use the official Notta MCP integration to transcribe local audio/video files, check transcription status, retrieve transcript results, and search Notta records.

## Who uses this workflow

Users who record meetings, interviews, calls, lectures, webinars, or videos and want Claude to work with Notta transcriptions.

## Attribution

Based on Notta's official MCP integration:
https://github.com/mindcruiser/notta-mcp

Smithery listing:
https://smithery.ai/servers/notta/notta-mcp