### PR TITLE
Add Design Counsel to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [Design Counsel](https://github.com/Aakreit/design-counsel) - Evidence-grounded product design and UX review for screenshots, Figma frames, specs, and implementations — prioritized findings with severity anchors, state-matrix coverage, accessibility checks, and a sourced design-knowledge wiki. Works in Claude Code and Codex. *By [@Aakreit](https://github.com/Aakreit)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
## What skill does this add?

**[Design Counsel](https://github.com/Aakreit/design-counsel)** — an evidence-grounded product design & UX review skill for Claude Code and Codex.

## Why it belongs here

- **Real use case:** built and used daily for production design review at an enterprise SaaS company; every doctrine rule traces to a logged miss, a standards update, or a documented capability change.
- **Well-documented:** SKILL.md routes to 12 on-demand reference files; a 37-page sourced wiki (WCAG 2.2, DTCG, Material 3, Google PAIR, ~44 primary sources) backs every prescription.
- **Tested:** ships a regression harness — 7 semantic fixtures and 22 gate-validated result records from grader-blind baseline-vs-candidate runs, plus a public miss log.
- **Safe:** guardrails are fixture-tested — conflicting local instructions are disclosed and refused, secrets are never written to calibration, severity inflation is explicitly countered.
- **Portable:** one folder works in Claude Code (plugin or agent) and Codex (skills directory); AGENTS.md covers other harnesses.

No duplicate found in the list — existing design entries generate or extract designs; this one reviews them with evidence discipline.