### PR TITLE
Add cc-usage skill (Data & Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
-- [cc-usage](https://github.com/liberzon/cc-usage) - Analyzes your local Claude Code token usage and pay-as-you-go API-equivalent cost across all projects — totals, daily/weekly breakdowns, per-model repricing, and top days/weeks. Read-only and stdlib-only. *By [@liberzon](https://github.com/liberzon)*
+- [cc-usage](https://github.com/liberzon/cc-usage) - Reports how many tokens you've spent in Claude Code and the pay-as-you-go API-equivalent cost across all projects — daily/weekly breakdowns, per-model repricing, and top days/weeks. Read-only and stdlib-only. *By [@liberzon](https://github.com/liberzon)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [cc-usage](https://github.com/liberzon/cc-usage) - Analyzes your local Claude Code token usage and pay-as-you-go API-equivalent cost across all projects — totals, daily/weekly breakdowns, per-model repricing, and top days/weeks. Read-only and stdlib-only. *By [@liberzon](https://github.com/liberzon)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## Adds: [cc-usage](https://github.com/liberzon/cc-usage)

A Claude Code skill that analyzes your **local** token usage and the equivalent **pay-as-you-go (API dollar) cost** across all your projects — reading the JSONL transcripts Claude Code already writes to `~/.claude/projects/`.

**Category:** Data & Analysis

**What it does**
- All-time totals: input / output / cache-read / cache-write tokens + pay-as-you-go $
- Daily and weekly breakdowns; top days/weeks by tokens or cost
- Per-model cost at the actual model mix, or reprice everything onto one model (`--model`)
- Weekly min/max/median/mean statistics

**Why it's a real use case:** answers "how much would I have paid without a subscription?" and "what's my heaviest day?" — questions the subscription dashboard doesn't. The numbers are derived from files already on disk, so they're independently reproducible (the README includes a one-liner anyone can run to verify their own total).

**Standalone value / not a SaaS:** read-only, Python 3 standard-library only, no dependencies, no network calls, no paid service. It reads token *counts* and model names — never message content.

**License:** MIT

### Contribution checklist
- [x] Based on a real use case
- [x] Documented with examples (README + SKILL.md)
- [x] Safe (read-only)
- [x] Not a duplicate of an existing entry
- [x] Placed in the most appropriate category (Data & Analysis), alphabetical position

🤖 Generated with [Claude Code](https://claude.com/claude-code)