### PR TITLE
Add html-collab skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
+- [html-collab](https://github.com/ljn-hust/html-collab) - Single-file HTML format for LLM-human collaborative document review. The LLM generates a self-contained .html, humans comment and edit it in Chrome, and the skill reads the annotations to produce the next revision. No server or accounts needed. *By [@ljn-hust](https://github.com/ljn-hust)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Document Processing
 
 - [docx](https://github.com/anthropics/skills/tree/main/skills/docx) - Create, edit, analyze Word docs with tracked changes, comments, formatting.
+- [html-collab](https://github.com/ljn-hust/html-collab) - Single-file HTML format for LLM-human collaborative document review. The LLM generates a self-contained .html, humans comment and edit it in Chrome, and the skill reads the annotations to produce the next revision. No server or accounts needed. *By [@ljn-hust](https://github.com/ljn-hust)*
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
-- [html-collab](https://github.com/ljn-hust/html-collab) - Single-file HTML format for LLM-human collaborative document review. The LLM generates a self-contained .html, humans comment and edit it in Chrome, and the skill reads the annotations to produce the next revision. No server or accounts needed. *By [@ljn-hust](https://github.com/ljn-hust)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 


### PR DESCRIPTION
Adds **html-collab** to the Document Processing category.

## What it is

A single-file HTML format for LLM-human collaborative document review. The LLM generates a self-contained `.html` file; a human opens it in Chrome to leave comments (with optional screenshot pastes) and inline edits with tracked diffs; the skill then reads those annotations to produce the next revision. No server, no accounts, no build step.

## Checklist

- [x] Real use case (iterative LLM-human document review)
- [x] Documented with a live self-demonstrating demo: https://ljn-hust.github.io/html-collab/
- [x] MIT licensed
- [x] Added in the correct category, alphabetical order, no emojis
- [x] Tested on Claude Code and OpenClaw

Repo: https://github.com/ljn-hust/html-collab