### PR TITLE
Add Arcgram — agent-neutral reasoning-diagram skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [Arcgram](https://github.com/jovesun-lab/arcgram) - Turns an AI agent's reasoning into an auditable node-and-edge diagram you can inspect and correct — a single standalone HTML file, no build/npm/CDN. Agent-neutral (Claude, GPT, Gemini, Cursor, local LLMs) with headless Checkpoint/Reconcile/Validate self-checks. *By [@jovesun-lab](https://github.com/jovesun-lab)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds Arcgram to Development & Code Tools.

Arcgram lets an AI agent surface its reasoning as an auditable node-and-edge diagram — a single standalone HTML file (no build/npm/CDN) that a human can inspect and correct, instead of trusting a wall of prose. It's agent-neutral (Claude, GPT, Gemini, Cursor, local LLMs) and ships headless Checkpoint/Reconcile/Validate self-checks. Apache-2.0.

Repo: https://github.com/jovesun-lab/arcgram