### PR TITLE
Add fulcru skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Claude Skills are customizable workflows that teach Claude how to perform specif
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [Fulcru](https://github.com/gsmmediaro/fulcru/tree/master/skills/fulcru) - Get named by AI search engines. Audits a domain, finds the buyer questions where ChatGPT, Gemini and Perplexity name a competitor instead of you, writes the page that closes the biggest gap, and re-measures after publishing. Runs standalone on web access, no account and no API key. *By [@gsmmediaro](https://github.com/gsmmediaro)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
Adds the `fulcru` Claude Skill: it audits a domain, finds the buyer questions where AI search names a competitor instead of you, writes the page that closes the biggest gap, and re-measures after publishing. Free and standalone: it needs web access only, no account and no API key.

Source: https://github.com/gsmmediaro/fulcru/tree/master/skills/fulcru