### PR TITLE
Add HotClip — local AI video clipping (long video → vertical shorts) skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [HotClip](https://github.com/xixihhhh/hotclip) - Turn long videos and livestream VODs into viral vertical shorts, 100% locally: on-device transcription, LLM highlight detection, 9:16 reframe with karaoke captions, and a per-clip render-QA report with self-repair. Ships as a desktop app plus a headless CLI / MCP server / Agent Skill. *By [@xixihhhh](https://github.com/xixihhhh)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
## What this adds

**[HotClip](https://github.com/xixihhhh/hotclip)** under **Creative & Media** — a free, open-source (AGPL-3.0) local AI clipping tool that turns long videos and livestream VODs into publish-ready vertical shorts, with everything running on-device (footage never leaves the machine):

- On-device word-level transcription (SenseVoice / Paraformer / FireRedASR2), LLM highlight detection with an evidence chain (loudness / shot cuts / facial emotion / vision model / live-chat density)
- Frame-accurate cutting, 9:16 face-tracked reframe, karaoke / keyword / Hormozi-style caption burn-in
- Per-clip render-QA report (black frames / long silences / loudness / mid-word cuts / platform banned-words lint) with a self-repair loop
- Usable from Claude Code via a bundled **Agent Skill** ([skills/hotclip/SKILL.md](https://github.com/xixihhhh/hotclip/blob/main/skills/hotclip/SKILL.md)), a headless CLI, and a local stdio MCP server — all sharing the same pipeline as the desktop app

## Checklist
- Real use case: livestream clippers / podcasters cutting shorts for Douyin / TikTok / Shorts
- Documented: bilingual README + SKILL.md with setup, commands, hard rules and QA semantics
- Tested: 500+ unit tests; skill drives the same pipeline shipped in the desktop releases
- No duplicates: no existing local video-clipping skill in the list