### PR TITLE
Add BeachFinder skill (Productivity & Organization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Productivity & Organization
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
-- [BeachFinder](https://github.com/troulin-a11y/beachfinder-skills) - Find and compare 184,900 swimming spots worldwide (beaches, lakes, bathing places) with live weather, water temperature, wind, UV and wave signals, guides and source-backed providers. Routes requests across 14 languages to the right BeachFinder MCP tool and never claims water is safe to swim. *By [@troulin-a11y](https://github.com/troulin-a11y)*
+- [BeachFinder](https://github.com/troulin-a11y/beachfinder-skills) - Find and compare 184,900 swimming spots on [getbeachfinder.com](https://getbeachfinder.com) worldwide (beaches, lakes, bathing places) with live weather, water temperature, wind, UV and wave signals, guides and source-backed providers. Routes requests across 14 languages to the right BeachFinder MCP tool and never claims water is safe to swim. *By [@troulin-a11y](https://github.com/troulin-a11y)*
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Productivity & Organization
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
+- [BeachFinder](https://github.com/troulin-a11y/beachfinder-skills) - Find and compare 184,900 swimming spots worldwide (beaches, lakes, bathing places) with live weather, water temperature, wind, UV and wave signals, guides and source-backed providers. Routes requests across 14 languages to the right BeachFinder MCP tool and never claims water is safe to swim. *By [@troulin-a11y](https://github.com/troulin-a11y)*
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.


### PR DESCRIPTION
Adds **BeachFinder** — an Agent Skill that teaches Claude to use the public BeachFinder MCP server.

- Skill repo: https://github.com/troulin-a11y/beachfinder-skills
- Backing MCP (public, read-only, no auth): https://getbeachfinder.com/mcp
- Listed on the official MCP Registry as `com.getbeachfinder/beachfinder`

What it does: routes beach / swimming / surf / dive / snorkel / whitewater / vanlife / local-provider requests to the right BeachFinder tool across 14 languages, respects verification tiers (owner_verified/source_backed/mapped), and never declares water safe to swim (defers to official closures, flags, lifeguards, local authorities).

One-line bullet added alphabetically under Productivity & Organization, matching the existing format.