### PR TITLE
Add titlewise (conversation titler skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [titlewise](https://github.com/Battlelamb/claude-code-conversation-titler) - Interactively titles, names, and labels the current conversation with a recommended pick - multilingual (user language, English, Chinese), 13+ formats, plus a description and tags.
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adds **titlewise** - an interactive Claude Code skill that titles, names, and labels the current conversation.

- Multilingual: user language / English / Chinese
- 13+ title formats, a recommended pick, plus a description and tags
- Suggestion-only (never edits the session)
- MIT-licensed; install as a Claude Code plugin or a standalone skill

Repo: https://github.com/Battlelamb/claude-code-conversation-titler