### PR TITLE
Add agentbroker to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [agentbroker](https://github.com/antonorlov888/agentbroker) - Free MIT-licensed skill giving any AI agent a self-custodial USDC wallet on Base (x402 payments), the ability to hire other agents under a negotiation + milestone protocol, and cryptographically-signed reputation. Zero infrastructure. *By [@antonorlov888](https://github.com/antonorlov888)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds [agentbroker](https://github.com/antonorlov888/agentbroker) — a free, MIT-licensed Claude skill (single SKILL.md) that teaches an agent to hold its own self-custodial USDC wallet on Base, get paid / pay via x402, hire other agents under a negotiation + milestone protocol, and build reputation from cryptographically-signed reference letters, with zero infrastructure. Follows the list format (name, link, one-line description, attribution), no emojis, real and tested use case. Disclosure: I'm the author.