### PR TITLE
Add Social Media Publisher skill (Publora)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Publora Social Media Publisher](https://github.com/publora/skills) - Schedule and publish posts to 10 social platforms (X, LinkedIn, Instagram, Threads, TikTok, YouTube, Facebook, Bluesky, Mastodon, Telegram) from one prompt via the Publora MCP server, plus LinkedIn analytics. *By [@publora-team](https://github.com/publora-team)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds a new **Social Media Publisher** skill under Business & Marketing. It lets Claude (or any MCP client) schedule and publish posts across 10 social platforms from a single prompt via the official Publora MCP server, plus pull LinkedIn analytics.

The skill follows the SKILL.md template, and the README entry is added in alphabetical order within the Business & Marketing section. Based on the official [publora/skills](https://github.com/publora/skills) (MIT).