### PR TITLE
Add Atlas Cloud Media API to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Creative & Media
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
+- [Atlas Cloud Media API](https://www.atlascloud.ai/models) - OpenAI-compatible LLMs plus async image/video generation APIs for creative workflows, storyboards, product visuals, and multimodal agent outputs.
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.


### PR DESCRIPTION
## Summary
- add an `atlas-cloud-media-generation` Claude Skill for Atlas Cloud image/video workflows
- document image/video submission and polling endpoints
- list the skill under Creative & Media in the existing README catalog

## Validation
- checked `SKILL.md` frontmatter and README entry locally
- compared fork branch against upstream `master`: README + one new skill file only
- Atlas Media API smoke test: `generateImage` returned `code=200`, polling completed with one output

## Notes
- examples use the `ATLASCLOUD_API_KEY` environment variable and placeholder keys only
- this does not add a sponsor block, logo, or top-of-README promotional placement