### PR TITLE
Add resume-studio skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
+- [resume-studio](https://github.com/Sidgit11/resume-studio) - Builds a permanent memory of your career and tailors an ATS-safe, evidence-backed resume for every job. No fabricated claims, learns your style permanently. *By [@Sidgit11](https://github.com/Sidgit11)*
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.


### PR DESCRIPTION
Adds resume-studio to Productivity & Organization. The skill builds a permanent memory of your career and tailors an ATS-safe, evidence-backed resume for every job, without fabricating claims. Entry follows your contribution format: single-line, alphabetically placed within the category, external-repo link with `*By [@Sidgit11]*` attribution, no emojis.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ComposioHQ/codesmith/awesome-claude-skills/pr/1397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787231819&installation_model_id=428187&pr_number=1397&repository=ComposioHQ%2Fawesome-claude-skills&return_to=https%3A%2F%2Fgithub.com%2FComposioHQ%2Fawesome-claude-skills%2Fpull%2F1397&signature=1b1660dacdc57ea4825ef80f6aa870957d04a9266e6f1be0a402e8810ee5a48f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->