### PR TITLE
Add wf-toolkit (Adobe Workfront skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [outline](https://github.com/sanjay3290/ai-skills/tree/main/skills/outline) - Search, read, create, and manage documents in Outline wiki instances (cloud or self-hosted). *By [@sanjay3290](https://github.com/sanjay3290)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
+- [wf-toolkit](https://github.com/Thousand-Cuts/wf-toolkit) - Adobe Workfront skills: text mode reporting, REST API, calculated fields, custom forms, business rules, permissions diagnostics, and reports — every knowledge claim verified against live tenants. *By [Thousand Cuts](https://thousandcuts.ai)*
 
 ### Security & Systems
 


### PR DESCRIPTION
Adds wf-toolkit under Collaboration & Project Management (alphabetical order).

Adobe Workfront skills for Claude: text mode reporting, REST API, calculated custom fields, custom forms, business rules, permissions diagnostics, and reports. Based on real consulting delivery work and in production use across multiple Workfront tenants; knowledge files are verified against live tenants (production and preview) with dated findings, and the repo accepts finding-report issues for behavior the documentation doesn't cover. Safe-by-default: write operations are gated behind explicit acknowledgment on production environments.