### PR TITLE
Add PatentFig AI skill (patent figure generation & conversion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [PatentFig AI](https://github.com/TopLocalAI/patentfig-skill) - Generate USPTO/EPO-compliant patent figures from text via the PatentFig AI API — patent line art (PNG/SVG), vectorize drawings to SVG/DXF/PDF for CAD, AI-upscale, and convert to filing-ready formats. *By [@TopLocalAI](https://github.com/TopLocalAI)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds **[PatentFig AI](https://github.com/TopLocalAI/patentfig-skill)** to Creative & Media.

The skill teaches agents to call the PatentFig AI REST API:

- Generate USPTO/EPO-compliant patent figures from a text prompt (PNG or stroke-based SVG line art, optional reference numerals and reference images)
- Vectorize raster drawings to SVG / DXF / vector PDF (line-art redraw or faithful trace)
- AI-upscale 2×/4× with 300/600 DPI metadata, and convert to filing-ready TIFF/PDF/PNG

Auth is a `PATENTFIG_API_KEY` env var (never hardcoded); the SKILL.md covers timeouts, credit costs, rate limits, and error handling. Docs: https://patentfig.ai/docs · OpenAPI: https://patentfig.ai/api/openapi.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpyRDM5rKG2VczzDYnkxzs