### PR TITLE
Add bakeoff and YOLO skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
+- [bakeoff](https://github.com/CoriChui/bakeoff) - Turns a hard "which should I do?" into a judged tournament: generates diverse candidate solutions, auto-derives an evaluation rubric for the specific problem, scores each candidate with independent judges, adversarially refutes the leader, and returns a ranked winner with the reason it won. *By [@CoriChui](https://github.com/CoriChui)*
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [Chrome Relay](https://chrome-relay.kushalsm.com/) - Drives the user's already-open Chrome session — cookies, SSO, extensions, localhost — through a local CLI bridge. Real-Chrome counterpart to Playwright Browser Automation; install via `npx skills add chrome-relay` + a [Chrome Web Store extension](https://chromewebstore.google.com/detail/chrome-relay/cpdiapbifblhlcpnmlmfpgfjlacebokb). No remote relay, no Playwright fixtures, no MCP server needed.
@@ -146,6 +147,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [YOLO](https://github.com/CoriChui/yolo) - Reasoning-first, feature-aware development workflow where git is the source of truth and status is derived, never stored; eleven skills take a request from brief to planned, executed, verified, and landed, gated only at a plan and a ship checkpoint. *By [@CoriChui](https://github.com/CoriChui)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds two Claude Code skills to **Development & Code Tools** (alphabetical, no vendored folders — both are full standalone repos with their own homes).

### bakeoff — https://github.com/CoriChui/bakeoff
- **Problem it solves:** costly, hard-to-reverse decisions where several options are defensible and it's unclear *why* one wins.
- **What it does:** generates diverse candidate solutions, auto-derives an evaluation rubric for the specific problem, scores each candidate with independent judges (mechanically reconciled), adversarially refutes the leader, and returns a ranked winner with rationale. Self-contained; installs via `npx skills add CoriChui/bakeoff` or as a Claude Code plugin. MIT.

### YOLO — https://github.com/CoriChui/yolo
- **Problem it solves:** feature development that drifts because status lives in tracked files that go stale.
- **What it does:** a reasoning-first workflow where git is the source of truth and status is derived, never stored; eleven `yolo-*` skills take a request from brief → planned → executed → verified → landed, gated only at a plan and a ship checkpoint. Installs as a Claude Code plugin or copied into a project. MIT.

Both are authored by [@CoriChui](https://github.com/CoriChui). Descriptions follow the list's one-line, no-emoji, no-sales-pitch style.