### PR TITLE
Add seo-translator (SEO-aware translation skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [seo-translator](https://github.com/Skillproofdev/seo-translator) - SEO-aware translation for localizing sites and content: classifies SEO fields vs marketing vs UI strings, applies per-market registers, protects product names and code, and runs an anti-AI-pattern pass. Ships with a measured 10-language benchmark. *By [@Skillproofdev](https://github.com/Skillproofdev)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [seo-translator](https://github.com/Skillproofdev/seo-translator) under Business & Marketing (alphabetical order kept).

SEO-aware translation for localizing sites and content: per-market registers, protected product names/code, anti-AI-pattern pass; README includes a measured 10-language benchmark.

Disclosure: we're the authors (SkillProof — the tested Claude skills directory).