### PR TITLE
Add signs-of-ai — bilingual (EN/ES) AI-writing de-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [signs-of-ai](https://github.com/peopleworks/SignsofAI) - Detects and removes the tells of AI-generated writing in English and Spanish, or judges whether a text reads as AI-written; the front end of a scored, privacy-first writing-integrity engine (web, CLI, and MCP). *By [@peopleworks](https://github.com/peopleworks)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 
 ### Creative & Media


### PR DESCRIPTION
Adds **signs-of-ai** — a drop-in skill that removes the tells of AI-generated writing, or judges whether text reads as AI-written, in **English and Spanish** (the Spanish rule-pack is derived from scratch, not translated).

It's the human-judgment front end of an open-source (MIT), privacy-first writing-integrity engine, so it can hand off to a scored analyzer via web app, CLI, or MCP server.

- Skill: `skill/signs-of-ai/SKILL.md` (YAML frontmatter, two modes: edit + detect).
- Repo: https://github.com/peopleworks/SignsofAI — actively maintained.

Thanks for curating this list!
