### PR TITLE
Add NengZuoMa YongGe skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [NengZuoMa YongGe](https://github.com/turnerzhan/nengzuoma-yongge) - Audits storefronts, restaurant sites, franchise risks, and break-even economics for small businesses in China. Includes a Chinese domain corpus, case library, and executable calculators. *By [@turnerzhan](https://github.com/turnerzhan)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Summary

Adds **NengZuoMa YongGe** to the Business & Marketing section.

## Real-world use case

This MIT-licensed, Chinese-language Agent Skill helps restaurant founders and small-business operators in China evaluate storefront photos, site-selection signals, franchise risks, rent, labor, and break-even economics before signing a lease or investing.

A typical prompt includes a storefront photo or address plus rent, labor, and expected order value. The skill returns a red/yellow/green decision, the underlying break-even calculation, relevant case comparisons, and concrete next steps.

## Validation

- Public repository with a documented `SKILL.md`
- Domain corpus and case library included
- Executable break-even and franchise-risk calculators included
- Repository and author links verified

Original workflow and skill by [@turnerzhan](https://github.com/turnerzhan).