### PR TITLE
Add Mamba Labs GTM Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,66 @@
-<h1 align="center">Awesome Claude Skills</h1>
+<h1 align="center">
+  <br>
+  Awesome Agent Skills
+  <br>
+</h1>
 
 <p align="center">
-<a href="https://platform.composio.dev/?utm_source=Github&utm_medium=Youtube&utm_campaign=2025-11&utm_content=AwesomeSkills">
-  <img width="1280" height="640" alt="Composio banner" src="https://github.com/user-attachments/assets/adb3f57a-2706-4329-856f-059a32059d48">
-</a>
-
-
+  <strong>The universal skill repository for AI coding agents.</strong><br>
+  One command. Works everywhere.
 </p>
 
 <p align="center">
   <a href="https://awesome.re">
     <img src="https://awesome.re/badge.svg" alt="Awesome" />
   </a>
-  <a href="https://makeapullrequest.com">
-    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs Welcome" />
-  </a>
+  <img src="https://img.shields.io/badge/skills-50+-blue?style=flat-square" alt="Skills" />
+  <img src="https://img.shields.io/badge/agents-6+-green?style=flat-square" alt="Compatible Agents" />
   <a href="https://www.apache.org/licenses/LICENSE-2.0">
     <img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square" alt="License: Apache-2.0" />
   </a>
+  <img src="https://img.shields.io/npm/v/ai-agent-skills?style=flat-square&color=red" alt="npm" />
 </p>
-<div>
+
 <p align="center">
-  <a href="https://twitter.com/composio">
-    <img src="https://img.shields.io/badge/Follow on X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" />
-  </a>
-  <a href="https://www.linkedin.com/company/composiohq/">
-    <img src="https://img.shields.io/badge/Follow on LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="Follow on LinkedIn" />
-  </a>
-  <a href="https://discord.com/invite/composio">
-    <img src="https://img.shields.io/badge/Join our Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" />
-  </a>
-  </p>
-</div>
+  <a href="https://skillcreator.ai/discover"><strong>Browse Skills</strong></a> ·
+  <a href="https://skillcreator.ai/build"><strong>Create Skills</strong></a> ·
+  <a href="https://agentskills.io"><strong>Specification</strong></a> ·
+  <a href="https://x.com/skillcreatorai"><strong>Follow Updates</strong></a>
+</p>
 
-A curated list of practical Claude Skills for enhancing productivity across Claude.ai, Claude Code, and the Claude API.
+---
 
+## Quick Start
 
