### PR TITLE
Add penthera skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
+- [penthera](https://github.com/danoszz/penthera) - Security scanner for web apps that checks a live URL or repo for TLS, headers, auth, secrets, IDOR/OAuth, and injection issues, mapped to OWASP with SARIF output.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 
 ### Assistive Technology


### PR DESCRIPTION
Adds **penthera** to the Security & Systems section (in alphabetical order).

**Problem it solves:** AI-coded ("vibecoded") web apps frequently ship with avoidable security gaps such as exposed API routes, missing security headers, weak auth, and hardcoded secrets. Penthera scans a live URL or local repo and reports these before launch.

**Who uses this:** Developers shipping AI-assisted apps who want a quick pre-deploy security check from their agent or the CLI.

**What it does:** TLS, security headers, CORS, endpoint and OpenAPI discovery, JWT, auth hardening, IDOR/OAuth, injection probes, and secret scanning. Findings map to OWASP WSTG and export to SARIF for GitHub Security.

**Example:** Ask your agent "scan my app for security issues", or run `penthera https://myapp.com`.

- Repo: https://github.com/danoszz/penthera
- Install: `npx skills add danoszz/penthera`

For authorized, defensive testing only.
