### PR TITLE
Add ViralNote skill (social media posting/scheduling) to Business & M…

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [ViralNote](https://github.com/viralnote/viralnote-skill) - Schedule, publish, and manage social media content across X, Instagram, TikTok, YouTube, LinkedIn, Threads, and more through the ViralNote API. Covers posting, media import, analytics, and connected accounts. *By [@viralnote](https://github.com/viralnote)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds ViralNote to Business & Marketing — an MIT-licensed skill that teaches agents the ViralNote API: create, schedule, and publish posts across X, Instagram, TikTok, YouTube, LinkedIn, Threads, and more, plus media import and analytics.