### PR TITLE
Add time-ledger and trading-ledger skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [time-ledger](https://github.com/cruisekkk/time-ledger) - Natural-language time tracking that parses what you said you did into your own Notion database, asking instead of guessing when unsure. Bilingual (EN+中文).
+- [trading-ledger](https://github.com/cruisekkk/trading-ledger) - Trading journal that captures your stated reason, plan, and emotion at the moment of entry into your own Notion database, with reviews that grade decisions rather than P&L. Bilingual (EN+中文).
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adds two skills to **Productivity & Organization** (external links, same style as solo-skills / n8n-skills):

**time-ledger** — https://github.com/cruisekkk/time-ledger
- **Problem it solves:** time tracking dies because logging is a chore; this makes it one sentence in a chat you already have open ("read papers 2h, gym 1h" → structured rows in your own Notion DB).
- **Who it's for:** anyone who wants to know where their hours go but won't maintain a form/timer.
- **Example:** `claude -p "log it: read papers 2h today"` → Activity/minutes/date rows; anything uncertain becomes a to-confirm row it asks about, instead of fabricating.

**trading-ledger** — https://github.com/cruisekkk/trading-ledger
- **Problem it solves:** entry reasons decay overnight; spreadsheet journals capture fills but lose the thesis/plan/emotion. This asks "why?" at the moment of entry.
- **Who it's for:** traders who want Market Wizards-style reviews that grade decisions, not P&L.
- **Example:** "bought 500 NVDA at 135, betting the dip fills" → row with ticker/size/price + thesis; "review my trades" walks each closed trade through thesis vs plan vs emotion.

**Attribution:** both authored by me (@cruisekkk), MIT, bilingual EN/中文, in daily personal use. Real use case: they are my own daily drivers — the honesty contract ("ask instead of guessing") is the core design in both.
