### PR TITLE
Add AlphaAI Financial News Skills (Data & Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [AlphaAI Financial News Skills](https://github.com/makeev/alphai-claude-skills) - Five finance workflows over relevance-scored, ticker-linked market news: market pulse, single-stock briefs, SEC Form 4 insider radar, two-ticker read-across, and news-alert management. *By [@makeev](https://github.com/makeev)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
Adds [alphai-claude-skills](https://github.com/makeev/alphai-claude-skills) to **Data & Analysis** — five documented skills for finance workflows on top of the hosted AlphaAI MCP server (`mcp.alphai.io`):

- **market-pulse** — "what's moving right now?" across the tape
- **stock-brief** — situational brief on one ticker (news + SEC Form 4 insider activity + what to watch)
- **insider-radar** — insider buying/selling scan for a ticker or watchlist
- **peer-readacross** — two-ticker comparison / cross-read (e.g. NVDA vs AMD)
- **manage-alerts** — list/add/remove ticker news-alert subscriptions

Real use case: these are the workflows I run daily to follow the market from Claude Code instead of a terminal of browser tabs; each SKILL.md documents when to trigger, which MCP tools to call, and the expected output shape. Tested in Claude Code against the live MCP (OAuth 2.1; free tier — 100 calls/day, no card). Entry placed alphabetically, follows the existing format with attribution.