### PR TITLE
docs: add AdaL as a supported skill-loading platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
   </p>
 </div>
 
-A comprehensive and curated list of 1000+ production ready and practical Claude Skills and Plugins for enhancing productivity across usecases on not just Claude.ai, Claude Code, but also across coding agents like Codex, Cursor, Gemini CLI, Antigravity and more.
+A comprehensive and curated list of 1000+ production ready and practical Claude Skills and Plugins for enhancing productivity across usecases on not just Claude.ai, Claude Code, but also across coding agents like Codex, Cursor, Gemini CLI, Antigravity, [AdaL](https://github.com/SylphAI-Inc/adal) and more.
 
 ## Give your skills real-world actions
 
@@ -98,7 +98,7 @@ If you receive the email, Claude is now connected to 1000+ apps.
 
 ## What Are Claude Skills?
 
-Claude Skills are reusable instruction packages that teach an AI agent how to handle a specific class of tasks. Each skill is a folder containing a `SKILL.md` file with YAML frontmatter (name, description) and Markdown instructions, optionally bundled with scripts, references, and assets. Anthropic introduced the format in October 2025 and released it as an [open standard](https://github.com/anthropics/skills) in December 2025; it's now supported by Claude Code, Claude.ai, the Claude API, OpenAI Codex, Cursor, Gemini CLI, Antigravity, and Windsurf.
+Claude Skills are reusable instruction packages that teach an AI agent how to handle a specific class of tasks. Each skill is a folder containing a `SKILL.md` file with YAML frontmatter (name, description) and Markdown instructions, optionally bundled with scripts, references, and assets. Anthropic introduced the format in October 2025 and released it as an [open standard](https://github.com/anthropics/skills) in December 2025; it's now supported by Claude Code, Claude.ai, the Claude API, OpenAI Codex, Cursor, Gemini CLI, Antigravity, Windsurf, and [AdaL](https://github.com/SylphAI-Inc/adal).
 
 Skills load progressively. At session start, the agent sees only each skill's name and description — roughly 100 tokens per skill. The full SKILL.md body (typically under 5,000 tokens) loads only when the agent decides the skill is relevant to the current task. Auxiliary files in `scripts/` and `references/` load on demand. This is what lets a single agent host hundreds of skills without bloating its context window.
 
@@ -366,6 +366,28 @@ Pre-built workflow skills for 78 SaaS apps via [Rube MCP (Composio)](https://com
 
 4. The skill loads automatically and activates when relevant.
 
+### Using Skills in AdaL
+
+[AdaL](https://github.com/SylphAI-Inc/adal) natively supports the open `SKILL.md` standard for both personal and project-scoped skills.
+
+1. Place the skill in `~/.adal/skills/` (personal, global) or `.adal/skills/` (project-scoped):
+   ```bash
+   mkdir -p ~/.adal/skills/
+   cp -r skill-name ~/.adal/skills/
+   ```
+
+2. Verify skill metadata:
+   ```bash
+   head ~/.adal/skills/skill-name/SKILL.md
+   ```
+
+3. Start AdaL:
+   ```bash
+   adal
+   ```
+
+4. Browse and inspect loaded skills anytime with the `/skills` slash command. AdaL loads only each skill's name/description at session start and pulls in the full body on demand, keeping context usage low.
+
 ### Using Skills via API
 
 Use the Claude Skills API to programmatically load and manage skills:
@@ -500,4 +522,4 @@ Individual skills may have different licenses - please check each skill's folder
 
 ---
 
-**Note**: Claude Skills work across Claude.ai, Claude Code, and the Claude API. Once you create a skill, it's portable across all platforms, making your workflows consistent everywhere you use Claude.
+**Note**: Claude Skills work across Claude.ai, Claude Code, the Claude API, and other agent platforms like [AdaL](https://github.com/SylphAI-Inc/adal). Once you create a skill, it's portable across all platforms, making your workflows consistent everywhere you use Claude — or AdaL.


### PR DESCRIPTION
## TL;DR
Adds [AdaL](https://github.com/SylphAI-Inc/adal) to the list of platforms that support the open `SKILL.md` standard, alongside Claude Code, Codex, Cursor, Gemini CLI, Antigravity, and Windsurf — and adds a dedicated "Using Skills in AdaL" walkthrough.

## Why
This repo's own README states Claude Skills are portable across "Claude Code, Codex, Cursor, Gemini CLI, Antigravity, and Windsurf." AdaL is another agentic coding CLI that natively implements the same `SKILL.md` open standard (YAML frontmatter + progressive loading), so it belongs in that list.

## What AdaL supports (verified)
- **Personal skills**: `~/.adal/skills/`
- **Project-scoped skills**: `.adal/skills/`
- **Discovery**: `/skills` slash command lists and inspects loaded skills
- **Progressive loading**: only name/description loaded at session start; full `SKILL.md` body loaded on demand — same behavior this README already describes for Claude Skills generally

## Changes
1. Added AdaL to the intro paragraph's platform list
2. Added AdaL to the "What Are Claude Skills?" supported-platforms sentence
3. Added a full **"Using Skills in AdaL"** subsection under *Getting Started*, mirroring the existing Claude Code walkthrough (install path, verify metadata, start, discover via slash command)
4. Added AdaL to the closing portability note

## Testing
Manually verified on a local AdaL install:
- Skills placed in `~/.adal/skills/<name>/SKILL.md` are correctly discovered and listed via `/skills`
- Skill metadata (frontmatter `name`/`description`) is parsed and shown without loading the full body until invoked
