### PR TITLE
add remote openclaw to community resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [Remote OpenClaw](https://www.remoteopenclaw.com/skills) - directory of agent skills and mcp servers for OpenClaw, Hermes Agent, Claude Code and Codex, browsable by ecosystem and category
 
 ### Inspiration & Use Cases
 


### PR DESCRIPTION
hey, thanks for putting this list together. added remote openclaw under community resources since it's a directory of claude code, openclaw, hermes and codex skills plus mcp servers that you can browse by ecosystem and category. seemed like a good fit next to the other resources here. feel free to move or reword it.