### PR TITLE
Add WSL ML Setup skill — troubleshoot ML inference environments on Windows+WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [WSL ML Setup](https://github.com/ball-out-of-tune/claude-code-skill-wsl-ml-setup) - Diagnose and fix ML inference environment issues on Windows+WSL: Python version, CUDA mismatch, flash-attn compilation, triton, pip mirrors, and 10 common pitfalls. Battle-tested with nano-vllm + Qwen3. *By [@ball-out-of-tune](https://github.com/ball-out-of-tune)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds wsl-ml-setup — a Claude Code skill that diagnoses and fixes the 10 most common pitfalls when setting up ML inference on Windows+WSL. Battle-tested with nano-vllm + Qwen3-0.6B. Covers Python version, CUDA matching, flash-attn, triton, pip mirrors, and more.