### PR TITLE
Add auto-git (per-round git auto-commit skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Development & Code Tools
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
+- [auto-git](https://github.com/hfjddjksaj/auto-git) - Gives code projects an automatic per-round git safety net: repo init with a sensible .gitignore, plus Stop hooks that commit each round's work (pushing only when an upstream exists) and optionally remind Claude to keep progress.md current. Cross-platform bash + PowerShell. *By [@hfjddjksaj](https://github.com/hfjddjksaj)*
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
Adds **[auto-git](https://github.com/hfjddjksaj/auto-git)** to the Development & Code Tools section (alphabetical position).

**What it is:** a Claude Code skill that gives any code project an automatic per-round git safety net — repo init with a sensible .gitignore (mandatory secrets block), a progress.md convention, and project-local Stop hooks: an autocommit hook that commits each round's leftovers (pushing only when an upstream already exists, never force-pushing) and an opt-in progress-check hook that reminds Claude once when progress.md went stale. Both hooks ship as bash and PowerShell, so it works on macOS/Linux and Windows.

**Checklist per CONTRIBUTING:**
- Real use case: built from daily use (never losing a round of work, readable history)
- Documented: bilingual README (EN/中文) with install instructions; hook behavior spelled out
- Tested: bash hooks verified with a functional test suite (8 cases); safety rules (no history rewriting, no force-push, hooks always exit 0)
- Safe: hooks are only installed per-project with the user's explicit approval; the reminder hook is opt-in with consequences explained first
- License: MIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQYkbfHaANq4Shu2kwuiet