### PR TITLE
Add negotiation-coach skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [negotiation-coach](https://github.com/HemanthGangula/negotiation-coach) - Coaches salary, freelance, vendor, and price negotiations by diagnosing your BATNA first, then returning ready-to-send scripts from ten proven tactics. *By [@HemanthGangula](https://github.com/HemanthGangula)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
This pull request adds a new skill to the list in the `README.md` file that coaches users on negotiation strategies. The addition includes a description of the skill and credits its author.

New skill added:

* Added `[negotiation-coach](https://github.com/HemanthGangula/negotiation-coach)` to the list of skills, which coaches users on various negotiation scenarios and provides ready-to-send scripts based on proven tactics. Attribution to the author is included.