### PR TITLE
Add anywrite skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [anywrite](https://github.com/Antheurus/anywrite) - Full-coverage CLI for Anytype's local API (all 52 endpoints of the 2025-11-08 spec) compiled to a single dependency-free binary; wired as a Claude Code skill so an agent drives spaces, objects, properties, tags, files, and chat non-interactively. *By [@Antheurus](https://github.com/Antheurus)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds [anywrite](https://github.com/Antheurus/anywrite) to Development & Code Tools.

- **What problem it solves**: the official Anytype MCP server always loads 52 tools into every session's context whether they're used or not; anywrite is a normal CLI wired as a Claude Code skill instead, so it costs zero context until invoked.
- **Who uses this workflow**: anyone driving Anytype (spaces/objects/properties/tags/types/templates/lists/chat/files/members/search) from an agent session or a terminal.
- **Attribution**: built directly against Anytype's official local API spec (2025-11-08); MIT-licensed, open source.