### PR TITLE
Add UIZZE — STOP UI SLOP for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
+- [UIZZE UI Research](https://github.com/aislon/uizze-mcp/tree/main/skills/uizze-ui-research) - Gives coding agents free public iOS and web UI references, with full-access Agent Connector workflows for design contracts, validation, audits, and critiques. *By [UIZZE](https://uizze.com/)*
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
-- [UIZZE — STOP UI SLOP](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Ground Claude Code in 800,000+ real web and iOS screens, lock a product-specific design contract, and force a hard finish gate before generic UI ships. *By [UIZZE](https://uizze.com/)*
+- [UIZZE — STOP UI SLOP](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Ground Claude Code in 800,000+ real web and iOS screens, lock a product-specific design contract, and force a hard finish gate before generic UI ships. *By [UIZZE](https://uizze.com/)*
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
-- [UIZZE UI Research](https://github.com/aislon/uizze-mcp/tree/main/skills/uizze-ui-research) - Gives coding agents free public iOS and web UI references, with full-access Agent Connector workflows for design contracts, validation, audits, and critiques. *By [UIZZE](https://uizze.com/)*
+- [UIZZE — STOP UI SLOP](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Ground Claude Code in 800,000+ real web and iOS screens, lock a product-specific design contract, and force a hard finish gate before generic UI ships. *By [UIZZE](https://uizze.com/)*
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*


### PR DESCRIPTION
## What changed

Adds the canonical free UIZZE `anti-ui-slop` skill to Creative & Media.

## Why

**STOP UI SLOP.** The skill grounds Claude Code in 800,000+ real web and iOS screens, turns the evidence into a product-specific design contract, and forces a hard finish gate before generic UI ships. The optional full UIZZE MCP adds live search, validation, audits, and screenshot critique.

## Validation

- canonical skill and product URLs verified
- one README entry only
- `git diff --check` passes

## Affiliation

I am affiliated with UIZZE and am submitting its official skill.