### PR TITLE
Add web-reverse-engineer skill to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
-- [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 - [web-reverse-engineer](https://github.com/uycung/web-reverse-engineer) - Clean-room SKILL.md workflow that studies a public site's runtime behavior, motion, and interaction, then guides an agent to rebuild an original implementation. Not a clone tool. *By [@uycung](https://github.com/uycung)*
-
+- [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+  
 ### Data & Analysis
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [web-reverse-engineer](https://github.com/uycung/web-reverse-engineer) - Clean-room SKILL.md workflow that studies a public site's runtime behavior, motion, and interaction, then guides an agent to rebuild an original implementation. Not a clone tool. *By [@uycung](https://github.com/uycung)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds web-reverse-engineer, a portable SKILL.md workflow that teaches Claude to study a public site's runtime behavior, motion, and interaction, then rebuild an original clean-room implementation. Not a clone/copy tool — no source, assets, or exact styling is copied.

Repo: https://github.com/uycung/web-reverse-engineer
Live demos: https://web-reverse-engineer.netlify.app/