### PR TITLE
Add airtight to Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,11 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Security & Systems
 
+- [airtight](https://github.com/Zyoffsec/airtight-secure-coding) - Applies 67 numbered secure-coding gates while the assistant writes, catching safeguards it silently omits such as rate limits, lockout and audit logging. Mapped to OWASP Top 10 and CWE.
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
-- [airtight](https://github.com/Zyoffsec/airtight-secure-coding) - Applies 67 numbered secure-coding gates while the assistant writes, catching safeguards it silently omits such as rate limits, lockout and audit logging. Mapped to OWASP Top 10 and CWE.
 
 ### Assistive Technology
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [airtight](https://github.com/Zyoffsec/airtight-secure-coding) - Applies 67 numbered secure-coding gates while the assistant writes, catching safeguards it silently omits such as rate limits, lockout and audit logging. Mapped to OWASP Top 10 and CWE.
 
 ### Assistive Technology
 


### PR DESCRIPTION
Adds [airtight](https://github.com/Zyoffsec/airtight-secure-coding) under Security & Systems.

The existing entries in that section cover forensics and threat hunting. This one covers the write side: it applies 67 numbered secure-coding gates **while the assistant is generating code**, rather than scanning afterwards, so the controls that normally get silently omitted (rate limits, account lockout, audit logging, ownership checks) are present in the first place. Gates are mapped to OWASP Top 10 and CWE.

Free, MIT licensed, no signup or telemetry. Works with Claude Code, Cursor and Codex. It stays silent on non security work so it adds no overhead to ordinary edits.

Listed as an external link in line with the other entries in this section. Happy to adjust wording or placement.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ComposioHQ/codesmith/awesome-claude-skills/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787221527&installation_model_id=428187&pr_number=1395&repository=ComposioHQ%2Fawesome-claude-skills&return_to=https%3A%2F%2Fgithub.com%2FComposioHQ%2Fawesome-claude-skills%2Fpull%2F1395&signature=9b83c8caa479a151c3e80781ffee067595950e483d54b88c739e15dc07173107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->