### PR TITLE
Add Upkeep skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [Upkeep](https://github.com/Wei18/Upkeep) - Claude Code plugin that audits a repo for docs/spec/asset drift, flags findings by severity with evidence, and renders a self-contained HTML report; strictly output-only, never edits files. Includes a reusable GitHub Actions workflow for scheduled CI audits. *By [@Wei18](https://github.com/Wei18)*
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
## What it is

[Upkeep](https://github.com/Wei18/Upkeep) is a Claude Code plugin that audits a repository for drift between docs, specs, and the actual code/assets. It surfaces findings with evidence, ranks them by severity, and renders a self-contained HTML report. It is strictly output-only — it never modifies files. It ships as a Claude Code plugin/skill (`upkeep-audit`) plus a reusable GitHub Actions workflow for scheduling the audit in CI.

Added to the Development & Code Tools section, alphabetically ordered between `test-driven-development` and `using-git-worktrees`.

## Test plan

- [x] Link resolves: https://github.com/Wei18/Upkeep
- [x] Entry placed in alphabetical order within its category
- [x] Only README.md changed, one line added

🤖 Generated with [Claude Code](https://claude.com/claude-code)