### PR TITLE
Add fable-mode (reasoning-discipline skill, Spanish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [fable-mode](https://github.com/KevssG/fable-mode) - Reasoning-discipline skill (in Spanish) that makes Opus 4.8 work with Fable 5’s habits: plan gate, scope fence, adversarial self-verification, verify loop, result-first. Validated with blind pairwise tests. *By [@KevssG](https://github.com/KevssG)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
Adds [fable-mode](https://github.com/KevssG/fable-mode) under Productivity & Organization.

Reasoning-discipline skill (in Spanish) that makes Claude Code / Opus 4.8 work with the habits of Fable 5: plan gate, scope fence, adversarial self-verification, verify loop with executable success criteria, result-first delivery, and per-task-type checklists.

Distilled from 5 official Claude/Anthropic videos (quotes verified verbatim against transcripts) and validated with blind pairwise tests on Opus 4.8 (v1.1 won 2-1, rubric 25.0 vs 23.0/30). Landing page documents wins AND losses: https://kevssg.github.io/fable-mode/

🤖 Generated with [Claude Code](https://claude.com/claude-code)