### PR TITLE
feat: add sparda-skills (Proof-Carrying Code for Agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
+- [sparda-skills](https://github.com/zyx77550/sparda-skills) - Connects AI coding agents to the SPARDA Security Gate. Validates agent edits to ensure they do not violate invariants, prompt injection policies, or data constraints. Required when operating with the SPARDA MCP server.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 
 ### Assistive Technology


### PR DESCRIPTION
Adds sparda-skills, a skill that connects AI coding agents to the SPARDA Security Gate to validate agent edits against runtime invariants before applying them.