### PR TITLE
Add Modellix skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Modellix](https://github.com/Modellix/modellix-plugin/tree/main/skills/modellix) - Generate images and videos via Modellix's unified model API and CLI. *By [Modellix](https://modellix.ai)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
## Summary
Add Modellix under Creative & Media.

**Problem it solves:** Agents need a reliable way to generate and edit images/videos through a unified model API without hand-rolling async polling.

**Who uses this:** Developers and creators using Claude/Cursor agents for media generation workflows.

**Source:** https://github.com/Modellix/modellix-skill/tree/main/modellix-skill

**Example usage:** Ask the agent to generate an image or short video; the skill uses `modellix-cli model run --wait` and `task download` (or REST fallback).

Made with [Cursor](https://cursor.com)