### PR TITLE
Add AceDataCloud Agent Skills to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [AceDataCloud Agent Skills](https://github.com/AceDataCloud/Skills) - 92 skills for AI media generation (music, image, video, speech) and publishing to Zhihu, CSDN, Juejin, Medium, Dev.to, X, Reddit, LinkedIn, Bluesky and Mastodon. *By [@AceDataCloud](https://github.com/AceDataCloud)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Replaces #456, which has been conflicting since March. Rebased on current `master` and updated — the collection has grown from 18 skills to 92 since that PR was opened.

Added one line to **Creative & Media**:

- AI media generation — music (Suno, Producer), image (Midjourney, Flux, Seedream, NanoBanana, GPT-Image), video (Sora, Veo, Kling, Hailuo, Luma, Seedance, Wan), speech (Fish Audio), face transform
- Publishing — Zhihu, CSDN, Juejin, Bilibili, Weibo, Medium, Dev.to, Hashnode, Substack, WordPress, X, Reddit, LinkedIn, Bluesky, Mastodon, Threads

Usage: [`@acedatacloud/skills`](https://www.npmjs.com/package/@acedatacloud/skills) had 21,012 npm downloads last month. Works with Claude Code, Codex, Cursor, and Gemini CLI.

Disclosure: I maintain this collection; the skills call Ace Data Cloud APIs.