### PR TITLE
Add thank-you-ai to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [thank-you-ai](https://github.com/hanpulse/thank-you-ai) - Turns a genuine closing "thank you" into a brief reflection, keeping only the note that changes the next agent's first move.
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adds one entry to Productivity & Organization, following the existing external-link format used by entries like `kaizen`, `n8n-skills`, and `tapestry` in this same section.

**[thank-you-ai](https://github.com/hanpulse/thank-you-ai)** — an Agent Skills skill that turns a genuine end-of-task "thank you" into a brief closing ritual: triage whether the thanks is passing, closing, emphatic, or hollow, then write only the note that would change a future agent's first move (often nothing at all). Solves a real, recurring problem: agent conversations end with no memory carried forward unless someone remembers to run a retro. MIT licensed, host-agnostic (Claude Code, Codex, or any Agent Skills-compatible host).

Single-line addition, no other changes.