### PR TITLE
Add Legible Legitimacy (workflow-governance guardrail) to Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
+- [Legible Legitimacy](https://github.com/that-guy-jamie/legible-legitimacy) - Workflow-governance guardrail that restructures high-consequence agent work (production mutations, delegated access, secrets, bulk jobs, security tests) so authorization, scope, least privilege, and reversibility are enforced by the workflow and evidenced by its artifacts — not asserted in prose. Ships as a Claude Code plugin with before/after examples and trigger/non-trigger evals. *By [@that-guy-jamie](https://github.com/that-guy-jamie)*
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 


### PR DESCRIPTION
## What this adds

**[Legible Legitimacy](https://github.com/that-guy-jamie/legible-legitimacy)** — a workflow-governance guardrail skill for high-consequence agent operations, added alphabetically under **Security & Systems**.

When a task would exercise a sensitive capability — production mutation, delegated access/impersonation, secrets in context, bulk scraping, security testing, or background jobs — the skill has the agent restructure the work so authorization, scope, least privilege, reversibility, and accountability are enforced by the workflow and evidenced by its artifacts (dry runs, bounded manifests, audit records, receipts), rather than asserted in prose. Its core distinction: **legible legitimacy over flag avoidance** — don't make dangerous work *sound* safer; redesign it so it *is* safer.

## Checklist per CONTRIBUTING

- **Real use case:** Extracted and generalized from the production agent-governance doctrine of a live multi-agent codebase (ASTRO Engine), where it gates production data fixes, support delegated-access flows, secret handling, and municipal-data ingest runners in daily use.
- **No duplication:** Searched the list — existing security entries cover forensics, fuzzing, and threat hunting; nothing covers workflow-shape governance for agent operations.
- **Standard structure:** Self-contained folder centered on `SKILL.md` with YAML frontmatter (name, description), per the open Agent Skills standard. Tool-neutral — no MCP servers or scripts required.
- **Tested:** In production use with Claude Code; repo ships 8 should-trigger and 7 should-not-trigger eval cases with expected behaviors.
- **Documentation:** Repo includes README with both install paths (Claude Code plugin marketplace + direct copy), four before/after examples by task shape, SECURITY.md, CHANGELOG, Apache 2.0.
- **Safe:** The skill's entire purpose is confirm-before-destructive, generalized — bounded cohorts, dry-run-first gates, hard stops, and audit artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)