### PR TITLE
Add Bullshit Detector to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [Bullshit Detector](https://github.com/SerhiiKorniienko/bullshit-detector) - Fact-checks any YouTube video, article, tweet, or PDF: extracts every claim, verifies each against independent sources via web search, and returns per-claim verdicts with a 0-10 BS score. Ranks sources by tier and counts independent origins rather than URLs, so ten reprints of one press release don't read as ten confirmations. *By [@SerhiiKorniienko](https://github.com/SerhiiKorniienko)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
Adds [bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector) under **Data & Analysis** (inserted alphabetically).

### What it does

Point an agent at a YouTube video, article, tweet or PDF. It extracts every discrete claim, verifies each one against independent sources via web search, and returns per-claim verdicts (confirmed / plausible / misleading / false / unverifiable) with a 0-10 BS score.

The part that makes it different from "search and summarise": it ranks sources into tiers with empirical and primary sources on top, and counts **independent origins rather than URLs**, so ten reprints of one press release don't read as ten confirmations.

### Against the contribution guidelines

- **Real use case, not hypothetical** — launched publicly, 77 stars, and five published example reports on real content including a 2.36M-view video and a self-audit of its own README.
- **Well documented** — per-skill `SKILL.md`, a rubric, and `SETUP.md` covering each surface.
- **Includes examples** — [`examples/`](https://github.com/SerhiiKorniienko/bullshit-detector/tree/main/examples) holds five complete reports.
- **Tested** — works in Claude Code CLI, the desktop Code tab, and via the skills.sh installer in other harnesses. Caveats per surface are documented rather than glossed over.
- **Safe** — read-only. It fetches and searches, and writes only the report file.
- **Portable** — no agent-specific tool names in skill bodies; subagents are referenced conditionally so it degrades gracefully where they aren't available.
- **Attribution** — mine, and several features credit the Hacker News commenters who proposed them.

It also publishes its own [negative results](https://github.com/SerhiiKorniienko/bullshit-detector/tree/main/experiments), including a measurement that 16 major news organisations block the crawler it depends on. Seemed worth being upfront about the limitations of a tool like this.

MIT licensed.