### PR TITLE
Add AgentHook skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Creative & Media
 
+- [AgentHook](https://github.com/AvivK5498/agenthook) - Make character-consistent UGC videos: create a reusable AI influencer once, then reuse the same face across video, image, and caption generation. Install with `npx skills add AvivK5498/agenthook`. *By [@AvivK5498](https://github.com/AvivK5498)*
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
Adds [AgentHook](https://github.com/AvivK5498/agenthook) under Creative & Media. It lets an agent make character-consistent UGC video: create a reusable AI influencer once, then reuse the same face across video, image, and caption generation. Install with `npx skills add AvivK5498/agenthook`.

Follows the external-skill format (repo link + `*By [@handle]*`, no folder, no emojis), placed alphabetically at the top of Creative & Media.