### PR TITLE
Add agent-experiment to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [agent-experiment](https://github.com/hashiruu/agent-experiment) - Working discipline for research runs that stay up for days: 26 rules distilled from real incidents (GPU indices that lie, stale completion markers read as success, two chains writing the same directory, a table updated while the prose still quotes the old number), plus three ledger files, a long-run monitoring guide, and a resumable task skeleton that snapshots the code per run. Rules are layered (general / GPU compute / LaTeX writing) so you deploy only what applies. Rule text is in Chinese; docs are bilingual. *By [@hashiruu](https://github.com/hashiruu)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds [agent-experiment](https://github.com/hashiruu/agent-experiment) under **Development & Code Tools** (alphabetical position).

### What it is

Working discipline for research runs that stay up for days at a time. It deploys into any project:

- **26 rules** in `CLAUDE.md`, layered as general (11) / GPU compute (8) / LaTeX writing (7), so a frontend project does not inherit GPU advice
- **three ledger files** — project incidents, a FIFO queue with a blocked section, and a number → weights/code/logs traceability index
- **a monitoring guide** for the failure mode that matters when nobody is watching: grepping only for success markers means a crash prints nothing
- **a task skeleton** that resumes from checkpoints, snapshots the code per run, and never writes a completion marker on a failure path

### Against the contribution guidelines

- **Real use case, not hypothetical** — the rules come out of producing one paper, where the experiments ran semi-automatically over a long stretch. Each rule carries the incident that produced it, e.g. bash reads a script incrementally by byte offset, so editing one mid-run makes it resume inside a token.
- **Documented** — bilingual README (zh / en), an architecture diagram, layer table, command reference, and a per-flag table.
- **Tested** — install → deploy → layer filtering → idempotent re-run → a real task run → a deliberately failing run to confirm no completion marker is written. Verified before each release.
- **Safe** — `--dry-run` writes nothing; the three ledgers and the task script are never overwritten once created; it does not touch git config or `.gitignore`.
- **Portable** — plain Markdown and Bash. Works standalone via `deploy.sh`, or as a Claude Code plugin (`claude plugin validate` passes). For Codex or Gemini CLI, symlink `CLAUDE.md` to `AGENTS.md` / `GEMINI.md`.

### One thing to flag

The 26 rules themselves are written in Chinese, deliberately: they were recorded in the language the incidents happened in. Both READMEs are bilingual and the entry says so, so nobody clicks through expecting otherwise. Happy to drop the entry if that makes it a poor fit for the list.