### PR TITLE
Add Shopify Review Triage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Shopify Review Triage](https://alfredtech2026.github.io/shopify-app-review-brief/skills/shopify-review-triage/?utm_source=awesome-claude-skills&utm_medium=resource-directory&utm_campaign=inbound-validation) - Turns public Shopify App Store reviews into a first-pass P0–P3 action brief, with public-data-only and human-check boundaries. *By [@alfredtech2026](https://github.com/alfredtech2026)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## What problem it solves

Shopify app teams with several active listings can miss incident risk, repeated friction, pricing confusion, and feature requests across a stream of public 1–3-star App Store reviews. This skill turns supplied public review rows into a transparent first-pass P0–P3 action brief while keeping every source link and routing ambiguous rows to human review.

## Who uses this workflow

Shopify app developers and product or support leads triaging public App Store feedback across a portfolio of apps.

## Real-world use case and example

Paste public review rows into the skill, classify each row with the published keyword rubric, preserve secondary matches, verify ownership context, and produce a Markdown brief that distinguishes first-pass output from human-checked conclusions. The published page includes a worked eight-row example and a pre-delivery self-check.

## Safety and portability

- Public review text only; no private merchant data
- Never invents evidence or contacts anyone
- Explicitly labels heuristic output as not human-checked
- Harness-neutral Agent Skills frontmatter with no network or vendor dependency
- MIT-licensed public source

## Verification

- Canonical Agent Skills specification and rubric tests pass
- Live attributed skill page returns HTTP 200
- Public source repository is MIT licensed and actively maintained
- This PR changes exactly one alphabetically placed README entry