### PR TITLE
Add SeldonFrame Agent Business skill (build → sell → get paid for AI …

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [SeldonFrame Agent Business](https://github.com/seldonframe/seldonframe/tree/main/skills/seldonframe-agent-business) - Build, eval-gate, deploy, and sell AI agents for real businesses from your IDE via the SeldonFrame MCP: build → test → deploy → sell → get paid. *By [@seldonframe](https://github.com/seldonframe)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
`seldonframe-agent-business` teaches an IDE agent (Claude Code, Cursor, Codex) the complete agent-business loop on SeldonFrame: build an AI agent for a real business from one sentence, test it against the 8-scenario eval suite that gates publishing at ≥ 87.5%, deploy it to a real channel with the human-only connect step handled honestly, list it on the marketplace with per-call or per-outcome usage pricing, and withdraw the earnings. Every tool name is grounded in the real `@seldonframe/mcp` tool surface — no invented tools. Guardrails: the agent never collects secret keys in chat and never moves real money without an explicit human ask. First workspace is free with no API key.

Natural fit here: SeldonFrame's deployed agents use Composio for per-deployment Google/Outlook calendar booking and 1000+ app connectors, so the two ecosystems already compose.