### PR TITLE
Add higgsfield-trailer-finishing (Creative & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [higgsfield-trailer-finishing](https://github.com/cindyxu1030/higgsfield-trailer-finishing) - Finish AI-generated clips (Higgsfield or any source) into one video: ffmpeg stitch, cinematic grade, and an original licensed soundtrack matched to the assembled cut via Sonilo video-to-music. *By [@cindyxu1030](https://github.com/cindyxu1030)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
Adds [higgsfield-trailer-finishing](https://github.com/cindyxu1030/higgsfield-trailer-finishing) to Creative & Media: an Agent Skill that finishes AI-generated clips into one delivered video — ffmpeg stitch, cinematic grade, and an original licensed soundtrack matched to the assembled cut (Sonilo video-to-music).

Disclosure: I work on Sonilo, which powers the soundtrack stage (user-supplied API key; stitch/grade/mux work without it).