### PR TITLE
Add Sonar ASO to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Sonar ASO](https://github.com/trysonar/skills) - App Store Optimization skill for AI agents — keyword difficulty and popularity scores, ASO audits, review mining, and revenue estimates for iOS App Store and Google Play apps. *By [@trysonar](https://github.com/trysonar)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [Sonar ASO](https://github.com/trysonar/skills) to the Business & Marketing section (alphabetical position).

Sonar ASO is an App Store Optimization skill for AI agents: keyword difficulty and popularity scores, ASO audits, review mining, and revenue estimates for iOS App Store and Google Play apps. It's in active use with Claude Code and other Agent Skills-compatible tools, backed by the Sonar API ([docs](https://trysonar.app/docs)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)