### PR TITLE
Add reddit-lead-finder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [reddit-lead-finder](https://github.com/threadsnoop/reddit-skills/tree/main/reddit-lead-finder) - Finds real Reddit posts and comments from people describing a problem a specific product solves, scores them against a Customer Fit / Problem Severity / Purchase Intent rubric, and returns a ranked lead report with quoted evidence and links. Read-only, never posts, comments, votes, or DMs. *By [@threadsnoop](https://github.com/threadsnoop)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## What problem it solves

Finding the first customers for a product on Reddit currently means manually reading through subreddits looking for people expressing the exact problem your product solves — slow, and easy to mistake a success story or generic advice-seeker for a real lead. `reddit-lead-finder` automates that judgment: it finds real Reddit posts/comments where someone is describing a matching problem, scores each one against a fixed Customer Fit / Problem Severity / Purchase Intent rubric, and returns a ranked report with quoted evidence and links.

## Who uses this workflow

Solo developers and small teams looking for their first customers on Reddit without building custom scraping or lead-scoring logic themselves.

## Attribution/inspiration source

Built and maintained by ThreadSnoop (github.com/threadsnoop), backed by the ThreadSnoop Reddit read API — this is the product's own core scoring rubric (Customer Fit / Problem Severity / Purchase Intent), exposed as a general-purpose skill. Live-tested end to end — see [`examples/real-run.md`](https://github.com/threadsnoop/reddit-skills/blob/main/reddit-lead-finder/examples/real-run.md) for a real, non-fabricated finding, and [`examples/sample-report.md`](https://github.com/threadsnoop/reddit-skills/blob/main/reddit-lead-finder/examples/sample-report.md) for the report format.

## Example of how it's used

Describe your product (or point Claude at its URL) and ask it to find Reddit leads — the skill searches, scores each candidate against the rubric, and returns a short ranked report with quoted evidence and thread links.

Read-only by hard rule: never posts, comments, votes, or DMs on the user's behalf. Companion to `reddit-search` (also submitted, see #1524) — that skill is the general-purpose search/monitoring tool; this one is specifically for finding people describing a problem a given product solves.