### PR TITLE
Add cvnizer to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
+- [cvnizer](https://github.com/slovozaslovo/cvnizer) - Converts CV/resume prose into executive-register wording with deterministic checks and a scored rewrite loop seeded with published-CV samples; strictly wording-only, never changes facts. Works in Claude Code, Codex CLI, and Cursor.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*


### PR DESCRIPTION
Adds [cvnizer](https://github.com/slovozaslovo/cvnizer) to the Communication & Writing section (alphabetical spot after Content Research Writer).

What it is: an agent skill that converts CV/resume prose into executive-register wording — a deterministic checker (word/sentence limits per block type, pronouns, em dashes, fluff/casual wordlists; optional local config) plus a scored convergence loop (Voice, Register, Altitude, Rhythm, Density) seeded with excerpts from professionally written executive CVs and driven by before/after conversion pairs. Strictly wording-only: it never changes facts, names, or numbers, and its README says so prominently.

MIT, self-contained (one Python script, no network calls), installs in Claude Code, Codex CLI, and Cursor.