### PR TITLE
Add docs-only contribution reviewer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Claude Code Terminal Title](https://github.com/bluzername/claude-code-terminal-title) - Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what.
 - [Connect](./connect/) - Connect Claude to any app. Send emails, create issues, post messages, update databases - take real actions across Gmail, Slack, GitHub, Notion, and 1000+ services.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*
+- [Docs-Only Contribution Reviewer](./docs-only-contribution-reviewer/) - Reviews documentation-only PRs for link integrity, content accuracy, and merge readiness.
 - [FFUF Web Fuzzing](https://github.com/jthack/ffuf_claude_skill) - Integrates the ffuf web fuzzer so Claude can run fuzzing tasks and analyze results for vulnerabilities. *By [@jthack](https://github.com/jthack)*
 - [finishing-a-development-branch](https://github.com/obra/superpowers/tree/main/skills/finishing-a-development-branch) - Guides completion of development work by presenting clear options and handling chosen workflow.
 - [Full-Page Screenshot](https://github.com/LewisLiu007/full-page-screenshot) - Captures full-page screenshots of web pages via Chrome DevTools Protocol with zero dependencies. *By [@LewisLiu007](https://github.com/LewisLiu007)*

--- a/docs-only-contribution-reviewer/SKILL.md
+++ b/docs-only-contribution-reviewer/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: docs-only-contribution-reviewer
+description: Validate documentation-only PRs with style checks, cross-link health, terminology consistency, and clear merge criteria.
+---
+
+# Docs-Only Contribution Reviewer
+
+Use this skill for pull requests where only documentation-like files are intended to change.
+
+## When to Use This Skill
+
+- Reviewing edits to `README`, guides, API docs, and changelogs.
+- Enforcing doc quality before release notes or onboarding updates.
+- Catching drift between examples and behavior before merge.
+
+## What This Skill Does
+
+1. Confirms scope is documentation-only.
+2. Checks structure, clarity, and consistency against existing docs patterns.
+3. Verifies examples and references remain valid.
+4. Produces merge-ready status with exact follow-ups.
+
+## Verification Steps
+
+### 1) Scope Safety
+
+- Confirm no source code files changed.
+- Confirm no build or config files changed unless explicitly needed for docs.
+- If non-doc files are touched, return `BLOCK` with re-route to code review flow.
+
+### 2) Style and Structure
+
+- Compare tone and formatting against nearby docs in repo.
+- Verify heading structure is logical and searchable.
+- Check glossary consistency for terms introduced.
+
+### 3) Content Accuracy
+
+- Validate commands against expected shell output syntax.
+- Validate markdown tables, links, and anchor names.
+- Check examples use realistic paths and current package/tool versions.
+
+### 4) Link Integrity
+
+- Spot obvious broken local links:
+  - missing `./` or wrong relative path
+  - wrong case in case-sensitive filesystems
+- Flag any external link requiring access tokens or short-lived sessions.
+
+### 5) Merge Decision
+
+Return:
+
+- `PASS`: documentation-only and coherent
+- `PASS_WITH_NOTES`: stylistic cleanup only
+- `BLOCK`: technical inaccuracies or scope mismatch
+
+Include:
+- changed docs files
+- verification summary
+- link checks
+- required edits before merge
+
+## Extra Rules
+
+- For API docs, include at least one example input/output pair.
+- For workflow docs, include one "what to do next" section.
+- Keep diff small and avoid rewrites without value.
+


### PR DESCRIPTION
## Summary

Adds a skill for reviewing documentation-only contributions.

## Changes

* Adds doc-only scope, style, link, and accuracy checks
* Registers the skill in Development & Code Tools

## Validation

* Frontmatter and README placement checked
* `git diff --check`

## Notes

Kept intentionally small and self-contained.