### PR TITLE
Add character-card-skills (roleplay character card authoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
+- [character-card-skills](https://github.com/foreverse-app/character-card-skills) - Roleplay character card authoring: 47 genre playbooks, five opening paradigms, a rule-based AI-flavor detector with gold regression, plus a chat-quality triage skill with per-model symptom profiles. Cards export to SillyTavern-ready v2 JSON / v3 PNG. *By [@foreverseapp](https://github.com/foreverseapp)*
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
@@ -184,7 +185,6 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
-- [character-card-skills](https://github.com/foreverse-app/character-card-skills) - Roleplay character card authoring: 47 genre playbooks, five opening paradigms, a rule-based AI-flavor detector with gold regression, plus a chat-quality triage skill with per-model symptom profiles. Cards export to SillyTavern-ready v2 JSON / v3 PNG. *By [@foreverseapp](https://github.com/foreverseapp)*
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
+- [character-card-skills](https://github.com/foreverse-app/character-card-skills) - Roleplay character card authoring: 47 genre playbooks, five opening paradigms, a rule-based AI-flavor detector with gold regression, plus a chat-quality triage skill with per-model symptom profiles. Cards export to SillyTavern-ready v2 JSON / v3 PNG. *By [@foreverseapp](https://github.com/foreverseapp)*
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
 


### PR DESCRIPTION
Adds **character-card-skills** to Communication & Writing.

What it is: two SKILL.md-convention skills for roleplay character card authors — `character-card-author` (four-axis positioning, 47 genre playbooks, five opening-message paradigms, prose discipline with hard sentence-pattern quotas) and `chat-quality-doctor` (symptom-to-fix triage with 8 per-model RP profiles). Ships with 15 original cards (each as card.md + chara_card_v2 JSON + v3 PNG), a rule-based AI-flavor detector whose gold set is public, and a zero-dependency converter. CI re-scores every card on each commit.

Checklist against your contribution guidelines:
- Real use case: this is the production authoring pipeline behind our app's built-in agent; the three English cards in the repo were written by the skill itself
- No duplicate: searched the list, no existing character-card authoring skill
- Structure: standard SKILL.md frontmatter + progressive disclosure (genres/ and styles/ loaded on demand)
- Tested in Claude Code, Cursor and Codex (folder-copy install)

Licensing: code MIT, skills/cards/docs CC BY 4.0. Disclosure: we build Foreverse, the repo is standalone and works without it.
