### PR TITLE
Add Apify LinkedIn Posts skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [apify-linkedin-posts-scraper](https://github.com/johnisanerd/claude-skill-linkedin-posts-scraper) - Scrape public LinkedIn posts into structured JSON via the Apify LinkedIn Posts API. *By [@johnisanerd](https://github.com/johnisanerd)*
+- [apify-linkedin-post-engagement](https://github.com/johnisanerd/claude-skill-linkedin-post-engagement) - Analyze LinkedIn post engagement (reactions, comments, shares) via the Apify LinkedIn Posts API. *By [@johnisanerd](https://github.com/johnisanerd)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
-- [apify-linkedin-posts-scraper](https://github.com/johnisanerd/claude-skill-linkedin-posts-scraper) - Scrape public LinkedIn posts into structured JSON via the Apify LinkedIn Posts API. *By [@johnisanerd](https://github.com/johnisanerd)*
 - [apify-linkedin-post-engagement](https://github.com/johnisanerd/claude-skill-linkedin-post-engagement) - Analyze LinkedIn post engagement (reactions, comments, shares) via the Apify LinkedIn Posts API. *By [@johnisanerd](https://github.com/johnisanerd)*
+- [apify-linkedin-posts-scraper](https://github.com/johnisanerd/claude-skill-linkedin-posts-scraper) - Scrape public LinkedIn posts into structured JSON via the Apify LinkedIn Posts API. *By [@johnisanerd](https://github.com/johnisanerd)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
Two agent skills for the Apify LinkedIn Posts API: apify-linkedin-posts-scraper (scrape posts to JSON) and apify-linkedin-post-engagement (analyze engagement). Public repos with working SKILL.md files, added under Data & Analysis.