### PR TITLE
Add AI Meeting skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [AI Meeting](https://github.com/bin1874/ai-meeting-skill) - Runs structured multi-agent decision reviews with Codex, Claude Code, and adapter-based CLI agents. *By [@bin1874](https://github.com/bin1874)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
## Summary

Adds AI Meeting, a Claude/Codex-compatible skill for structured multi-agent decision reviews.

## Why it is useful

AI Meeting helps teams review technical plans, product decisions, and implementation proposals by running independent agent rounds, preserving provider sessions, and producing a final decision report.

## Validation

- `python3 /home/ben/.codex/skills/.system/skill-creator/scripts/quick_validate.py ai-meeting`
- `node --check ai-meeting/scripts/ai-meeting.mjs`

## Source

https://github.com/bin1874/ai-meeting-skill