### PR TITLE
Add Image Generator skill (Pollinations AI, no API key needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Image Generator](./image-generator/) - Generates images from plain English descriptions using Pollinations AI — no API key required, auto-enhances prompts, and adapts dimensions to use case. *By [@lukan-lawslaf](https://github.com/lukan-lawslaf)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
Adds a plug-and-play image generation skill using Pollinations AI — no API key needed, works out of the box.

Problem it solves: Users want to generate images directly in Claude without setting up any API credentials.

Target audience: Anyone using Claude who wants image generation with zero configuration.

Usage example:

"Draw me a cyberpunk fox at night"
→ Claude enhances the prompt, runs generate_image.py, embeds the result inline.

Tested on: Claude Code/Claude Desktop