### PR TITLE
Add pm-trace-eval to Data & Analysis skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [pm-trace-eval](https://github.com/Nyota-tree/pm-trace-eval) - PM-facing AI conversation trace evaluation with user-defined north-star metrics, 1-5 scores, red/yellow/green signals, and per-turn good/bad original quotes. *By [@Nyota-tree](https://github.com/Nyota-tree)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
-- [pm-trace-eval](https://github.com/Nyota-tree/pm-trace-eval) - PM-facing AI conversation trace evaluation with user-defined north-star metrics, 1–5 scores, red/yellow/green signals, and per-turn good/bad original quotes. *By [@Nyota-tree](https://github.com/Nyota-tree)*
 
 ### Business & Marketing
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [pm-trace-eval](https://github.com/Nyota-tree/pm-trace-eval) - PM-facing AI conversation trace evaluation with user-defined north-star metrics, 1–5 scores, red/yellow/green signals, and per-turn good/bad original quotes. *By [@Nyota-tree](https://github.com/Nyota-tree)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds [pm-trace-eval](https://github.com/Nyota-tree/pm-trace-eval) under Data & Analysis - PM-facing conversation trace evaluation with north-star metrics, rubric scores, and per-turn quote review.

Install: `npx skills add Nyota-tree/pm-trace-eval -g -y`