### PR TITLE
Adds Agentic Design Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 
 ### Development & Code Tools
-
+- [Agentic Design Patterns](https://github.com/albertoclemente/agentic-design-patterns-skills) - A router skill plus 21 pattern skills that route any agent problem to the right design pattern, distilled from Antonio Gulli's *Agentic Design Patterns*. Install with `npx skills add`. *By [@albertoclemente](https://github.com/albertoclemente)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+  
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds Agentic Design Patterns — a router skill plus 21 pattern skills (one per chapter of Antonio Gulli's free, framework-agnostic Agentic Design Patterns) that help select the right agentic pattern for a problem. Original distillation, MIT-licensed, no server or paid service required. Installable via `npx skills add albertoclemente/agentic-design-patterns-skills`. Placed under Development & Code Tools.