### PR TITLE
Add Process Builder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Process Builder](https://github.com/Castaldo-Solutions/process-builder) - Interviews you about a business process and generates a BPMN swimlane diagram as a draw.io file, with AS-IS pain-point mapping and TO-BE automation roadmaps. Interview guides in Italian, generator is language-agnostic. *By [@Castaldo-Solutions](https://github.com/Castaldo-Solutions)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## What problem it solves

Business process mapping usually fails at information gathering, not drawing. Consultants and ops teams spend hours interviewing stakeholders, then hours more redrawing swimlanes as the picture changes. **Process Builder** structures both halves: a strict interview protocol (the skill refuses to generate until it knows who does what, in which order, with which tool, and what each decision depends on — no plausible-but-invented processes), and a zero-dependency Python generator that turns a small JSON into a clean .drawio BPMN swimlane with deterministic, collision-free layout.

## Who uses this workflow

Built and used in real consulting engagements with Italian SMEs (process assessment before automation projects). It produces the AS-IS with pain points highlighted outside the flow, then TO-BE variants (Quick Win vs Full Automation) with automated/new tasks visually marked.

## Attribution

**Credit:** Based on Castaldo Solutions' internal process-assessment workflow, open-sourced at https://github.com/Castaldo-Solutions/process-builder (MIT).

## Example of how it's used

**User**: "Mappiamo il nostro processo di richiesta ferie" (let's map our leave-request process)

**Flow**: the skill interviews the user (one question per turn), confirms a structured summary, writes a JSON like `examples/richiesta_ferie_as_is.json`, runs `python scripts/generate_swimlane.py input.json out.drawio`, and delivers a .drawio file: one lane per actor, BPMN XOR gateway for the approval decision, tool annotations under each task, two pain points connected to the offending steps with dashed red lines.

The linked repository includes SKILL.md (Agent Skills spec), three reference guides, the generator script, 3 runnable example JSONs and eval scenarios.

*(PR updated: now a README-only entry linking to the external repo, per the validation workflow.)*

Note: interview guides and prompts are in Italian (real use case: Italian-speaking teams); the JSON schema and the generator are language-agnostic. Tested with Claude Code.
