### PR TITLE
Add life-log skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
+- [life-log](https://github.com/yuki4266/life-log) - Talk to Claude like a friend; it auto-classifies, timestamps, and files each note into local markdown categories, with suggestions.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.


### PR DESCRIPTION
Adds **life-log** to Skills → Productivity & Organization (alphabetically, between `kaizen` and `n8n-skills`).

**What it is:** a local-first Claude Code plugin for journaling. You talk to Claude like a friend — a complaint or a quick note — and it auto-classifies, timestamps, and files each message into dated markdown category notes (work, health, mood, money, ideas, …), then replies with a suggestion. A `UserPromptSubmit` safety-net hook mirrors every raw message so nothing is ever lost. No cloud, no account, no telemetry. MIT-licensed.

Repo: https://github.com/yuki4266/life-log

- [x] Single entry, one line
- [x] Added in the correct category, in alphabetical order
- [x] Link tested; description is concise and non-promotional

🤖 Generated with [Claude Code](https://claude.com/claude-code)