### PR TITLE
Add Vexilo · A field guide to Claude Code to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en) — Visual interactive index of 31 agents · 99 commands · 123 skills · 13 rules, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click "Teach Claude this handbook" feeds the whole guide into a local Claude session in 30 seconds. Browser-based, zero install. ([companion repo](https://github.com/lilhawk7077/claude-code-resources))
 
 ### Inspiration & Use Cases
 


### PR DESCRIPTION
## Adds Vexilo · A field guide to Claude Code to Community Resources

[Vexilo](https://vexilo.app/?lang=en) is a live, interactive, visual index of **31 agents · 99 commands · 123 skills · 13 rules**, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). The killer feature is a one-click **"Teach Claude this handbook"** that primes any local Claude session with the whole index in 30 seconds.

### Why it fits `Community Resources`
- Visual index / navigation aid (no current entry covers this gap)
- Cross-platform: works in browser, no install, runs alongside any Claude Code / Skills setup
- Companion repo (MIT): https://github.com/lilhawk7077/claude-code-resources

### Checklist
- [x] Open and free, no paywall
- [x] Actively maintained (v1.1.9, weekly updates)
- [x] Directly relevant to Claude Code & Claude Skills
- [x] No duplicate of existing entry