### PR TITLE
Add UIZZE UI finish gate skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [UIZZE](https://uizze.com) - Free UI slop finish gate and screenshot score for product-specific web and iOS UI, with optional MCP access to 800,000+ real screens.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
## What this adds

Adds UIZZE to Development & Code Tools as an external, open-source Agent Skill.

## Real-world use case

Coding-agent UI work often reaches a functionally correct implementation before it reaches a product-specific one. The free UIZZE workflow gives the agent a finish gate and screenshot-based UI Slop Score before a frontend change is treated as done.

## Compatibility

The linked repository is MIT-licensed, contains the complete portable skill and examples, and supports Claude Code alongside Codex, Cursor, and Copilot. The MCP extension is optional; the free workflow remains usable without it.
