### PR TITLE
Add ai-shortfilm-prompts to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [ai-shortfilm-prompts](https://github.com/jnMetaCode/ai-shortfilm-prompts) - Turns any idea into a cinematic, model-ready video prompt for Sora/Kling/Veo/Seedance using a 5-stage structure distilled from a 13M-view AI short film; 21 genre templates + eval suite. *By [@jnMetaCode](https://github.com/jnMetaCode)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds a skill that turns a scene idea into a cinematic, model-ready video prompt for Sora / Kling / Veo / Seedance 2.0.

- 5-stage prompt structure (core theme → character/scene → atmosphere → camera rules → per-shot storyboard) distilled from Mx-Shell's *Zombie Scavenger*, the AI short Hollywood director PJ Ace called "one of the best short films I've seen in years" (13.4M views)
- 21 genre templates (transformation, sci-fi, product ad, pet/family narrative, found-footage horror, etc.)
- Ships with an eval suite (`evals/` + CI) and IP-name safety handling for platforms like Seedance that reject named IP
- MIT licensed, bilingual (EN/中文) docs

Repo: https://github.com/jnMetaCode/ai-shortfilm-prompts