### PR TITLE
Add local-marketing to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
-- [local-marketing](https://github.com/navig-me/local-marketing) - Local-only, agent-agnostic customer-acquisition system: ICP interview, market research, SQLite prospect CRM, and drafted outreach sequences that require human approval (file-move from `pending_review/` to `approved/`) before anything sends over SMTP. *By [@navig-me](https://github.com/navig-me)*
+- [local-marketing](https://github.com/navig-me/local-marketing) - Local-only marketing skill for ICP research and human-approved outreach sequences, with no hosted CRM.
 
 ### Communication & Writing
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [local-marketing](https://github.com/navig-me/local-marketing) - Local-only, agent-agnostic customer-acquisition system: ICP interview, market research, SQLite prospect CRM, and drafted outreach sequences that require human approval (file-move from `pending_review/` to `approved/`) before anything sends over SMTP. *By [@navig-me](https://github.com/navig-me)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [local-marketing](https://github.com/navig-me/local-marketing), a local-only, agent-agnostic Claude Code skill for customer-acquisition outreach: ICP interview, market research, SQLite prospect CRM, and file-approved outreach sequences (`pending_review/` → `approved/`) over SMTP — no hosted CRM, no cloud database.

- Works with Claude Code natively; agent-agnostic core also usable by other headless CLI agents.
- Published on npm as `@navig-me/local-marketing`, MIT licensed.