### PR TITLE
Add agent-qa skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [agent-qa Authoring](https://github.com/vostride/agent-qa/tree/main/skills/agent-qa-authoring) - Author natural-language web and mobile QA tests. *By [@vostride](https://github.com/vostride)*
+- [agent-qa Debug Fix](https://github.com/vostride/agent-qa/tree/main/skills/agent-qa-debug-fix) - Debug failed agent-qa runs and propose fixes. *By [@vostride](https://github.com/vostride)*
+- [agent-qa Result Triage](https://github.com/vostride/agent-qa/tree/main/skills/agent-qa-result-triage) - Triage agent-qa results by failure category. *By [@vostride](https://github.com/vostride)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
## Summary
- add agent-qa authoring, debug/fix, and result triage skills to Development & Code Tools
- link to the published SKILL.md directories in vostride/agent-qa

## Checks
- git diff --check

Disclosure: I am affiliated with Agent QA and Vostride.