### PR TITLE
Add sshepherd skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
+- [sshepherd](https://github.com/Antheurus/sshepherd) - Zero-knowledge SSH ops CLI wired as a Claude Code skill; drives server health checks, docker/systemd control, log tailing, read-only Postgres introspection, and declarative deploys without the agent ever seeing a password, key, host, user, or port. *By [@Antheurus](https://github.com/Antheurus)*
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 
 ### Assistive Technology


### PR DESCRIPTION
Adds [sshepherd](https://github.com/Antheurus/sshepherd) to Security & Systems.

- **What problem it solves**: an agent driving real infrastructure normally ends up holding credentials it has no business seeing (host, user, private key, password all sitting in its context and tool-call log), or gets handed raw unstructured remote output it must parse ad hoc every time. sshepherd's answer is a one-transport core plus a one-envelope contract: every op shells out to the system `ssh` binary through a single execution path, and every response comes back as the same typed envelope, never a raw terminal dump. The agent only ever passes a *name* — an ssh alias, a Postgres target, or a deploy recipe — that resolves entirely outside the process; there is no host/user/port/ip field anywhere in the response shape, structurally.
- **Who uses this workflow**: developers and AI agents that need safe remote server operations — health checks, docker/systemd control, log tailing, read-only Postgres introspection, config edits, and declarative TOML deploys — without ever exposing credentials.
- **Real tool, not hypothetical**: it's a compiled Bun/TypeScript CLI (`bun build --compile`, single binary) covering 9 registry-driven command groups / 52 ops, MIT-licensed, with CI, a live E2E smoke suite against a disposable sshd + Postgres fixture, and build-provenance attestations on each release.

Follows the existing convention in this list (single README line linking the source repo, alphabetically ordered within the category, `*By [@Antheurus]*` attribution), matching the sibling anywrite entry in #1298.