### PR TITLE
Add claude-video-plus skill to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [claude-video-plus](https://github.com/abe238/claude-video-plus) - Ask a video a question: retrieves only the chapters, numeric facts, and on-screen moments that answer it instead of sampling the whole timeline. *By [@abe238](https://github.com/abe238)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
Adds **claude-video-plus** to **Creative & Media** (one line, alphabetically placed after Canvas Design).

**What it does:** you ask a video a question and it retrieves only the chapters, numeric facts, and on-screen moments that answer it, instead of sampling the whole timeline.

**Install (universal):**
```
npx skills add abe238/claude-video-plus -g
```
Claude Code plugin: `/plugin marketplace add abe238/claude-video-plus` then `/plugin install watch@claude-video-plus` (slash command `/watch`).

**Why it meets the bar:** per the skill's own sealed, receipt-gated benchmark, it matched the original pipeline's blind-judged answer quality (8.83 vs 8.80) at roughly 56% fewer tokens, and ships 338 deterministic tests. It fails open, reverting to the original pipeline on no captions, a local file, a short video, or any error, so it never degrades the baseline.

**Attribution:** it is an attributed MIT fork of [bradautomates/claude-video](https://github.com/bradautomates/claude-video), with upstream authorship preserved.

Entry follows the existing format (link to GitHub, one-sentence description, `*By [@abe238]*`), no emojis, no TOC change (Creative & Media already listed in Contents).
