### PR TITLE
Add zero-sugar to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [zero-sugar](https://github.com/edward-sh88/zero-sugar) - Honesty mode: damage-ranked findings, evidence per criticism, calibrated confidence, no politeness padding. Trigger-tested with independently verified before/after examples. *By [@edward-sh88](https://github.com/edward-sh88)*
 
 ### Creative & Media
 


### PR DESCRIPTION
Adds [zero-sugar](https://github.com/edward-sh88/zero-sugar) — an honesty mode for Claude: damage-ranked findings, evidence per criticism, calibrated confidence, no politeness padding.

Against the contribution criteria:
- **Real use case:** born from a real daily ritual (demanding "1000% honesty" on plans and work) — used daily by its author before publishing.
- **Documented + examples:** the repo ships three unedited before/after example runs; every factual claim in the examples was independently re-run and reproduced before publishing.
- **Tested:** trigger description validated on a 20-query eval set (10 must-trigger / 10 near-miss): 20/20, zero over-triggering. Works in Claude Code (folder install) and claude.ai (.skill upload in the v1.0.0 release).
- **Safe / portable:** single SKILL.md, no scripts, no destructive operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)