### PR TITLE
add remote openclaw under community resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [Remote OpenClaw](https://www.remoteopenclaw.com/skills) - directory of agent skills and mcp servers for OpenClaw, Hermes Agent, Claude Code and Codex, browsable by ecosystem and category
 
 ### Inspiration & Use Cases
 


### PR DESCRIPTION
hi, thanks for maintaining this list. adding remote openclaw (remoteopenclaw.com) under community resources — it's a directory of agent skills, mcp servers, and plugins for claude code, openclaw, hermes, and codex, searchable by category, so it fits alongside the other discovery resources. cheers