### PR TITLE
Add The GTM Co-Founder to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [The GTM Co-Founder](https://github.com/AIDevGTM/gtm-cofounder) - Go-to-market skill pack for technical AI and dev-tool founders. Answers five questions, then builds a prioritized go-to-market roadmap and works it with you: positioning, ICP, first users, launch, and pricing. *By [@AIDevGTM](https://github.com/AIDevGTM)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
-- [The GTM Co-Founder](https://github.com/AIDevGTM/gtm-cofounder) - Go-to-market skill pack for technical AI and dev-tool founders. Answers five questions, then builds a prioritized go-to-market roadmap and works it with you: positioning, ICP, first users, launch, and pricing. *By [@AIDevGTM](https://github.com/AIDevGTM)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [The GTM Co-Founder](https://github.com/AIDevGTM/gtm-cofounder) - Go-to-market skill pack for technical AI and dev-tool founders. Answers five questions, then builds a prioritized go-to-market roadmap and works it with you: positioning, ICP, first users, launch, and pricing. *By [@AIDevGTM](https://github.com/AIDevGTM)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds **The GTM Co-Founder** to the Business & Marketing section.

It's an open-source (MIT) Claude skill pack for technical AI and dev-tool founders. It interviews the founder with five core questions, keeps a persistent brief and a prioritized roadmap, then applies positioning, first-users, launch, and pricing playbooks grounded in developer go-to-market frameworks. Works in Claude.ai (copy a skill), Claude Code (folder or plugin), and other agents.

- Repo: https://github.com/AIDevGTM/gtm-cofounder
- License: MIT
- Placed alphabetically within Business & Marketing.
