### PR TITLE
Add Claude Code SEO/GEO Skills PT-BR

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,14 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
+- [Claude Code SEO/GEO Skills PT-BR](https://github.com/viniensina/claude-code-seo-geo-skills-pt-br) - Production-used SEO/GEO and WordPress content skills for Portuguese blogs. Inspired by ViniEnsina's editorial workflow.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 
 ### Communication & Writing
-
+S
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.


### PR DESCRIPTION
Adds a production-used Claude Code skill pack for SEO/GEO and WordPress content workflows in Portuguese.

The repository includes four skills:

- blog-article
- backlinks
- cover-image
- rankmath-seo

It also includes reusable docs for AI citation content, WordPress publishing flow, and Rank Math API usage.

Case study:
https://viniensina.com.br/claude-code-skills-seo-geo/