### PR TITLE
Add attester (verification oracle) to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Development & Code Tools
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
+- [attester](https://github.com/maminihds/attester-mcp/tree/main/skills/attester) - Verification oracle for agents: check whether a package or symbol really exists in PyPI and npm, whether sources support a claim, and whether a counterparty is safe to pay. Free quota via X-Payer header; wallet-signed receipts on every verdict. *By [@maminihds](https://github.com/maminihds)*
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
## What

Adds the **attester** skill ([maminihds/attester-mcp/skills/attester](https://github.com/maminihds/attester-mcp/tree/main/skills/attester)) to Development & Code Tools, inserted alphabetically before aws-skills.

## What the skill does

attester.dev is a paid verification oracle for agents. The SKILL.md teaches the agent when to verify facts and gives exact, runnable calls for each endpoint:

- **Package/symbol existence** in PyPI and npm ($0.002/$0.005), built from real published artifacts. Negative answers carry signed proof (artifact sha256 + source URL), which retrieval engines cannot give.
- **Citation support checks** ($0.25): does a source actually support the claim.
- **Rubric grading** ($0.10): score another agent's output with per-criterion evidence.
- **Counterparty check** ($0.005) before paying an unfamiliar service.

Free quota works with any wallet address as the X-Payer header, so the skill is usable with zero setup. Every verdict ships an EIP-191 signed attestation verifiable offline or via the free /receipts/verify endpoint.

## Checklist per CONTRIBUTING.md

- Real use case: agents hallucinate package names (5-20% in published studies); the skill checks before import.
- Well documented: SKILL.md covers triggers, auth, every endpoint with exact curl, verdict reading, honesty rules.
- Examples included: two real transcripts in skills/attester/examples/, captured against the live API.
- Tested: the free path was called against https://attester.dev during authoring (200 responses with signed attestations).
- Safe and portable: read-only HTTP calls; works in any agent that can run curl or the bundled stdlib+httpx helper.

Disclosure: I operate attester.dev (hello@attester.dev).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ComposioHQ/codesmith/awesome-claude-skills/pr/1398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787248348&installation_model_id=428187&pr_number=1398&repository=ComposioHQ%2Fawesome-claude-skills&return_to=https%3A%2F%2Fgithub.com%2FComposioHQ%2Fawesome-claude-skills%2Fpull%2F1398&signature=ba973e4ab6a02efc8de73c9cc0f38f6954a4e7d4d1fbf0c5e9341baff647350f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->