### PR TITLE
Add HTML Mark (Creative & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [HTML Mark](https://github.com/xuxinmaxen/html-mark) - Click-to-annotate overlay for HTML prototypes: drop pins on any element, write feedback inline, copy it out as Markdown/JSON for design review. Self-contained JS, works as a skill or bookmarklet ([live demo](https://xuxinmaxen.github.io/html-mark/)). *By [@xuxinmaxen](https://github.com/xuxinmaxen)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
## What

Adds **[HTML Mark](https://github.com/xuxinmaxen/html-mark)** to the Creative & Media section.

## Why it's useful

Design review on HTML prototypes usually means screenshots with red circles, or verbose "third card from the left" messages. HTML Mark is a self-contained ~32 KB JS overlay: click any element to drop a pin, write the note inline, copy everything out as structured Markdown / Plain / JSON — ready to paste into an issue tracker or back into Claude Code for fixes.

- **Live demo (no install):** https://xuxinmaxen.github.io/html-mark/
- Works three ways: Claude Code skill (injects into generated HTML), inline script, or bookmarklet on any page
- No dependencies, no network calls, `.mm-*` prefixed CSS so it never collides with the host page
- MIT-0, includes SKILL.md + README + screenshots + examples

## Checklist

- [x] Real use case (reviewing AI-generated HTML prototypes)
- [x] No duplicate in existing entries
- [x] Documented (README + SKILL.md), tested, no secrets
- [x] I'm the author (self-submission, stated openly)