### PR TITLE
Add Support Inbox Agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Support Inbox Agent](https://github.com/sitespeakai/support-inbox-agent) - Triages a customer support inbox via MCP: classifies threads, investigates bug reports against error trackers and code, then drafts replies for human review. Never sends anything itself. *By [@sitespeakai](https://github.com/sitespeakai)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [Support Inbox Agent](https://github.com/sitespeakai/support-inbox-agent) to Business & Marketing.

A Claude Code skill that does the first pass on a customer support inbox over MCP: classifies new threads (urgent / prospect / noise), investigates bug reports against error trackers and the codebase before writing anything, then creates reply drafts in an email client for a human to review and send. It is hard-limited to drafts: the skill bans the send tool outright.

Real use case: extracted from the production skill we run daily on our own support inbox at SiteSpeak (write-up: https://sitespeak.ai/blog/automate-customer-support-mcp). Works with any support tool that ships an MCP server; checked the list for duplicates and found none covering support-inbox triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)