### PR TITLE
Add deep-security-check (defensive security assessment skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Security & Systems
 
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
+- [deep-security-check](https://github.com/give-jd/deep-security-check) - Defensive read-only security assessment combining Semgrep SAST, osv-scanner SCA, and gitleaks secrets detection into a reproducible 0-100 (A-F) grade. *By [@give-jd](https://github.com/give-jd)*
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.


### PR DESCRIPTION
Adds [deep-security-check](https://github.com/give-jd/deep-security-check) — a defensive, read-only security assessment skill for Claude Code. It runs Semgrep (SAST), osv-scanner (dependency CVEs) and gitleaks (secrets) against a local project and produces a report with a reproducible reliability grade (0-100, A-F) computed by a deterministic rubric, not model opinion.

- MIT licensed, static analysis only, never sends traffic to live targets
- Works standalone without Claude too
- v0.1.0 released: https://github.com/give-jd/deep-security-check/releases/tag/v0.1.0

Entry follows the existing format of the section. Thanks for maintaining the list!