### PR TITLE
Add website-seo-audit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [website-seo-audit](https://github.com/zxhydfzr/website-seo-audit) - Crawls any website and grades its SEO across on-page, technical, and JSON-LD structured-data checks with zero dependencies; runs as a CLI or an AI agent skill. *By [@zxhydfzr](https://github.com/zxhydfzr)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
### What it is
[website-seo-audit](https://github.com/zxhydfzr/website-seo-audit) — a zero-dependency (Python stdlib only) SEO auditor that crawls a website and returns a graded report across **on-page**, **technical**, and **JSON-LD / Schema.org structured-data** checks. No API keys, no sign-up. Ships a `SKILL.md`, so any agent supporting the open Agent Skills format (Claude Code, Codex, opencode) can run it: just say "audit the SEO of https://example.com".

### Problem it solves
Most quick SEO checkers stop at titles and headings. This one also validates the structured data that search and AI answer engines rely on to understand and cite pages — and runs anywhere Python does (laptop, CI, locked-down server) with zero install.

### Where I added it
Alphabetical position at the end of **Development & Code Tools** (after "Webapp Testing"), with `*By [@zxhydfzr]*` attribution, following the existing entry format. Checked for duplicates first; edited only README.md; one skill in this PR.