### PR TITLE
Add GTM Engine to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [GTM Engine](https://github.com/himanshusaleria/gtm-engine) - Turns Claude Code into a founder's sales team with 8 slash-command skills for pipeline tracking, daily rituals, call analysis, lead scoring, and cold outreach. *By [@himanshusaleria](https://github.com/himanshusaleria)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
## What this adds

[GTM Engine](https://github.com/himanshusaleria/gtm-engine) — a suite of 8 slash-command skills that run a founder's sales workflow in Claude Code: pipeline tracking (Linear as CRM), daily briefing/wrap-up rituals, call transcript analysis, lead scoring against an ICP, and signal-based cold outreach. Backed by 15 sales frameworks the skills actively apply.

## What to expect

- **Real use case:** I built this to run my own company's GTM motion (QAbyAI) and used it daily for months before open-sourcing it — it's not hypothetical.
- **Tested:** All 8 skills in daily production use; installable via the manual copy method or as a Claude Code plugin (`/plugin marketplace add himanshusaleria/gtm-engine`).
- **Well-documented:** Full README with per-skill usage, setup guide, framework guide, and a config wizard (`/setup`). MIT licensed.
- **No duplicate:** Checked the list — no existing sales/GTM skill suite.
- Entry placed alphabetically in *Business & Marketing*, formatted to match the existing external-repo entries (author credit suffix).