### PR TITLE
Add RunAPI CLI Skill to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [RunAPI CLI Skill](https://github.com/runapi-ai/cli-skill) - Run AI image, video, music/audio, and other model API jobs from Claude Code, Codex, Cursor, and similar agents through the RunAPI CLI. *By [@runapi-ai](https://github.com/runapi-ai)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds RunAPI CLI Skill to the Creative & Media section.

It gives agents a reusable way to run AI image, video, music/audio, and other model API jobs through the RunAPI CLI.