### PR TITLE
feat: Add Universal AI Clipboard Vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [Universal AI Clipboard Vision](https://github.com/1himanshu1804442/antigravity-clipboard-vision) - Enable zero-click image inspection and multi-screenshot visual debugging directly from the native Windows system clipboard (`Win + Shift + S`) across Claude Code, Codex, and Antigravity CLI sessions without manually saving files. *By [@1himanshu1804442](https://github.com/1himanshu1804442)*
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
### Summary
Adds **Universal AI Clipboard Vision** to the **Development & Code Tools** section.

### Description
Enables zero-click image inspection and multi-screenshot visual debugging directly from the native Windows system clipboard (Win + Shift + S) across Claude Code, Codex, and Antigravity CLI sessions without manually saving files. Includes a universal automated installer and self-cleaning cache.