### PR TITLE
Add Business Name Fit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
+- [Business Name Fit](https://github.com/Elham-Farajnejad/business-name-fit) - Suggests or vets business, startup, and product names for cultural authenticity and cross-market fit, checking meaning, look-alike, pronunciation, distinctiveness, and sound against the founder's origin language and target markets. *By [@Elham-Farajnejad](https://github.com/Elham-Farajnejad)*
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.


### PR DESCRIPTION
Adds a link to Business Name Fit, a skill that helps founders pick or vet a business, product, or brand name that stays authentic to their cultural origin while working professionally in the markets they want to sell into.

What problem it solves: a name that sounds great in the founder's native language can carry an unintended meaning, be hard to pronounce, or clash once translated into a target market. This skill runs a structured check (meaning, look-alike words, pronunciation, spelling, distinctiveness, sound, tone fit, origin authenticity) before a name gets locked in.

Who uses it: founders and marketers naming a company, product, or brand for a market outside their home culture or language.

Attribution: authored and maintained by Elham Farajnejad (@Elham-Farajnejad) and Mahdi Mansouri (@mh-mansouri). Linked here rather than copied in, following this repo's existing precedent for external skills (e.g. Brand Build Skills).

Example: a Persian founder naming a childcare brand "Anali" gets flagged for an unintended meaning in Swedish before launch, with an alternative name suggested that passes all checks.