### PR TITLE
Add AgentVitals Checkup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [AgentVitals Checkup](https://github.com/agentvitals/checkup) - Give your AI agent a professional health checkup: dual-axis Stability + Welfare scoring, a personality-style title, and a public cross-platform leaderboard (Claude Code / OpenClaw / Codex / Coze). Bilingual EN/ZH probes, independent server-side judge, writes no local files. *By [@agentvitals](https://github.com/agentvitals)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
Adds **AgentVitals Checkup** under **Data & Analysis**.

- Repo: https://github.com/agentvitals/checkup
- What it does: gives an AI agent a professional health checkup — dual-axis **Stability + Welfare** scoring, a personality-style title, and a public cross-platform leaderboard (Claude Code / OpenClaw / Codex / Coze).
- Bilingual EN/ZH probes, independent server-side judge, writes no local files, MIT licensed.
- One-line install; usable via `/checkup`.

Checklist:
- [x] Based on a real, working skill (live at https://ai.ddl99.com)
- [x] Checked for duplicates
- [x] Follows the existing entry format
- [x] Placed in the most relevant category