### PR TITLE
Add SMB Acquisition Due Diligence skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [SMB Acquisition Due Diligence](https://github.com/bigjoecoding/smb-acquisition-diligence) - Normalizes seller's discretionary earnings from real financials, sanity-checks asking prices against valuation ranges, flags deal red flags, and runs a phased due-diligence checklist for small-business acquisitions. *By [@bigjoecoding](https://github.com/bigjoecoding)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## What problem it solves

Evaluating whether to buy a small business (roughly under $5M revenue) requires normalizing Seller's Discretionary Earnings from messy financials, sanity-checking the asking price, and running structured due diligence — work that's usually locked behind broker/advisor fees. This skill walks Claude through the full workflow: a line-by-line SDE worksheet with disciplined add-back rules, valuation-range checks with published multiple bands, a red-flag catalog, a phased diligence checklist, and a fillable deal memo.

## Who uses this workflow

Independent searchers, first-time business buyers, and small holding companies evaluating owner-operated acquisitions — the same analysis a business broker, M&A advisor, or SBA lender would expect to see, organized and ready to bring to those professionals. Every output carries an explicit not-financial/legal-advice disclaimer and routes users to a CPA/attorney/appraiser for real transactions.

## Attribution

Original skill by [@bigjoecoding](https://github.com/bigjoecoding), built on standard SDE/business-valuation methodology (BizBuySell-style multiple bands, SBA-lender diligence conventions).

## Example

**User:** "Here are 3 years of P&Ls for a plumbing business asking $850K — is that price reasonable?"

**Output:** a multi-year SDE bridge (normalizing owner comp, below-market related-party rent, recurring "one-time" expenses), a defensible valuation range ($604K–$739K at 2.3–2.7x normalized SDE), the red flags found, and a one-page deal memo with a renegotiate/pass/proceed recommendation.

The pack includes reference files (SDE formula + add-back categories, valuation multiples, red-flag catalog, phased checklist), 3 fillable templates, and a fully worked example. Tested in Claude Code end-to-end on two scenarios (plumbing and landscaping businesses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
