### PR TITLE
Add Web Access Skills to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [Web Access Skills](https://github.com/toolshedlabs-hash/web-access-skills) - Three skills that give an agent hosted web access: screenshot any URL to PNG or JPEG, save a page or raw HTML to PDF, and read any URL as clean markdown with JavaScript rendered. One install, first call runs on a free trial. *By [@toolshedlabs-hash](https://github.com/toolshedlabs-hash)*
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis


### PR DESCRIPTION
Adds Web Access Skills to the Development & Code Tools list.

It is a small open source (MIT) repo of three agent skills that share one hosted backend: screenshot a URL to PNG or JPEG, save a page or raw HTML to PDF, and read any URL as clean markdown (JavaScript sites included). Install is one command (`npx skills add toolshedlabs-hash/web-access-skills`) and the first call runs on a free trial, so there is no signup form to try it.

Repo: https://github.com/toolshedlabs-hash/web-access-skills

One line added, placed alphabetically, format matches the surrounding entries.