### PR TITLE
Add wrap-pickup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [wrap-pickup](https://github.com/alexschar/wrap-pickup) - Cross-agent session continuity — /wrap closes a session into a validated receipt, /pickup resumes it in another client (Claude Code, Codex, Kimi). *By [@alexschar](https://github.com/alexschar)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds one entry to the Development & Code Tools section: [wrap-pickup](https://github.com/alexschar/wrap-pickup).

What it is: cross-agent session continuity for Claude Code, Codex, and Kimi. `/wrap` closes a session into a validated Markdown receipt (what was verified, what's broken, the next exact action); `/pickup` in another client scans the receipt store, cross-checks the claims against the live project state, and hands back a brief. Each client gets a thin adapter (`adapters/<client>/skills/{wrap,pickup}/SKILL.md`) over one shared receipt contract.

Why it fits Development & Code Tools: it's a Claude Code developer workflow tool (session handoff), same category as other entries like Claude Code Terminal Title and finishing-a-development-branch.

Disclosure: I'm the author of wrap-pickup (this is a self-submission).