### PR TITLE
Add deciqAI Knowledge Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [deciqAI Knowledge Skills](https://github.com/deciqAI/knowledge-skills) - 163 MIT-licensed thinking-framework skills covering first principles, inversion, Bayesian reasoning, mental models, and business frameworks. Each skill is an executable step-by-step process with primary-sourced historical case studies; install via `npx skills add deciqAI/knowledge-skills`. *By [@deciqAI](https://github.com/deciqAI)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
This PR adds [deciqAI Knowledge Skills](https://github.com/deciqAI/knowledge-skills) to the Productivity & Organization section: 163 open-source (MIT) thinking-framework Agent Skills — first principles, inversion, Bayesian reasoning, mental models, and business frameworks. Each skill uses the standard SKILL.md format and is an executable step-by-step process with worked examples backed by primary-sourced historical case studies, installable via `npx skills add deciqAI/knowledge-skills`.

The entry follows the list's existing format (alphabetical order within the section, one-line factual description, author attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)