### PR TITLE
Add PMM Skill Stack (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [PMM Skill Stack](https://www.cmoconfessions.com/skills) - Four free, MIT-licensed skills for product marketers: impact-first case studies with a built-in claims audit, audience-correct release notes, buyer-criteria extraction from raw sales-call transcripts (Gong/Chorus/Zoom), and deal-specific competitive positioning tables. Each ships with worked examples and a packaged `.skill` file. *By [@msdanyg](https://github.com/msdanyg)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds the **PMM Skill Stack** — four free, MIT-licensed Claude Skills for product marketers, published at [cmoconfessions.com/skills](https://www.cmoconfessions.com/skills):

- [case-study-skill](https://github.com/msdanyg/case-study-skill) — impact-first customer case studies with a built-in claims-audit table
- [release-notes-skill](https://github.com/msdanyg/release-notes-skill) — audience-correct release notes from raw engineering notes
- [buyer-criteria-skill](https://github.com/msdanyg/buyer-criteria-skill) — buyer evaluation criteria extracted from raw call transcripts
- [positioning-table-skill](https://github.com/msdanyg/positioning-table-skill) — deal-specific competitive positioning tables

Each repo includes a worked example, a packaged `.skill` file for claude.ai upload, and an MIT license. Entry follows the existing format and alphabetical placement in **Business & Marketing**.