### PR TITLE
Add Mamba Labs GTM Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Mamba Labs GTM Skills](https://github.com/mambalabsdev/mamba-labs-skills) - 4 free GTM skills for signal-based outbound: ICP definition, cold email auditing, domain health checks, and hiring signal detection. Works with Claude Code, Codex CLI, Cursor, and MCP-compatible agents. *By [@mambalabsdev](https://github.com/mambalabsdev)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adding [Mamba Labs GTM Skills](https://github.com/mambalabsdev/mamba-labs-skills), a collection of 4 free, MIT-licensed GTM skills for signal-based outbound workflows.

Skills included:
- **ICP Definition Builder**: Guided interview that outputs a structured ICP block for Clay, CRM filters, or targeting briefs.
- **Cold Email Structure Checker**: Audits cold email drafts against a 7-point framework with pass/fail scorecard and revised version.
- **Domain Health Pre-Check**: Scans SPF, DKIM, DMARC, and blacklist status via the Mamba Labs Domain Deliverability Checker MCP server.
- **Hiring Signal Spotter**: Detects GTM hiring signals on Greenhouse, Lever, and Ashby via the Mamba Labs GTM Hiring Signal Scraper MCP server.

Compatible with Claude Code, Codex CLI, Cursor, Gemini CLI, and MCP-compatible agents. Each skill includes YAML frontmatter with name, description, license, metadata (category + tags), compatibility, and version fields. The repo ships with a `.claude-plugin/marketplace.json` manifest.
