### PR TITLE
Add OpenTikZ skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [OpenTikZ](https://github.com/opentikz/opentikz) - Generate and edit TikZ diagrams for academic papers from copyable icons and parametric architecture, pipeline, and flowchart templates, then compile to PDF/SVG. _By [@opentikz](https://github.com/opentikz)_
 
 ### Productivity & Organization
 

--- a/README.md
+++ b/README.md
@@ -180,13 +180,13 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [OpenTikZ](https://github.com/opentikz/opentikz) - Generate and edit TikZ diagrams for academic papers from copyable icons and parametric architecture, pipeline, and flowchart templates, then compile to PDF/SVG. _By [@opentikz](https://github.com/opentikz)_
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
-- [OpenTikZ](https://github.com/opentikz/opentikz) - Generate and edit TikZ diagrams for academic papers from copyable icons and parametric architecture, pipeline, and flowchart templates, then compile to PDF/SVG. _By [@opentikz](https://github.com/opentikz)_
 
 ### Productivity & Organization
 


### PR DESCRIPTION
**Problem solved:** Researchers who write papers in LaTeX often need system/architecture/pipeline/flow diagrams but don't want to hand-write TikZ from scratch.

**Target user:** LaTeX-comfortable researchers who aren't comfortable building TikZ from zero.

**What it is:** OpenTikZ is a repo-wide Claude Code skill + plugin and a CC0 library of TikZ resources. The skill discovers content via a catalog, edits the chosen icon/template via a structured edit-contract, and verifies it compiles. Added as an external community entry (the skill is repo-wide and depends on its bundled library, so it links to the source repo rather than vendoring a standalone SKILL.md).

**Usage example:** "Add a cross-attention layer to the encoder-decoder template and make it blue" → the skill edits the template and recompiles to PDF/SVG.

**Attribution:** By the OpenTikZ project — https://github.com/opentikz/opentikz