### PR TITLE
Add aigent-OS to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [aigent-OS](https://github.com/wrg32786/aigent-os) - Open-source Claude Code operating system — persistent memory in an Obsidian vault, an /open + /close session rhythm that loads and banks context, plus a Pantheon of subagents, hooks, and background daemons that maintain priorities, decisions, and delegation across sessions. Markdown + shell, no database or server. MIT. *By [@wrg32786](https://github.com/wrg32786)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
## Summary
- Adds [aigent-OS](https://github.com/wrg32786/aigent-os) to the Development & Code Tools section — an open-source Claude Code operating system built on persistent memory in an Obsidian vault, an /open + /close session rhythm, and a Pantheon of subagents/hooks/daemons for cross-session priorities and delegation.
- Markdown + shell only, no database or server. MIT licensed.
- Inserted alphabetically (before `artifacts-builder`), matching the existing list format.