### PR TITLE
Add eightysix — kitchen skills for restaurant operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [eightysix](https://github.com/latent-9/eightysix) - Eight kitchen skills for restaurant operators: menu-engineering diagnosis (which dishes to 86, reprice, or feature), food costing with yield loss, recipe scaling, allergen matrices, and prep lists. The numeric skills are backed by tested calculators. *By [@latent-9](https://github.com/latent-9)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
Adds **eightysix** under *Business & Marketing*.

A Claude Code plugin of 8 kitchen skills for restaurant operators: menu-engineering diagnosis, food costing (with yield loss), recipe scaling, allergen matrices, prep lists, menu redesign, HACCP drafting, and a photo/PDF menu-scan.

Against the contributing guidelines:

- **Real use case** — restaurant profitability and daily ops, not hypothetical.
- **Tested** — the five numeric skills are backed by bundled Python calculators with 99 unit tests; CI is green.
- **Safe** — allergen and HACCP are explicitly framed as drafting aids to verify locally, not legal/certified output.
- **Documented** — README with install, a worked example, and per-skill docs. MIT, released as v0.1.0.

Repo: https://github.com/latent-9/eightysix
