### PR TITLE
Add AILmanac Skill Packs (7 packs, one per user type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [AILmanac Skill Packs](https://github.com/derob98/ailmanac/tree/main/skills) - Seven MIT-licensed skill packs, one per user type: writing/content, developer workflow, research analyst, data analyst, business & marketing, student learning, and everyday productivity. Part of the AILmanac community almanac for Claude. *By [@derob98](https://github.com/derob98)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
## What this adds

[AILmanac Skill Packs](https://github.com/derob98/ailmanac/tree/main/skills) — seven MIT-licensed skills in the standard `SKILL.md` folder format, each targeting a different kind of user:

`writing-content-pro` · `developer-workflow` · `research-analyst` · `data-analyst` · `business-marketing` · `student-learning` · `everyday-productivity`

## Checklist against your requirements

- **Real use case**: packs distilled from the AILmanac docs project (live at https://derob98.github.io/ailmanac/), each pack maps to a documented persona
- **Well-documented**: every pack has frontmatter (name, description), workflow steps, and guardrails (e.g. the student pack refuses to just hand over homework answers; the data pack guards against hallucinated numbers)
- **Accessible**: written for non-technical users where applicable
- **Tested**: used in Claude Code and Claude.ai
- **Safe / portable**: instruction-only skills, no scripts, no destructive operations

Listed under *Productivity & Organization* in alphabetical position; happy to move it or split entries per-category if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)