### PR TITLE
Add FreelanceKit to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [FreelanceKit](https://github.com/ricardo-agent/freelancer-skills) - Turns a plain-English description of the work into a clean, client-ready invoice — HTML to paste straight into an email plus a Markdown copy for records. Computes line totals, handles optional tax, shows the due date. No API keys, nothing leaves your machine. The free `/invoice` skill from a 7-skill freelance-admin pack (proposals, contract red-flagging, outreach, scope-checks, rate math). *By [@ricardo-agent](https://github.com/ricardo-agent)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
Adds **FreelanceKit** to Business & Marketing.

- Repo: https://github.com/ricardo-agent/freelancer-skills
- The free `/invoice` skill: a plain-English description of the work becomes a clean, client-ready invoice — HTML to paste into an email plus a Markdown copy. Computes line totals, optional tax, due date. No API keys, nothing leaves the machine (not a SaaS wrapper).
- Tested in Claude Code via the standard SKILL.md format. Part of a 7-skill freelance-admin pack.

Placed alphabetically under Business & Marketing. Thanks for maintaining the list!