### PR TITLE
Add Paper Format Agent to Document Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
+- [Paper Format Agent](https://github.com/zxyasfas/paper_format_agent) - Reformats academic paper DOCX files (thesis, journal, IEEE/APA) to match a format guide, with a content-fingerprint guard that proves the body text was left untouched — only the formatting changed. *By [@zxyasfas](https://github.com/zxyasfas)*
 
 ### Development & Code Tools
 


### PR DESCRIPTION
### What
Adds **Paper Format Agent** to the Document Processing section.

### Short pitch
An open-source Claude skill (ships a top-level `SKILL.md`) that reformats academic paper DOCX files — thesis, journal, IEEE/APA — to match a target format guide. Its distinguishing feature is a **content-fingerprint guard**: it hashes the body and table text before and after formatting and refuses to write the file if that text changed, so a reviewer can prove the wording was left untouched and only the formatting moved. Runs locally, MIT licensed.

### Checklist
- [x] Real use case (academic formatting where content preservation matters), not hypothetical
- [x] Has a `SKILL.md` so an agent can install and invoke it
- [x] Open-source (MIT), maintained (active this week), CI-green with 56 tests
- [x] Searched existing entries — not a duplicate
- [x] One entry added, placed in the Document Processing section