### PR TITLE
Add project-portfolio skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
+- [project-portfolio](https://github.com/mc856/project-portfolio) - Long-term project memory for coding agents: file-based tracking of goals, next actions, triggers, and history across folders and sessions.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.


### PR DESCRIPTION
Adds **project-portfolio** to the *Productivity & Organization* section.

A file-based, long-term project memory layer for coding agents. Coding agents scope to one folder and one session, but real efforts — a job hunt, several side projects, PRs across repositories — span many folders and months. This skill tracks each project's goal, next actions, triggers, and history as plain markdown the user owns, plus a global watchlist that makes syncing cheap and follow-ups automatic.

- Repo: https://github.com/mc856/project-portfolio
- Placed alphabetically within the category (between `n8n-skills` and `Raffle Winner Picker`).
- Entry format matches the existing list style; links work.