### PR TITLE
Add korean-marketing-skills (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
+- [Korean Marketing Skills](https://github.com/gugdongbag-eng/korean-marketing-skills) - 9 citation-backed skills for Korean marketing (Naver, Kakao, Baemin, 당근) that pin down local facts general LLMs get wrong, each sourced to law and official docs. *By [@gugdongbag-eng](https://github.com/gugdongbag-eng)*
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 
 ### Communication & Writing


### PR DESCRIPTION
Adds **korean-marketing-skills** — an MIT-licensed pack of 9 Claude Code skills for Korean marketing (Naver, Kakao, Baemin, 당근, 정보통신망법 / Network Act).

Each skill pins down facts that general LLMs commonly get wrong for the Korean market — e.g. night-time ad-messaging rules under the Network Act, or which crawler actually controls AI-search visibility — with every claim sourced to statutes and official vendor docs, and dated with a "verify" note since policies change. Works with Claude Code / Codex / Cursor.

Placed in the **Business & Marketing** section in alphabetical order.

Repo: https://github.com/gugdongbag-eng/korean-marketing-skills
