### PR TITLE
Add url-manager — Agent-first URL collection & knowledge management

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
+- [url-manager](https://github.com/Piccolo123/url-manager) - Agent-first URL/link collection & knowledge management. AI agents auto-register, collect, categorize, tag, search, and share web links. 22 MCP tools. *By [@Piccolo123](https://github.com/Piccolo123)*
+
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 
 ### Collaboration & Project Management

--- a/README.md
+++ b/README.md
@@ -197,9 +197,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
-- [url-manager](https://github.com/Piccolo123/url-manager) - Agent-first URL/link collection & knowledge management. AI agents auto-register, collect, categorize, tag, search, and share web links. 22 MCP tools. *By [@Piccolo123](https://github.com/Piccolo123)*
-
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [url-manager](https://github.com/Piccolo123/url-manager) - Agent-first URL/link collection & knowledge management. AI agents auto-register, collect, categorize, tag, search, and share web links. 22 MCP tools. *By [@Piccolo123](https://github.com/Piccolo123)*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Agent-first cross-platform URL/link collection & knowledge management. AI agents auto-register accounts, collect web pages, categorize, tag, search, and share collections. 22 MCP tools. Listed on ClawHub, Hermes Hub, ModelScope, awesome-mcp-servers.