### PR TITLE
Add Agentic Commerce News (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
+- [Agentic Commerce News](https://github.com/xuxinmaxen/agentic-commerce-news) - Weekly agentic-commerce briefing: scans the past 7 days of X, media, and VC announcements for funding rounds, product launches, and founder/VC takes on AI shopping agents, endorsement-gated with source links. No API keys needed. *By [@xuxinmaxen](https://github.com/xuxinmaxen)*
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.


### PR DESCRIPTION
## What

Adds **[Agentic Commerce News](https://github.com/xuxinmaxen/agentic-commerce-news)** to the Business & Marketing section.

## Why it's useful

Agentic commerce (AI agents that discover, compare, and check out on behalf of shoppers) moves fast and the signal is scattered across X threads, VC announcements, and trade media. This skill runs 10+ parallel WebSearch queries scoped to the past 7 days, keeps only items with credible endorsement (VC investment, recognized-figure amplification, major report, or official platform partnership), classifies each into a 9-layer agentic-commerce stack, and outputs a structured briefing with source links.

- Endorsement-gated quality bar — no PR fluff, every item has a source link
- No API keys or external services; WebSearch/WebFetch only
- Includes scheduling recipes for a recurring digest (Claude Code cron / OpenClaw)
- Published briefing archive in the repo shows real output before you install
- MIT-0

## Checklist

- [x] Real use case (weekly market intel for anyone building in or watching AI commerce)
- [x] No duplicate in existing entries
- [x] Documented (README + SKILL.md), tested, no secrets
- [x] I'm the author (self-submission, stated openly)