### PR TITLE
Add Idea Validator (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [Idea Validator](https://github.com/dersi3/idea-validator-skill) - Runs a 30-minute BUILD / RESHAPE / SKIP evidence protocol on a product idea: forces a falsifiable one-sentence bet, hunts for disconfirming evidence and competitors, scores a 5-factor rubric, and ends in a verdict. *By [@dersi3](https://github.com/dersi3)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
Adds [Idea Validator](https://github.com/dersi3/idea-validator-skill), a free MIT-licensed skill that runs a 30-minute evidence protocol on a product idea before any code is written: it forces a falsifiable one-sentence bet ({who} will pay {price} for {thing} because {pain}), searches for disconfirming evidence (competitor pricing, unprompted pain in forums, free alternatives, buyer reachability), scores a 5-factor 0-10 rubric, and ends in a hard BUILD / RESHAPE / SKIP verdict.

Meets the skill requirements: built from real use (it was used to validate the product it ships with), tested in Claude Code, trigger-focused description, documented with install instructions and examples in the repo README, no destructive operations. Entry placed alphabetically in Business & Marketing, following the external-repo format used by other entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)