### PR TITLE
Add Riffkit to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [Riffkit](https://github.com/riffkit/skill) - Riff a winning short video into your own: studies a proven TikTok's emotion formula and regenerates it as a new video around your product, character, and language (Claude Code / Codex). Hosted backend — needs a Riffkit account, billed per second of finished video. *By [@riffkit](https://github.com/riffkit)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds **Riffkit** to **Creative & Media** — an agent skill for recreating the *formula* of a winning short video.

**What it does / problem it solves:** Short-form sellers and creators have to keep shipping video. Riffkit takes one proven source (a TikTok link, an uploaded clip, or an analyzed template), studies the emotion formula that drives its retention — the hook, pacing, and beats — and generates a brand-new video around the user's own product, character, and language (English/Spanish). It never re-uploads the source; the output is an original.

**Who it's for:** TikTok Shop & e-commerce sellers, ad buyers, indie founders, faceless-account operators.

**How it's used (from an agent):**
```
Read https://riffkit.ai/SKILL.md and follow the instructions to set up Riffkit.
```
then, in plain language: `riff https://www.tiktok.com/@user/video/123 into a video for my product, in Spanish`

**Skill repo (MIT):** https://github.com/riffkit/skill — open-source integration spec + docs. Rendering runs on Riffkit's hosted backend (account required, billed by the second of finished video), consistent with other hosted skills already listed (e.g. Pixelbin, the Composio app automations).

One item, added to the end of the Creative & Media section in the existing entry format.
