### PR TITLE
Add goose-skills to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [goose-skills](https://github.com/gooseworks-ai/goose-skills) - Growth and GTM skill library with 125 skills across ads, content, lead generation, outreach, competitive intelligence, monitoring, research, and SEO. Works with Claude Code, Codex, and Cursor; installable via CLI. *By [@gooseworks-ai](https://github.com/gooseworks-ai)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
Adds [goose-skills](https://github.com/gooseworks-ai/goose-skills) to the **Business & Marketing** section (alphabetical position).

**What it is:** an open-source (MIT) library of 125 growth/GTM skills — ads, content, lead generation, outreach, competitive intelligence, monitoring, research, and SEO — for Claude Code, Codex, and Cursor, installable via CLI with a skills index and per-skill metadata.

**Checklist per contributing guidelines:**
- Real use case: 1k+ stars, used in production GTM workflows
- No duplicate: closest existing entry is Brand Build Skills, which covers the website lifecycle; goose-skills covers the GTM/growth motion
- Single entry, single commit, branched from current upstream main
- MIT licensed

— Himanshu Bamoria, co-founder @ [GooseWorks](https://gooseworks.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)