### PR TITLE
Add HyperShots — App Store screenshot skill (Creative & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [HyperShots](https://github.com/hypersocialinc/hypershots) - Generates App Store screenshots perfect to Apple's specs: agent-authored HTML panels rendered at exact store dimensions with a fail-closed validator (dims/alpha/ICC/count/8MB), one-pass localization with auto-fit headlines, optional AI sticker art and spec-preserving style passes, and fastlane submission. *By [@Selcukatli](https://github.com/Selcukatli)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
Adds [HyperShots](https://github.com/hypersocialinc/hypershots) (MIT) to Creative & Media, alphabetical order.

Real use case per the contributing guide: extracted from shipping a real app's App Store listing (image-model screenshots kept getting rejected for spec violations). Two production apps have shipped sets through it; live gallery at https://hypershots.dev. Works in Claude Code and Codex (`npx skills add hypersocialinc/hypershots`), documented with runbooks for create/revise/translate/style/submit, 17-test CI suite.