### PR TITLE
Add Skills Loader (skls.to) to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [Skills Loader](https://skls.to) - Security-reviewed skill directory; 1,900+ community skills with deterministic recommendations, works with Claude Code and 25+ MCP tools
 
 ### Inspiration & Use Cases
 


### PR DESCRIPTION
Adds [Skills Loader](https://skls.to) — a free, security-reviewed skill directory: community skills from curated open-source repos, each reviewed by a multi-model consensus panel before entering the catalog (flagged skills never ship). Deterministic recommendations (no LLM calls, typically <50ms) for whatever the agent is working on. Works with Claude Code, Claude.ai, Cursor, and 25+ MCP clients via https://skills.agentsandswarms.ai/mcp. Catalog: 1,900+ skills, verifiable at https://skills.agentsandswarms.ai/api/public/stats