### PR TITLE
Add agmem to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [agmem](https://github.com/albedoweb/agmem) - Persistent project memory for coding agents. Indexes repo structure (Terraform, Python, Go, YAML, Markdown) into local JSONL and retrieves task-relevant constraints and facts via BM25 — no LLM calls, nothing leaves the machine. Ships as a Claude Code plugin with a context-injection hook, an agmem skill, and an `/agmem:setup` command.
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adds **agmem** — persistent project memory for coding agents.

It indexes repo structure (Terraform, Python, Go, YAML, Markdown) into local JSONL and retrieves task-relevant constraints and facts via BM25 retrieval — no LLM calls, nothing leaves the machine. Ships as a Claude Code plugin: a context-injection hook (UserPromptSubmit), an agmem skill with query-phrasing guidance, and an `/agmem:setup` command.

Real use case: an agent working in an infra monorepo asks `agmem context "rds bastion ec2 instance"` and instantly gets the team's rule ("prefer the dedicated bastion module over generic ec2") plus the relevant terraform files — instead of re-exploring the repo every session.

Placed alphabetically in Development & Code Tools. Apache-2.0, tested on Claude Code (macOS/Linux).