### PR TITLE
Add Maoxuan Product Agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Maoxuan Product Agent](https://github.com/atdy/maoxuan-product-agent) - Chinese product decision skill that diagnoses bottlenecks, stages, constraints, and next actions across 36 product, growth, operations, data, and collaboration scenarios. *By [@atdy](https://github.com/atdy)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## What problem it solves

Product and operations questions often produce broad lists of plausible tactics without identifying which bottleneck matters at the current stage. Maoxuan Product Agent is a Chinese-first decision skill that separates facts from assumptions, identifies the current bottleneck and dominant mechanism, and returns 1-3 concrete next actions plus stop conditions.

## Who uses this workflow

Product managers, product owners, growth and operations teams, founders, and project leads working in Chinese internet-product contexts. It covers 36 recurring scenarios including prioritization, Roadmaps, retention, conversion, community/content operations, metric anomalies, A/B Tests, resource conflicts, delays, and cross-functional alignment.

## Testing and portability

- 36/36 documented product cases pass the repository quality gate
- Four clean-session forward tests were run with Claude Code
- Works with Claude Code, Codex, Cursor, and the open Agent Skills directory format
- MIT licensed, no API key, service, or paid dependency

## Source and example

Repository: https://github.com/atdy/maoxuan-product-agent
Live overview: https://atdy.github.io/maoxuan-product-agent/
Install: `npx skills add atdy/maoxuan-product-agent --skill product-decision-agent`

The reasoning workflow is distilled from complete readings of *On Practice* and *On Contradiction*, but default output deliberately uses modern product language and does not quote source texts, teach history, or perform political role-play.

## Disclosure

I am the author and maintainer of the submitted skill.