### PR TITLE
Add Krosos net-worth skill (Data & Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [Krosos net-worth skill](https://krosos.com/docs/api-access) - Lets Claude operate your own accounting ledger over a scoped API token: read net worth, holdings and history, log trades and balance updates, with an OpenAPI spec and a read-only token mode. Downloadable from any Krosos instance. *By [@Krosos](https://github.com/Krosos)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds the Krosos net-worth skill under Data & Analysis: it lets Claude read and update a personal accounting ledger (net worth, holdings, trades, history) over a scoped bearer token, with a public OpenAPI spec and a documented read-only mode. The skill and its docs live at the linked page. I am the founder.