### PR TITLE
Add android-adb-debloat and samsung-debloat skills (Security & Systems)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,11 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Security & Systems
 
+- [android-adb-debloat](https://github.com/g4vvj4n7z6-eng/android-adb-debloat) - Debloat and de-Google any Android phone over ADB: no root, tiered removal with a never-touch list, round-trip-tested rollback, and honest measure-first performance claims. *By [@g4vvj4n7z6-eng](https://github.com/g4vvj4n7z6-eng)*
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
+- [samsung-debloat](https://github.com/g4vvj4n7z6-eng/samsung-debloat) - Full Samsung Galaxy debloat, privacy setup (HeliBoard keyboard, Google-only contacts) and iPhone-style home-screen automation over ADB: reversible, root-free, validated on One UI. *By [@g4vvj4n7z6-eng](https://github.com/g4vvj4n7z6-eng)*
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 
 ### Assistive Technology


### PR DESCRIPTION
Adds two companion Android skills:

**[android-adb-debloat](https://github.com/g4vvj4n7z6-eng/android-adb-debloat)** — Debloat and de-Google any Android phone over ADB: no root, tiered removal (zero-downside / ask-first / never-touch), `pm uninstall --user 0` with a round-trip-tested restore script (catches the Android ≤ 9 `cmd package install-existing` trap), safe WebView/keyboard replacement ordering, honest de-Googling trade-offs (GMS vs push notifications), and evidence-based battery health assessment.

**[samsung-debloat](https://github.com/g4vvj4n7z6-eng/samsung-debloat)** — The Samsung/One UI companion: validated Bixby/telemetry/partner-preload package tiers, the three Samsung removal methods (system vs omcagent preload vs Play app — each restores differently), HeliBoard privacy-keyboard swap verified by permission inspection, Google-only contacts, and iPhone-style home-screen layout built via UI automation with the launcher-drag gotchas documented.

Both are sibling skills to [windows-process-cleanup](https://github.com/g4vvj4n7z6-eng/windows-process-cleanup) (separate PR): measure first, consent-gated, always reversible. MIT licensed, validated on real devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
