### PR TITLE
Add ambient-claude to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [ambient-claude](https://github.com/chriswangcq/ambient-claude) - Connects a live Claude Code session to Telegram, WeChat, or Discord so it can message you proactively. Tiny zero-dependency skill that reuses your existing Claude Code subscription, no extra API key. *By [@chriswangcq](https://github.com/chriswangcq)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
Adds [ambient-claude](https://github.com/chriswangcq/ambient-claude) — a tiny zero-dependency Claude Code skill that connects a live session to Telegram, WeChat, or Discord so Claude can message you proactively (ambient agent), reusing your existing Claude Code subscription with no extra API key.

Built from a real daily workflow (I run it as my personal ambient assistant over Telegram and WeChat). MIT licensed, follows the standard SKILL.md format. Added as an external link in alphabetical order under Productivity & Organization, matching the existing entry style.