### PR TITLE
Add The Fable 5 Blueprint to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [The Fable 5 Blueprint](https://github.com/abdelrahmanelmeligy16-glitch/fable5-blueprint) - Model-agnostic operating doctrine (P0–P7) that makes any AI agent verify its own work instead of hallucinating. One file, paste into Claude/GPT/Gemini.
 
 ### Inspiration & Use Cases
 


### PR DESCRIPTION
Adds **The Fable 5 Blueprint** to Community Resources — a model-agnostic operating doctrine (P0–P7) for AI agents: anti-hallucination, verification, delegation, and cost discipline.

It's not a single skill but the operating *layer* skills run under — it makes agents check their own work instead of hallucinating. MIT-licensed, single file, works across Claude.ai, Claude Code, and the API (and other models).

Repo: https://github.com/abdelrahmanelmeligy16-glitch/fable5-blueprint