### PR TITLE
Add BankBridge skills to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [BankBridge](https://github.com/bankbridge-money/bankbridge-skills) - 19 read-only personal-finance slash commands wrapping a hosted MCP server (balances, monthly cashflow check, subscriptions audit, recurring detection, tax prep, budget draft, fraud check, portfolio health, and more). Reads from your real bank accounts via Plaid; no financial data cached.
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
Adds **BankBridge** to the Productivity & Organization section.

**What it is:** 19 read-only personal-finance slash commands wrapping a hosted MCP server. Reads your real bank accounts via a secure bank link flow; nothing cached on our side.

**Commands:** \`/balances\`, \`/monthly-check\`, \`/subscriptions\`, \`/portfolio-health\`, \`/budget-draft\`, \`/price-creep\`, \`/year-in-review\`, \`/spending-by\`, \`/compare-months\`, \`/cashflow-trend\`, \`/dividends\`, \`/tax-prep\`, \`/duplicate-check\`, \`/fraud-check\`, \`/monthly-report\`, and more.

**Links:**
- Skills repo: https://github.com/bankbridge-money/bankbridge-skills
- Plugin: https://github.com/bankbridge-money/bankbridge-plugin
- Site: https://bankbridge.money
- Also on the Official MCP Registry as \`money.bankbridge/server\`

Pricing: \$5/month per connected bank, first month free. Happy to revise the entry length or position.
