### PR TITLE
docs: add CRE Agent Skills to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [CRE Agent Skills](https://github.com/sasha-deneux/claude-skills-cre) - 10 commercial-real-estate skills (deal screening, underwriting, rent-roll normalization, off-market sourcing, feasibility, zoning, permits, due diligence, LP reporting). Spec-compliant SKILL.md frontmatter (validated: name to directory match, descriptions under 1024 chars); portable across Claude Code, the API, and claude.ai; no external dependencies. *By [@sasha-deneux](https://github.com/sasha-deneux)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds a set of 10 real-estate (CRE) Agent Skills: deal screening, underwriting, rent-roll/T-12 normalization, off-market sourcing, developer feasibility, zoning/entitlement decoding, permit monitoring, due-diligence tracking, and LP reporting. Each is a directory with a SKILL.md that conforms to the Anthropic Agent Skills spec (agentskills.io): required `name` (lowercase-hyphen, <=64 chars, matches the parent dir) and `description` (<=1024 chars); optional `version` + `metadata.author` per spec; no XML, no scripts, no network/package deps. Validated: frontmatter parses, name to directory match, every description well under the 1024-char limit. Portable across Claude Code (`.claude/skills/`), the API (zip/Files upload), and claude.ai custom skills.

Added as a link bullet under Data & Analysis, matching the section format (hyphen separator + `*By [@handle]*` attribution).