-> If you want your skills to take actions across 500+ apps, wire them up with [Composio](https://platform.composio.dev/?utm_source=Github&utm_medium=Youtube&utm_campaign=2025-11&utm_content=AwesomeSkills)
+```bash
+# Install any skill to any agent
+npx ai-agent-skills install frontend-design
+npx ai-agent-skills install pdf --agent cursor
+npx ai-agent-skills install mcp-builder --agent vscode
+```
 
+That's it. The skill installs to the right location for your agent automatically.
+
+## Why This Exists
+
+Every major AI coding agent now supports skills. But they're scattered everywhere.
+
+This repo curates the best in one place. Quality over quantity. All skills follow the [Agent Skills spec](https://agentskills.io).
+
+## Compatible Agents
+
+| Agent | Flag | Install Location |
+|-------|------|------------------|
+| Claude Code | `--agent claude` (default) | `~/.claude/skills/` |
+| VS Code / Copilot | `--agent vscode` | `.github/skills/` |
+| Cursor | `--agent cursor` | `.cursor/skills/` |
+| Amp | `--agent amp` | `~/.amp/skills/` |
+| Goose | `--agent goose` | `~/.config/goose/skills/` |
+| OpenCode | `--agent opencode` | `~/.opencode/skills/` |
+| Portable | `--agent project` | `.skills/` (works with any agent) |
 
 ## Contents
 
-- [What Are Claude Skills?](#what-are-claude-skills)
 - [Skills](#skills)
   - [Document Processing](#document-processing)
   - [Development & Code Tools](#development--code-tools)
@@ -52,252 +71,213 @@ A curated list of practical Claude Skills for enhancing productivity across Clau
   - [Productivity & Organization](#productivity--organization)
   - [Collaboration & Project Management](#collaboration--project-management)
   - [Security & Systems](#security--systems)
-- [Getting Started](#getting-started)
+- [Installation](#installation)
 - [Creating Skills](#creating-skills)
 - [Contributing](#contributing)
 - [Resources](#resources)
-- [License](#license)
-
-## What Are Claude Skills?
-
-Claude Skills are customizable workflows that teach Claude how to perform specific tasks according to your unique requirements. Skills enable Claude to execute tasks in a repeatable, standardized manner across all Claude platforms.
 
 ## Skills
 
 ### Document Processing
 
-- [docx](https://github.com/anthropics/skills/tree/main/document-skills/docx) - Create, edit, analyze Word docs with tracked changes, comments, formatting.
-- [pdf](https://github.com/anthropics/skills/tree/main/document-skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
-- [pptx](https://github.com/anthropics/skills/tree/main/document-skills/pptx) - Read, generate, and adjust slides, layouts, templates.
-- [xlsx](https://github.com/anthropics/skills/tree/main/document-skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
-- [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
+| Skill | Description | Install |
+|-------|-------------|---------|
+| [docx](./document-skills/docx) | Create, edit, analyze Word docs with tracked changes, comments, formatting | `npx ai-agent-skills install docx` |
+| [pdf](./document-skills/pdf) | Extract text, tables, metadata, merge & annotate PDFs | `npx ai-agent-skills install pdf` |
+| [pptx](./document-skills/pptx) | Read, generate, and adjust slides, layouts, templates | `npx ai-agent-skills install pptx` |
+| [xlsx](./document-skills/xlsx) | Spreadsheet manipulation: formulas, charts, data transformations | `npx ai-agent-skills install xlsx` |
+| [Markdown to EPUB](https://github.com/smerchek/claude-epub-skill) | Converts markdown documents into professional EPUB ebook files | External |
 
 ### Development & Code Tools
 
-- [artifacts-builder](https://github.com/anthropics/skills/tree/main/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
-- [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
-- [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
-- [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
-- [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*
-- [FFUF Web Fuzzing](https://github.com/jthack/ffuf_claude_skill) - Integrates the ffuf web fuzzer so Claude can run fuzzing tasks and analyze results for vulnerabilities. *By [@jthack](https://github.com/jthack)*
-- [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.
-- [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) - Enables Claude to interact with iOS Simulator for testing and debugging iOS applications. *By [@conorluddy](https://github.com/conorluddy)*
-- [MCP Builder](./mcp-builder/) - Guides creation of high-quality MCP (Model Context Protocol) servers for integrating external APIs and services with LLMs using Python or TypeScript.
-- [move-code-quality-skill](https://github.com/1NickPappas/move-code-quality-skill) - Analyzes Move language packages against the official Move Book Code Quality Checklist for Move 2024 Edition compliance and best practices.
-- [Playwright Browser Automation](https://github.com/lackeyjb/playwright-skill) - Model-invoked Playwright automation for testing and validating web applications. *By [@lackeyjb](https://github.com/lackeyjb)*
-- [prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering) - Teaches well-known prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
-- [pypict-claude-skill](https://github.com/omkamal/pypict-claude-skill) - Design comprehensive test cases using PICT (Pairwise Independent Combinatorial Testing) for requirements or code, generating optimized test suites with pairwise coverage.
-- [Skill Creator](./skill-creator/) - Provides guidance for creating effective Claude Skills that extend capabilities with specialized knowledge, workflows, and tool integrations.
-- [Skill Seekers](https://github.com/yusufkaraaslan/Skill_Seekers) - Automatically converts any documentation website into a Claude AI skill in minutes. *By [@yusufkaraaslan](https://github.com/yusufkaraaslan)*
-- [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
-- [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
-- [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
-- [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
-- [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+| Skill | Description | Install |
+|-------|-------------|---------|
+| [artifacts-builder](./artifacts-builder) | Create elaborate HTML artifacts using React, Tailwind CSS, shadcn/ui | `npx ai-agent-skills install artifacts-builder` |
+| [mcp-builder](./mcp-builder) | Create MCP servers for integrating external APIs with LLMs | `npx ai-agent-skills install mcp-builder` |
+| [skill-creator](./skill-creator) | Guide for creating effective agent skills | `npx ai-agent-skills install skill-creator` |
+| [webapp-testing](./webapp-testing) | Test web applications using Playwright automation | `npx ai-agent-skills install webapp-testing` |
+| [changelog-generator](./changelog-generator) | Create user-facing changelogs from git commits | `npx ai-agent-skills install changelog-generator` |
+| [frontend-design](https://github.com/skillcreatorai/Ai-Agent-Skills) | Production-grade UI components and styling | `npx ai-agent-skills install frontend-design` |
+| [code-review](https://github.com/skillcreatorai/Ai-Agent-Skills) | Automated PR review patterns | `npx ai-agent-skills install code-review` |
+| [code-refactoring](https://github.com/skillcreatorai/Ai-Agent-Skills) | Systematic code improvement techniques | `npx ai-agent-skills install code-refactoring` |
+| [backend-development](https://github.com/skillcreatorai/Ai-Agent-Skills) | APIs, databases, server architecture | `npx ai-agent-skills install backend-development` |
+| [python-development](https://github.com/skillcreatorai/Ai-Agent-Skills) | Modern Python 3.12+ patterns | `npx ai-agent-skills install python-development` |
+| [javascript-typescript](https://github.com/skillcreatorai/Ai-Agent-Skills) | ES6+, Node, React, TypeScript | `npx ai-agent-skills install javascript-typescript` |
+| [aws-skills](https://github.com/zxkane/aws-skills) | AWS development with CDK best practices | External |
+| [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) | D3 charts and interactive data visualizations | External |
+| [Playwright Automation](https://github.com/lackeyjb/playwright-skill) | Browser automation for testing web apps | External |
+| [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) | Interact with iOS Simulator for testing | External |
 
 ### Data & Analysis
 
-- [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
-- [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+| Skill | Description | Install |
+|-------|-------------|---------|
+| [CSV Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) | Analyze CSV files and generate insights with visualizations | External |
+| [database-design](https://github.com/skillcreatorai/Ai-Agent-Skills) | Schema design and optimization | `npx ai-agent-skills install database-design` |
 
 ### Business & Marketing
 
-- [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
-- [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
-- [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
-- [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
-- [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+| Skill | Description | Install |
+|-------|-------------|---------|
+| [brand-guidelines](./brand-guidelines) | Apply brand colors and typography to artifacts | `npx ai-agent-skills install brand-guidelines` |
+| [competitive-ads-extractor](./competitive-ads-extractor) | Extract and analyze competitors' ads | `npx ai-agent-skills install competitive-ads-extractor` |
+| [domain-name-brainstormer](./domain-name-brainstormer) | Generate domain name ideas and check availability | `npx ai-agent-skills install domain-name-brainstormer` |
+| [internal-comms](./internal-comms) | Write internal communications and status reports | `npx ai-agent-skills install internal-comms` |
+| [lead-research-assistant](./lead-research-assistant) | Identify and qualify high-quality leads | `npx ai-agent-skills install lead-research-assistant` |
+| [job-application](https://github.com/skillcreatorai/Ai-Agent-Skills) | Cover letters and applications using your CV | `npx ai-agent-skills install job-application` |
 
 ### Communication & Writing
 
-- [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
-- [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
-- [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
-- [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
-- [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
-- [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+| Skill | Description | Install |
+|-------|-------------|---------|
+| [content-research-writer](./content-research-writer) | Research and write high-quality content with citations | `npx ai-agent-skills install content-research-writer` |
+| [meeting-insights-analyzer](./meeting-insights-analyzer) | Analyze meeting transcripts for behavioral patterns | `npx ai-agent-skills install meeting-insights-analyzer` |
+| [code-documentation](https://github.com/skillcreatorai/Ai-Agent-Skills) | Generate docs from code | `npx ai-agent-skills install code-documentation` |
 
 ### Creative & Media
 
-- [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
-- [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
-- [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
-- [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
-- [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
-- [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
+| Skill | Description | Install |
+|-------|-------------|---------|
+| [canvas-design](./canvas-design) | Create visual art in PNG and PDF documents | `npx ai-agent-skills install canvas-design` |
+| [image-enhancer](./image-enhancer) | Improve image quality, resolution, sharpness | `npx ai-agent-skills install image-enhancer` |
+| [slack-gif-creator](./slack-gif-creator) | Create animated GIFs optimized for Slack | `npx ai-agent-skills install slack-gif-creator` |
+| [theme-factory](./theme-factory) | Apply professional font and color themes | `npx ai-agent-skills install theme-factory` |
+| [video-downloader](./video-downloader) | Download videos from YouTube and other platforms | `npx ai-agent-skills install video-downloader` |
+| [algorithmic-art](https://github.com/skillcreatorai/Ai-Agent-Skills) | Generative art with p5.js | `npx ai-agent-skills install algorithmic-art` |
 
 ### Productivity & Organization
 
-- [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
-- [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
-- [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
-- [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
-- [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
-- [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
-- [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+| Skill | Description | Install |
+|-------|-------------|---------|
+| [file-organizer](./file-organizer) | Intelligently organize files and find duplicates | `npx ai-agent-skills install file-organizer` |
+| [invoice-organizer](./invoice-organizer) | Organize invoices and receipts for tax prep | `npx ai-agent-skills install invoice-organizer` |
+| [raffle-winner-picker](./raffle-winner-picker) | Randomly select winners for giveaways | `npx ai-agent-skills install raffle-winner-picker` |
+| [jira-issues](https://github.com/skillcreatorai/Ai-Agent-Skills) | Create and manage Jira issues from natural language | `npx ai-agent-skills install jira-issues` |
+| [qa-regression](https://github.com/skillcreatorai/Ai-Agent-Skills) | Automated regression testing with Playwright | `npx ai-agent-skills install qa-regression` |
+| [llm-application-dev](https://github.com/skillcreatorai/Ai-Agent-Skills) | Build LLM-powered applications | `npx ai-agent-skills install llm-application-dev` |
 
 ### Collaboration & Project Management
 
-- [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
-- [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
-- [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
+| Skill | Description | Install |
+|-------|-------------|---------|
+| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | Automate git operations and repository interactions | External |
+| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | Evaluate code implementation plans | External |
+| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | Detect failing tests and propose fixes | External |
 
 ### Security & Systems
 
-- [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
-- [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
-- [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
-- [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+| Skill | Description | Install |
+|-------|-------------|---------|
+| [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace) | Digital forensics analysis and investigation | External |
+| [threat-hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | Hunt for threats using Sigma detection rules | External |
 
-## Getting Started
+## Installation
 
-### Using Skills in Claude.ai
+### One Command (Recommended)
 
-1. Click the skill icon (🧩) in your chat interface.
-2. Add skills from the marketplace or upload custom skills.
-3. Claude automatically activates relevant skills based on your task.
+```bash
+# Install for Claude Code (default)
+npx ai-agent-skills install <skill-name>
 
-### Using Skills in Claude Code
-
-1. Place the skill in `~/.config/claude-code/skills/`:
-   ```bash
-   mkdir -p ~/.config/claude-code/skills/
-   cp -r skill-name ~/.config/claude-code/skills/
-   ```
-
-2. Verify skill metadata:
-   ```bash
-   head ~/.config/claude-code/skills/skill-name/SKILL.md
-   ```
-
-3. Start Claude Code:
-   ```bash
-   claude
-   ```
-
-4. The skill loads automatically and activates when relevant.
-
-### Using Skills via API
-
-Use the Claude Skills API to programmatically load and manage skills:
-
-```python
-import anthropic
-
-client = anthropic.Anthropic(api_key="your-api-key")
-
-response = client.messages.create(
-    model="claude-3-5-sonnet-20241022",
-    skills=["skill-id-here"],
-    messages=[{"role": "user", "content": "Your prompt"}]
-)
+# Install for other agents
+npx ai-agent-skills install <skill-name> --agent cursor
+npx ai-agent-skills install <skill-name> --agent vscode
+npx ai-agent-skills install <skill-name> --agent amp
 ```
 
-See the [Skills API documentation](https://docs.claude.com/en/api/skills-guide) for details.
+### Manual Install
+
+```bash
+# Clone the repo
+git clone https://github.com/skillcreatorai/Awesome-Agent-Skills.git
+
+# Copy a skill to your skills directory
+cp -r Awesome-Agent-Skills/canvas-design ~/.claude/skills/
+```
+
+### CLI Commands
+
+```bash
+npx ai-agent-skills list              # List all skills
+npx ai-agent-skills search <query>    # Search skills
+npx ai-agent-skills info <name>       # Get skill details
+npx ai-agent-skills install <name>    # Install a skill
+```
 
 ## Creating Skills
 
 ### Skill Structure
 
-Each skill is a folder containing a `SKILL.md` file with YAML frontmatter:
-
 ```
 skill-name/
-├── SKILL.md          # Required: Skill instructions and metadata
+├── SKILL.md          # Required: Instructions and metadata
 ├── scripts/          # Optional: Helper scripts
 ├── templates/        # Optional: Document templates
 └── resources/        # Optional: Reference files
 ```
 
-### Basic Skill Template
+### Basic Template
 
 ```markdown
 ---
 name: my-skill-name
-description: A clear description of what this skill does and when to use it.
+description: A clear description of what this skill does.
 ---
 
 # My Skill Name
 
-Detailed description of the skill's purpose and capabilities.
+Detailed description of the skill's purpose.
 
 ## When to Use This Skill
 
 - Use case 1
 - Use case 2
-- Use case 3
 
 ## Instructions
 
-[Detailed instructions for Claude on how to execute this skill]
+[Detailed instructions for the AI agent]
 
 ## Examples
 
-[Real-world examples showing the skill in action]
+[Real-world examples]
 ```
 
-### Skill Best Practices
+### Two Ways to Create Skills
 
-- Focus on specific, repeatable tasks
-- Include clear examples and edge cases
-- Write instructions for Claude, not end users
-- Test across Claude.ai, Claude Code, and API
-- Document prerequisites and dependencies
-- Include error handling guidance
+1. **Generate in 30 seconds**: [skillcreator.ai/build](https://skillcreator.ai/build)
+2. **Build manually**: Follow the [Agent Skills spec](https://agentskills.io/specification)
 
 ## Contributing
 
-We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING.md) for details on:
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
-- How to submit new skills
-- Skill quality standards
-- Pull request process
-- Code of conduct
+### Quick Steps
 
-### Quick Contribution Steps
-
-1. Ensure your skill is based on a real use case
-2. Check for duplicates in existing skills
-3. Follow the skill structure template
-4. Test your skill across platforms
-5. Submit a pull request with clear documentation
+1. Fork this repo
+2. Add your skill folder with `SKILL.md`
+3. Test across multiple agents
+4. Submit PR with clear documentation
 
 ## Resources
 
 ### Official Documentation
 
-- [Claude Skills Overview](https://www.anthropic.com/news/skills) - Official announcement and features
-- [Skills User Guide](https://support.claude.com/en/articles/12512180-using-skills-in-claude) - How to use skills in Claude
-- [Creating Custom Skills](https://support.claude.com/en/articles/12512198-creating-custom-skills) - Skill development guide
-- [Skills API Documentation](https://docs.claude.com/en/api/skills-guide) - API integration guide
-- [Agent Skills Blog Post](https://anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) - Engineering deep dive
+- [Agent Skills Spec](https://agentskills.io) - The open standard
+- [Anthropic Skills](https://github.com/anthropics/skills) - Official example skills
+- [VS Code Skills Guide](https://code.visualstudio.com/docs/copilot/customization/agent-skills) - VS Code integration
 
-### Community Resources
+### Tools
 
-- [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
-- [Claude Community](https://community.anthropic.com) - Discuss skills with other users
-- [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
-
-### Inspiration & Use Cases
-
-- [Lenny's Newsletter](https://www.lennysnewsletter.com/p/everyone-should-be-using-claude-code) - 50 ways people use Claude Code
-- [Notion Skills](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0) - Notion integration skills
-
-
-## Join the Community
-
-- Have questions about integrating Composio with your auth setup? [Hop on a quick call with us](https://calendly.com/thomas-composio/composio-enterprise-setup)
-- [Follow us on Twitter](https://x.com/composio)
-- [Join our Discord](https://discord.com/invite/composio)
+- [SkillCreator.ai](https://skillcreator.ai/build) - Generate skills from plain English
+- [Browse Skills](https://skillcreator.ai/discover) - Visual skill gallery
+- [npm Package](https://www.npmjs.com/package/ai-agent-skills) - CLI installer
 
 ## License
 
-This repository is licensed under the Apache License 2.0.
-
-Individual skills may have different licenses - please check each skill's folder for specific licensing information.
+Apache License 2.0. Individual skills may have different licenses.
 
 ---
 
-**Note**: Claude Skills work across Claude.ai, Claude Code, and the Claude API. Once you create a skill, it's portable across all platforms, making your workflows consistent everywhere you use Claude.
-
-- [AgentsKB](https://agentskb.com) - Upgrade your AI with researched answers. We did the research so your AI gets it right the first time.
+<p align="center">
+  <sub>Curated by <a href="https://skillcreator.ai">SkillCreator.ai</a> · Originally forked from <a href="https://github.com/ComposioHQ/awesome-claude-skills">ComposioHQ/awesome-claude-skills</a></sub>
+</p>

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 - [SkillCreator.ai](https://skillcreator.ai/build) - Generate skills from plain English
 - [Browse Skills](https://skillcreator.ai/discover) - Visual skill gallery
-- [npm Package](https://www.npmjs.com/package/ai-agent-skills) - CLI installer
+- [npm Package](https://github.com/skillcreatorai/Ai-Agent-Skills) - CLI installer (`npx ai-agent-skills`)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ This repo curates the best in one place. Quality over quantity. All skills follo
 | [internal-comms](./internal-comms) | Write internal communications and status reports | `npx ai-agent-skills install internal-comms` |
 | [lead-research-assistant](./lead-research-assistant) | Identify and qualify high-quality leads | `npx ai-agent-skills install lead-research-assistant` |
 | [job-application](https://github.com/skillcreatorai/Ai-Agent-Skills) | Cover letters and applications using your CV | `npx ai-agent-skills install job-application` |
+| [ICP Definition Builder](https://github.com/mambalabsdev/mamba-labs-skills/tree/main/skills/icp-definition-builder) | Build a structured Ideal Customer Profile from a business description | External |
+| [Cold Email Structure Checker](https://github.com/mambalabsdev/mamba-labs-skills/tree/main/skills/cold-email-structure-checker) | Audit a cold email draft against a 7-point outbound framework | External |
+| [Domain Health Pre-Check](https://github.com/mambalabsdev/mamba-labs-skills/tree/main/skills/domain-health-precheck) | Scan SPF, DKIM, DMARC records and blacklist status for a sending domain | External |
+| [Hiring Signal Spotter](https://github.com/mambalabsdev/mamba-labs-skills/tree/main/skills/hiring-signal-spotter) | Detect GTM hiring signals at any company and generate an outbound angle | External |
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adding [Mamba Labs GTM Skills](https://github.com/mambalabsdev/mamba-labs-skills), a collection of 4 free, MIT-licensed GTM skills for signal-based outbound workflows.

Skills included:
- **ICP Definition Builder**: Guided interview that outputs a structured ICP block for Clay, CRM filters, or targeting briefs.
- **Cold Email Structure Checker**: Audits cold email drafts against a 7-point framework with pass/fail scorecard and revised version.
- **Domain Health Pre-Check**: Scans SPF, DKIM, DMARC, and blacklist status via the Mamba Labs Domain Deliverability Checker MCP server.
- **Hiring Signal Spotter**: Detects GTM hiring signals on Greenhouse, Lever, and Ashby via the Mamba Labs GTM Hiring Signal Scraper MCP server.

Compatible with Claude Code, Codex CLI, Cursor, Gemini CLI, and MCP-compatible agents. Each skill includes YAML frontmatter with name, description, license, metadata (category + tags), compatibility, and version fields. The repo ships with a `.claude-plugin/marketplace.json` manifest.
