### PR TITLE
Add Video Walkthrough skill (Development & Code Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [Video Walkthrough](https://github.com/Avatechdir/video-walkthrough-skill) - Turns one Playwright/Gherkin scenario into an automated test plus a captioned walkthrough video (mp4 + srt) with optional voice narration (en/ru), click highlighting, and clean before/after screenshots of every step for UX analysis. *By [@Avatechdir](https://github.com/Avatechdir)*
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis


### PR DESCRIPTION
## What

Adds **[Video Walkthrough](https://github.com/Avatechdir/video-walkthrough-skill)** to *Development & Code Tools* (alphabetical position, before Webapp Testing).

## Why it qualifies

- **Real use case**: turns one Playwright/Gherkin scenario into an automated test **plus** a captioned walkthrough video — the same artifact proves the feature is tested and documents it for the client. Built and used in production for delivering feature demos to stakeholders.
- **Well-documented**: English README (+ Russian translation), SKILL.md with authoring rules, UPGRADING guide, bundled runnable demo (`npm install && npm run video`) with reference scenarios in both languages.
- **Tested**: works in Claude Code; the repo ships prerecorded example videos produced by the skill itself.
- **Extras**: offline voice narration (en/ru, Silero/Edge TTS), click highlighting baked into frames, and a clean before/after screenshot bank of every step for UX analysis (`npm run screens`).

Install: `npx skills add avatechdir/video-walkthrough-skill` · [skills.sh page](https://skills.sh/avatechdir/video-walkthrough-skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)