### PR TITLE
Add apify-ultimate-scraper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [X Follower Scraper](https://apify.com/xquik/x-follower-scraper) - Extract followers, following, verified followers, lists, and communities from X with capped Apify Actor runs.
+- [X Tweet Scraper](https://apify.com/xquik/x-tweet-scraper) - Extract X posts, searches, profiles, threads, replies, quotes, and engagement with capped Apify Actor runs.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 ### Business & Marketing
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
-- [apify-ultimate-scraper](https://github.com/apify/agent-skills/tree/main/skills/apify-ultimate-scraper) - Selects Apify Actors, including Xquik's X Tweet and Follower Scrapers, for bounded extraction workflows.
+- [apify-ultimate-scraper](https://github.com/apify/agent-skills/tree/main/skills/apify-ultimate-scraper) - Selects Apify Actors, including Xquik's [X Tweet Scraper](https://apify.com/xquik/x-tweet-scraper) and [X Follower Scraper](https://apify.com/xquik/x-follower-scraper), for bounded extraction workflows.
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*

--- a/README.md
+++ b/README.md
@@ -152,13 +152,12 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [apify-ultimate-scraper](https://github.com/kriptoburak/apify-agent-skills/tree/codex/add-xquik-x-actors/skills/apify-ultimate-scraper) - Selects Apify Actors, including Xquik's X Tweet and Follower Scrapers, for bounded extraction workflows.
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
-- [X Follower Scraper](https://apify.com/xquik/x-follower-scraper) - Extract followers, following, verified followers, lists, and communities from X with capped Apify Actor runs.
-- [X Tweet Scraper](https://apify.com/xquik/x-tweet-scraper) - Extract X posts, searches, profiles, threads, replies, quotes, and engagement with capped Apify Actor runs.
 
 Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
-- [apify-ultimate-scraper](https://github.com/kriptoburak/apify-agent-skills/tree/codex/add-xquik-x-actors/skills/apify-ultimate-scraper) - Selects Apify Actors, including Xquik's X Tweet and Follower Scrapers, for bounded extraction workflows.
+- [apify-ultimate-scraper](https://github.com/apify/agent-skills/tree/main/skills/apify-ultimate-scraper) - Selects Apify Actors, including Xquik's X Tweet and Follower Scrapers, for bounded extraction workflows.
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## Summary

- Add the installable `apify-ultimate-scraper` Skill package.
- Include Xquik's X Tweet Scraper and X Follower Scraper routes.
- Keep direct Actor Store links inside the Skill's Actor index.
- Preserve bounded run guidance and the X Corp. independence notice.

## Use Case

Researchers can collect X posts and audiences through one Apify workflow.
The Skill selects the Actor, reads its live schema, and caps each run.

## Validation

- Linked folder contains `SKILL.md`: pass
- Linked package and raw Skill: HTTP 200
- README-only change: pass
- Alphabetical placement: pass
- Repository validation workflow: pass on the original head
- Diff whitespace: pass

No Actor was run. No Apify credits were consumed.

Disclosure: I am affiliated with Xquik.
