### PR TITLE
Add mindpowers knowledge-work skill suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
+- [mindpowers](https://github.com/rohitgehe05/mindpowers) - Socratic brainstorming plugin for knowledge-work docs (PRDs, business reviews, decision docs) with two approval gates before drafting. *By [@rohitgehe05](https://github.com/rohitgehe05)*
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
-- [mindpowers](https://github.com/rohitgehe05/mindpowers) - Socratic brainstorming plugin for knowledge-work docs (PRDs, business reviews, decision docs) with two approval gates before drafting. *By [@rohitgehe05](https://github.com/rohitgehe05)*
+- [mindpowers](https://github.com/rohitgehe05/mindpowers) - Problem-first knowledge-work skill suite: validates claims against direct evidence, shapes rough ideas into locked specs, drafts and reviews documents, and remembers preferences. Supports Claude Code, Cowork, Codex, ChatGPT desktop, and Cursor. *By [@rohitgehe05](https://github.com/rohitgehe05)*
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 


### PR DESCRIPTION
## Use case

Mindpowers gives knowledge workers a problem-first workflow for PRDs, business reviews, decision documents, one-pagers, and other non-code writing. It can validate a problem against available evidence before shaping the document, then uses Socratic elicitation and two approval gates before drafting.

## Problem solved

AI-written business documents often read smoothly while missing the underlying problem, evidence gaps, audience, or decision. Mindpowers separates five reusable jobs: `validating-problems`, `mindstorming`, `drafting`, `reviewing-docs`, and `calibrating`.

## Who uses it

PMs, executives, operators, and other knowledge workers who need defensible problem briefs and deliberate documents rather than immediate first drafts.

## Example

```text
/mindpowers:validating-problems test whether this problem is supported before we pitch a direction
```

## Distribution and validation

- Claude Code marketplace plugin and Cowork ZIP release
- Native Codex and ChatGPT desktop plugin packaging
- Cursor GitHub skill import support
- v0.7.1 install paths validated for Claude and Codex

## Inspiration

Adapts the structured questioning pattern from [obra/superpowers](https://github.com/obra/superpowers) to knowledge-work documents, with an independent evidence-validation stage before solution shaping.
