### PR TITLE
Add Vox Director (Vox-style collage video skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [Vox Director](https://github.com/Alisa0808/vox-director) - Turn one topic into a finished Vox-style paper-collage explainer/ad video (script → collage art → motion → voice-over → music → captions), automated on Atlas Cloud + ffmpeg. *By [@Alisa0808](https://github.com/Alisa0808)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds **Vox Director** under Creative & Media.

Open-source (MIT) agent skill: turns one topic into a finished Vox-style paper-collage explainer/ad video — script, collage keyframes, motion, voice-over, music and captions — automated end to end (Atlas Cloud API + local ffmpeg). Works with Claude Code and any SKILL.md agent.

Repo: https://github.com/Alisa0808/vox-director