### PR TITLE
Add ticketly to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
+- [ticketly](https://github.com/Shreyas0786/ticketly) - Turn a project spec or an existing codebase into a structured backlog: epics broken into tickets with acceptance criteria, effort estimates, and dependencies. Exports to Markdown, CSV, and Notion. *By [@Shreyas0786](https://github.com/Shreyas0786)*
 
 ### Security & Systems
 


### PR DESCRIPTION
Adds Ticketly to the Collaboration & Project Management section (link-only entry, alphabetical position, skill lives in its own repo).

Ticketly turns a project spec — or an existing codebase — into a structured backlog: epics broken into tickets, each with acceptance criteria, an effort estimate, and dependencies. Exports to Markdown, CSV, and Notion.

- Repo: https://github.com/Shreyas0786/ticketly
- Package: https://pypi.org/project/ticketly/ — [![PyPI downloads](https://static.pepy.tech/badge/ticketly)](https://pepy.tech/project/ticketly)
- Ships a SKILL.md; works in Claude Code and Codex, on the user's existing subscription (no API key).
- Runs locally, no network calls, and confirms before deleting anything it generated.

Real use case: planning a backlog without hand-writing tickets, and picking up existing repos by planning the work that's left rather than starting from a blank page.