### PR TITLE
Add Scribo skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Scribo](https://github.com/causa-prima-ai/scribo-skill) - Generates EN 16931-compliant e-invoices (German ZUGFeRD & XRechnung) or a plain US PDF from a plain-language request — free, no signup, the sender’s email is the login. *By [@causa-prima-ai](https://github.com/causa-prima-ai)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds **Scribo** to the **Business & Marketing** category.

**Problem it solves:** Generating a compliant invoice normally means a dedicated tool. Scribo lets an agent do it from a plain-language request ("bill Acme GmbH €2,400 for May design work") and returns a finished, standards-compliant invoice.

**Who uses it:** Freelancers and micro-SMBs (and their AI agents) who need EU- or US-compliant invoices without accounting software.

**What it does:** Produces EN 16931-compliant e-invoices — German ZUGFeRD (B2B) and XRechnung (B2G) live today, Factur-X / Peppol BIS / Spanish Facturae coming — or a plain US PDF. Free forever, no signup; the sender's email is the login.

**Usage example:** Ask your agent "create an invoice from Acme GmbH to Beta Ltd for €2,400 of May design work, German ZUGFeRD." The skill collects the details, generates the invoice, and returns a downloadable PDF (with embedded XML for EU formats).

**Attribution:** By Causa Prima (https://causaprima.ai). Skill repo: https://github.com/causa-prima-ai/scribo-skill

Added as one alphabetical line in Business & Marketing, external-repo format, no emojis, per CONTRIBUTING.