### PR TITLE
Add idea-hunt skill (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [idea-hunt](https://github.com/ANVEAI/idea-hunt-skill) - Evidence-first AI business idea discovery and validation: finds a painful, already-paid-for workflow AI can replace, then proves real willingness-to-pay before you build. Runs a 7-stage pipeline with kill-gates, the Mom Test, and a proof-of-wallet gate. *By [@ANVEAI](https://github.com/ANVEAI)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
### Adding: idea-hunt

**Repo:** https://github.com/ANVEAI/idea-hunt-skill · MIT · single self-contained `SKILL.md`, no API key or paid dependency.

**Category:** Business & Marketing (alphabetical placement between *Domain Name Brainstormer* and *Internal Comms*).

**What it does:** An evidence-first method for finding and validating AI business ideas. Instead of inventing an idea from a blank page, it hunts for an existing, already-paid-for workflow AI can now do as *completed work*, then runs a 7-stage pipeline — pain mining → kill-gates → the Mom Test → a proof-of-wallet test — so weak ideas die on paper before any build.

Checklist:
- [x] Actively maintained, clear documentation (README + FAQ)
- [x] No commercial-API/paid-subscription requirement to function
- [x] Real value to Claude / Claude Code users
- [x] One-sentence description, capitalized, ending with a period