### PR TITLE
Add GrowthLens to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [GrowthLens](https://github.com/fjilvi-afk/growthlens) - 12 business-analysis skills for marketers, growth & analysts: competitor teardown, funnel audit, pricing analysis, offer/value-ladder breakdown, ICP segmentation, and SEO content-gap. *By [@fjilvi-afk](https://github.com/fjilvi-afk)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
Adds **GrowthLens** to the Business & Marketing section.

GrowthLens is a pack of 12 Agent Skills for business analysis aimed at marketers, growth, and analysts (not developers): competitor & business-model teardown, pricing analysis, funnel audit, landing UX review, ad-creative analysis, ICP segmentation, SEO content-gap, offer/value-ladder teardown, positioning/messaging audit, social-proof audit, and a full online-school audit.

- MIT-licensed
- Installable as a Claude Code plugin, or clone and point any compatible agent at the `skills/` folder
- Repo: https://github.com/fjilvi-afk/growthlens

The entry is placed alphabetically within Business & Marketing and follows the existing `- [Name](link) - description. *By [@author]*` format.
