### PR TITLE
Add AAJ Marketing Skills skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
+- [AAJ Marketing Skills](https://github.com/sarojkjha/aaj-marketing-skills) - 39 marketing skills across GTM, SEO/GEO, unit economics, retention and pipeline. 24 ship runnable Node engines that compute the numbers — LTV:CAC and payback, weighted forecasts, A/B significance, AI citation visibility — rather than only prompting. *By [@sarojkjha](https://github.com/sarojkjha)*
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.


### PR DESCRIPTION
Adds AAJ Marketing Skills to Business & Marketing.

**What problem it solves**

Most marketing skills produce prose — a plan, a rewrite, a recommendation. They
can't tell you whether the plan holds up. These do the arithmetic: 24 of the 39
skills ship runnable Node engines that compute and return real numbers, so the
agent's advice rests on a calculation instead of a plausible-sounding paragraph.

Engines cover LTV:CAC and CAC payback, weighted pipeline forecasts and coverage
gaps, A/B test significance and sizing, paid budget allocation against a CAC
target, growth-loop amplification, churn and NRR, SEO/GEO/AEO page scoring, and
AI answer-engine citation tracking — including whether a change between runs is
statistically distinguishable from noise.

**Who uses this workflow**

Founders and marketers at seed to Series B startups, and the consultants working
with them. Built and used in live client engagements rather than generated in bulk.

**Attribution**

Built by Saroj Jha (AAJ), https://aajconsult.com. MIT licensed.

**Example**

    npx skills add sarojkjha/aaj-marketing-skills --skill unit-economics
    node .agents/skills/unit-economics/resources/unit-economics.js

Runs with no configuration and prints:

    Gross-margin LTV        $13,333   (3.0% monthly churn (~33.3 mo lifetime))
    CAC                     $3,000
    LTV : CAC               4.4:1
    CAC payback             7.5 mo
    ✓ LTV:CAC 4.4:1 is at or above the 3:1 floor.
    ✓ CAC payback 7.5 mo is within the ~12-month guideline for subscription.

Also emits JSON for programmatic use. Every engine has an equivalent demo.

- Repo: https://github.com/sarojkjha/aaj-marketing-skills
- Directory: https://www.skills.sh/sarojkjha/aaj-marketing-skills
- License: MIT
- Works with Claude Code, Cursor, Codex, Windsurf
- Security: Gen — Safe, Socket — 0 alerts