### PR TITLE
Add AI Presence Auditor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
+- [AI Presence Auditor](https://github.com/OptimizerTeam/agent-skills) - Audits whether ChatGPT, Perplexity, Gemini, and Google AI recommend a local or home-service business, then returns a prioritized list of AEO/GEO fixes. *By [@OptimizerTeam](https://github.com/OptimizerTeam)*
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.


### PR DESCRIPTION
Adds **AI Presence Auditor** to Business & Marketing.

**What it does:** a Claude skill that audits whether AI assistants (ChatGPT, Perplexity, Gemini, Google AI Overviews, Copilot) actually recommend a given local or home-service business when a customer asks for a provider — then returns a prioritized, plain-English list of fixes across listings, reviews, on-page copy, and citations.

**Who it's for:** owners and marketers of US local SMBs (HVAC, plumbing, electrical, and the trades) who want to know whether they show up in AI answers and what to fix first. It's answer-engine / generative-engine optimization (AEO/GEO) applied to local SEO.

**Usage:** `npx skills add OptimizerTeam/agent-skills`, then in Claude: "run the ai-presence-auditor skill for {business} in {city}."

Repo: https://github.com/OptimizerTeam/agent-skills (skill at `skills/ai-presence-auditor`; valid `SKILL.md` + `skills.sh.json` manifest). MIT-licensed, maintained by Optimizer (optimizer.team). No account or API key required to run it.

Placed alphabetically at the top of the section; no duplicate; no emoji.