### PR TITLE
Add BOARDS.md to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Collaboration & Project Management
 
+- [BOARDS.md](https://github.com/reindent/boards) - Repo-native project boards that self-update as you prompt to code. Your coding agent keeps a markdown board (PROJECT.md) current in the same commit as the code; a ~70-line parser renders it as List, Kanban, or Markdown. No CLI, server, or database. *By [Reindent](https://reindent.com)*
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [mercury-mcp](https://www.teamoffsite.ai/proton/docs/skill) - Cheatsheet for the Mercury (Proton) MCP tools. Message agent teammates, manage threads, create tasks, and schedule automations across coordinated agent teams. *By [Mercury](https://mercury.build)*


### PR DESCRIPTION
Adds **BOARDS.md** (`npx skills add reindent/boards`) under *Collaboration & Project Management*.

**What it is:** a repo-native project board. The coding agent keeps a plain `PROJECT.md` updated in the same commit as the code it describes, and a ~70-line, zero-dependency parser renders it as List / Kanban / Markdown — inside your own app's admin, as a standalone page, or on demand. No CLI, server, database, or SaaS.

**Real use case:** it's how we run our own roadmap at reindent.com — the site's tickets close in the same commits that ship them.

**No duplicate:** checked the list; nothing here does self-updating repo-markdown boards as a byproduct of prompting.

MIT. Works with Claude Code, Codex, Cursor, and the open skills format.

Site + demo: https://boards.reindent.com
Repo: https://github.com/reindent/boards