### PR TITLE
Add BOSS Zhipin JD Scraper to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [BOSS Zhipin JD Scraper](https://github.com/HeyClioo/boss-zhipin-jd-scraper) - Scrapes full job descriptions from BOSS Zhipin (zhipin.com) via a real logged-in browser: bypasses anti-bot verification, strips watermark noise, dedupes by job ID, and exports Markdown. *By [@HeyClioo](https://github.com/HeyClioo)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds a new skill under **Data & Analysis**:

- **[BOSS Zhipin JD Scraper](https://github.com/HeyClioo/boss-zhipin-jd-scraper)** — scrapes full job descriptions (responsibilities & requirements) from BOSS Zhipin (zhipin.com) via a **real, logged-in browser** (not headless), so it clears the anti-bot verification that blocks headless scrapers. Strips hidden `display:none` watermark words, de-duplicates by `encryptJobId`, and exports clean Markdown.

**Real use case**: collecting job-description data for job-seeking and recruitment research on China's BOSS Zhipin.
**Docs**: bilingual README (EN + zh-CN) + SKILL.md, works with Claude Code / Codex / WorkBuddy.
Link verified (200), added to the end of the Data & Analysis section in existing format.