### PR TITLE
Add claude-real-video to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [claude-real-video](https://github.com/HUANGCHIHHUNGLeo/claude-real-video) - Lets Claude actually watch a video: extracts scene-aware, deduplicated keyframes plus a timestamped transcript from a URL or local file, all processed locally. Ships a bundled Claude Code skill. *By [@HUANGCHIHHUNGLeo](https://github.com/HUANGCHIHHUNGLeo)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
## What

Adds [claude-real-video](https://github.com/HUANGCHIHHUNGLeo/claude-real-video) to the Creative & Media section (alphabetical position).

## Why it fits this list

- It solves a real, common problem: Claude (and most LLMs) cannot actually watch a video. This tool extracts scene-aware, deduplicated keyframes + a timestamped transcript from a URL or local file, producing a folder any LLM can read. All processing runs locally.
- Ships a bundled Claude Code skill (`skills/claude-real-video-for-agents/`) with SKILL.md, tested in Claude Code.
- MIT licensed, ~1.4k GitHub stars, reached the Hacker News front page.

Disclosure: I am the author of the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)