### PR TITLE
Add Hermes Tweet skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
+- [Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet) - Guides Hermes Agent operators through X/Twitter reads, monitoring, and approval-gated account actions. *By [@Xquik-dev](https://github.com/Xquik-dev)*
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.


### PR DESCRIPTION
## Summary
- Add Hermes Tweet to the Communication & Writing section.
- Keep the listing focused on Hermes Agent X/Twitter reads, monitoring, and approval-gated actions.

## Validation
- Ran `git diff --check`.
- Checked `https://github.com/Xquik-dev/hermes-tweet` and `https://github.com/Xquik-dev`.
- Duplicate check: no Hermes Tweet or Xquik entry found in README, tree, issues, or recent PRs. The existing Twitter Algorithm Optimizer entry is a different local skill.
- License review: GitHub reports no detected license metadata for this target repository.
