### PR TITLE
Add workorai (talent marketplace skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [workorai](https://github.com/work0r-ai/agent-kit/tree/main/skills/workorai) - Talent-marketplace skill for candidates (job search, applications) and employers (job lifecycle, ranked candidate discovery with white-box match explanations) via the WorkorAI MCP server.
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adds WorkorAI as an external-repo entry under Productivity & Organization (alphabetical position, matching the format of other external entries like kaizen, n8n-skills, solo-skills).

- Skill: https://github.com/work0r-ai/agent-kit/tree/main/skills/workorai — SKILL.md with name/description frontmatter plus references/ files for tool schemas and recipes
- Real use case: candidates search jobs and manage applications; employers run the job lifecycle and get ranked candidate discovery with a white-box match explanation per candidate (fit score, proven skills, gaps)
- Backed by the WorkorAI MCP server (streamable HTTP at https://workorai.com/mcp, on the official MCP Registry as io.github.work0r-ai/workorai); tested with Claude Code
- MIT licensed, npm: @workorai/agent-kit; no duplicate entry exists in the list
