### PR TITLE
Add WinCreator to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [WinCreator](https://github.com/winterbim/wincreator) - Turns agent-assisted engineering tasks into verification-gated loops with a machine-checkable Proof Ledger, so an agent's "done, tested" is backed by evidence, not assertion. *By [@winterbim](https://github.com/winterbim)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds **WinCreator** to the Development & Code Tools section.

**What problem it solves.** Long agent-assisted engineering sessions
degrade three predictable ways: the same context that wrote the code
grades its own work ("should work" becomes "works"), early constraints
get lost as the session grows, and a failing check gets re-attacked at
the same level forever instead of escalating. WinCreator counters each
one mechanically — a Proof Ledger with Builder/Skeptic role separation, a
re-emitted Loop Panel, and a Two-Failure Rule.

**Who uses this workflow.** Anyone running Claude Code / Codex / Cursor on
non-trivial, multi-step engineering work where truth matters more than
speed — and who has been burned by an agent reporting "done, tested" on
something that wasn't.

**How it's used.** The skill ships a stdlib-only `ledger_check.py` gate
that exits non-zero if any claim is unproven, so "done" is backed by
evidence that was actually executed and inspected. The repository dogfoods
its own doctrine: its `PROOF_LEDGER.md` and green CI badge are the real
proof trail from publishing it, not a demo.

Repo: https://github.com/winterbim/wincreator

One-line addition, alphabetically placed in Development & Code Tools,
matching the existing external-link + attribution format.
