### PR TITLE
Add Reef small-business skills collection (12 skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Reef Small-Business Skills](https://github.com/buildwithreef/claude-skills) - 12 skills for running a small business: invoice chasing, review replies, Google Business Profile and local SEO audits, landing-page teardowns, service pages, cold email, and proposals. Each skill is a real SOP with checklists and templates. *By [@buildwithreef](https://github.com/buildwithreef)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adding a collection of 12 MIT-licensed skills built for small-business operations, written as real SOPs (escalation ladders, audit checklists, named formulas) rather than persona prompts.

- Repo: https://github.com/buildwithreef/claude-skills
- Each skill: SKILL.md + reference files where needed, installable via `npx skills add buildwithreef/claude-skills`
- Docs/examples for every skill: https://buildwithreef.com/skills/

Added to Business & Marketing in alphabetical position, matching the existing external-entry format. Happy to adjust placement or wording.