### PR TITLE
Add Vanara to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [Vanara](https://github.com/vanara-agents/skills) - Catalog of 206 agents, skills, and packs for Claude Code, installed with `npx vanara install <name>`; 29 items are free and open source. *By [@Jay2597](https://github.com/Jay2597)*
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis


### PR DESCRIPTION
Vanara is a catalog of 206 agents, skills, and packs for Claude Code, installed via `npx vanara install <name>` (npm package `vanara`); 29 items are free and open source (Apache-2.0). Used for one-command setup of curated, verification-checked agent/skill bundles in Claude Code projects. Entry follows the section's format and alphabetical order.