### PR TITLE
Add TokenLab API Integration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [TokenLab API Integration](https://github.com/hedging8563/tokenlab-skills/tree/main/skills/tokenlab-api-integration) - Build runnable TokenLab API integrations across chat, media, audio, and native endpoint families. *By [@hedging8563](https://github.com/hedging8563)*
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
## Summary\n\nAdds a TokenLab API Integration skill under Development & Code Tools. The skill helps agents build runnable TokenLab API integrations across OpenAI-compatible chat, native Responses, Anthropic Messages, Gemini routes, media, audio, embeddings, rerank, and translation APIs.\n\n## Real-world use case\n\nDevelopers often ask coding agents to wire an app to an AI gateway, pick a model, or recover from model/endpoint errors. This skill gives the agent a concrete TokenLab workflow: use the correct base URL, choose model discovery before hardcoding IDs, inspect public model contracts for non-chat APIs, and use native endpoint hints when the OpenAI-compatible route is not the right contract.\n\n## Source and testing\n\n- Canonical public source: https://github.com/hedging8563/tokenlab-skills/tree/main/skills/tokenlab-api-integration\n- Verified local structure: SKILL.md frontmatter, README entry, and referenced usage notes file.\n- The skill is designed for Claude Code, Codex, Cursor, and other agents that support SKILL.md-style progressive loading.\n\n## Example prompt\n\n`Use TokenLab to add a minimal chat completion example to this Node app, and show when I should switch to native Anthropic Messages or Gemini routes.`