### PR TITLE
Add Stickies skill (Productivity & Organization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
+- [Stickies](https://github.com/dumbspacecookie/stickies/tree/master/skills/stickies) - Persistent sticky notes — decisions, blockers, todos, preferences, and context — that survive across Claude sessions in a local SQLite store; capture, recall, and dismiss on demand with no account or API key.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.


### PR DESCRIPTION
Adds Stickies under Productivity & Organization, in alphabetical order.

Stickies is a persistent sticky-note skill for Claude: capture, recall, and dismiss durable notes — decisions, blockers, todos, preferences, and context — that survive across sessions in a local SQLite store. No account, no API key; it drives the published stickies-mcp npm package (~570 downloads/week) and is MIT-licensed. The entry links to the skill folder in the source repo (single source of truth).

- Skill: https://github.com/dumbspacecookie/stickies/tree/master/skills/stickies
- npm: https://www.npmjs.com/package/stickies-mcp