### PR TITLE
Add collage-design to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [collage-design](https://github.com/polgarp/collage-design) - Makes cut-and-layer collage art: sources real open-licensed photographs and printed material, cuts them, unifies them into one palette, and composes a finished .svg plus .png — with every source logged and licence-checked. *By [@polgarp](https://github.com/polgarp)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
Adds [collage-design](https://github.com/polgarp/collage-design), a skill that makes cut-and-layer collage art from real, open-licensed archive imagery.

- Sources only open-licensed material and writes a full attribution ledger (URL, creator, licence) for every fragment
- Outputs a self-contained `.svg` plus `.png`, alongside the parametric build script that made the piece
- Apache-2.0; installable as a Claude Code plugin or a plain skill
- README shows four finished pieces with the one-line briefs that produced them

Requires ImageMagick/Inkscape/librsvg locally, so it is Claude Code only — flagged in the README.