### PR TITLE
Add apple-dev-skills to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [apple-dev-skills](https://github.com/Wei18/apple-dev-skills) - Curated catalog of 22 Apple/Swift development skills (SwiftUI navigation architecture, Swift 6 concurrency, App Store Connect API automation, Xcode Cloud CI) plus 12 AI-agent-collaboration skills, distributed as a Claude Code plugin marketplace. *By [@Wei18](https://github.com/Wei18)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
## What

Adds [apple-dev-skills](https://github.com/Wei18/apple-dev-skills) to the **Development & Code Tools** section (alphabetical position).

## Why it qualifies

- **Real use case**: 34 skills distilled from one developer's shipping experience on the App Store — 22 Apple/Swift skills (SwiftUI navigation architecture, Swift 6 concurrency, App Store Connect API automation, Xcode Cloud CI, accessibility, performance) and 12 AI-agent-collaboration skills.
- **Well-documented**: every skill has frontmatter description + worked examples; bilingual README (EN / zh-Hant) catalogs all skills.
- **Tested**: used daily in Claude Code; repo passes `claude plugin validate` and ships CI gates for skill quality (description length, version pins).
- **Portable**: standard SKILL.md format, installable via Claude Code plugin marketplace (`/plugin marketplace add wei18/apple-dev-skills`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)