### PR TITLE
Add marketingskills/seo skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [marketingskills/seo](https://github.com/marketingskills/seo) - 20 open-source SEO operator skills for Claude Code, Codex, and Cursor: diagnose traffic decay, find keyword opportunities, build proposals, and generate client-ready reports via live GSC/GA4 data. *By [@marketingskills](https://github.com/marketingskills)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [marketingskills/seo](https://github.com/marketingskills/seo) to the Business & Marketing section.

- 20 open-source SEO operator skills for Claude Code, Codex, and Cursor (SKILL.md format, Agent Skills spec)
- Install: `curl -fsSL marketingskills.net/seo | bash`
- Covers technical SEO audits, keyword opportunities, AI search (AEO/GEO), programmatic SEO, schema markup, refresh briefs, and client-ready reporting via live GSC/GA4 data
- MIT licensed, matches the existing section entry format

Affiliation disclosure: I maintain the marketingskills/seo project.

(Re-submission: original PR #1120 was closed when its head branch was force-pushed by maintenance tooling; this is an identical change on a fresh branch.)