### PR TITLE
Add EU AI Act Compliance Advisor skill (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [EU AI Act Compliance Advisor](https://github.com/dankofly/eu-ai-act-skill) - Checks content and AI features against the EU AI Act Article 50 labeling duties (applicable since August 2, 2026), applies every written exemption as a no-label decision path, and assesses provider vs. deployer roles plus enforcement risk. Ships SKILL.md for Claude and AGENTS.md for Codex. *By [@dankofly](https://github.com/dankofly)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
## What this adds

**[eu-ai-act](https://github.com/dankofly/eu-ai-act-skill)**: an EU AI Act compliance advisor skill, added alphabetically to Business & Marketing.

## Real use case (per contribution guidelines)

Article 50 of the EU AI Act (AI content labeling duties) became applicable on **August 2, 2026**. Everyone publishing AI-assisted content for EU audiences now has to decide, per piece of content: label or not? The skill walks the agent through the actual decision path: scope check, provider vs. deployer role, all five Article 50 duties, and every written exemption (commercial text is out of scope, human review + editorial responsibility exempts even news-like text, stylized visuals are not deepfakes).

I built it for my own agency work (we publish AI-assisted content daily) and use it in production.

## Quality notes

- Legal text quoted verbatim from EUR-Lex (CELEX 32024R1689), not paraphrased
- Incorporates the Commission Guidelines on Art. 50 (July 20, 2026) and the final Code of Practice
- Ships both SKILL.md (Claude) and AGENTS.md (Codex), MIT licensed
- Hard guardrails: refuses watermark stripping and fake human-authorship claims

Transparency: I am the author of the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)