### PR TITLE
Add Relay skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
+- - [Relay](https://github.com/mosuvo/relay) - Captures a full Claude chat into one portable briefing you paste into a fresh chat to continue without losing context. Chat-native and domain-adaptive. *By [@mosuvo](https://github.com/mosuvo)*
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
-- - [Relay](https://github.com/mosuvo/relay) - Captures a full Claude chat into one portable briefing you paste into a fresh chat to continue without losing context. Chat-native and domain-adaptive. *By [@mosuvo](https://github.com/mosuvo)*
+- [Relay](https://github.com/mosuvo/relay) - Captures a full Claude chat into one portable briefing you paste into a fresh chat to continue without losing context. Chat-native and domain-adaptive. *By [@mosuvo](https://github.com/mosuvo)*
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.


### PR DESCRIPTION
What problem it solves: Long Claude chats degrade and lose context; starting a fresh chat means re-explaining everything. Relay captures the whole chat into one paste-block to continue seamlessly.

Who uses this workflow: Anyone who hits long, complex Claude chats — the skill adapts to coding, writing, research, design, etc.

Attribution/inspiration: Original skill; studied ~8 existing handoff tools, built chat-native (most others are Claude Code–only).

Example of use: Say "relay" in a long chat → it prints a portable briefing → paste into a new chat to continue.