### PR TITLE
Add skill: dundas/thinkrun (ThinkRun Browser Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [ThinkRun Browser Skills](https://github.com/dundas/thinkrun) - Drive a real Chrome (your logged-in session, via extension + native host) or an isolated cloud browser: navigate, interact, extract, screenshot, plus a structured UX-audit workflow. CLI and MCP interfaces; ships reproducible cross-model trigger evals (fixtures + harness + benchmarks in-repo). *By [@dundas](https://github.com/dundas)*
 
 ### Data & Analysis
 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [ThinkRun Browser Skills](https://github.com/dundas/thinkrun) - Drive a real Chrome (your logged-in session, via extension + native host) or an isolated cloud browser: navigate, interact, extract, screenshot, plus a structured UX-audit workflow. CLI and MCP interfaces; ships reproducible cross-model trigger evals (fixtures + harness + benchmarks in-repo). *By [@dundas](https://github.com/dundas)*
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
-- [ThinkRun Browser Skills](https://github.com/dundas/thinkrun) - Drive a real Chrome (your logged-in session, via extension + native host) or an isolated cloud browser: navigate, interact, extract, screenshot, plus a structured UX-audit workflow. CLI and MCP interfaces; ships reproducible cross-model trigger evals (fixtures + harness + benchmarks in-repo). *By [@dundas](https://github.com/dundas)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds ThinkRun's browser skill pack to Development & Code Tools.

**What it is:** Four portable skills (web-browse, ux-audit, thinkbrowse-cli, thinkbrowse-mcp) for driving a real Chrome — the user's actual logged-in session via extension + native host — or an isolated cloud browser. Covers navigate/interact/extract/screenshot plus a structured UX-audit workflow. Works via CLI and MCP; skill mirrors ship for Claude Code, Codex, Cursor, and Gemini CLI.

**Meets the requirements:**
- Real use case: these are the skills we run daily for UX audits and live-site verification on our own product.
- Documented: each skill has SKILL.md + references; repo README covers install (npx @thinkrun/mcp / npm i -g @thinkrun/cli).
- Tested: reproducible trigger-eval fixtures + harness + published benchmarks in-repo (evals/BENCHMARK.md — 37 runs across 12 model configs incl. GPT and Claude families).
- Safe: local mode operates only on an explicitly attached tab; simple fetches are explicitly out of scope (deferred to WebFetch).
- MIT licensed.