### PR TITLE
Add Attention Control to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Development & Code Tools
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
+- [Attention Control](https://github.com/aaddrick/attention-control) - Air traffic control discipline for coding-agent output, tuned for ADHD reading: action first, one word one meaning, state restated every turn. *By [@aaddrick](https://github.com/aaddrick)*
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.


### PR DESCRIPTION
One entry, inserted alphabetically between `artifacts-builder` and `aws-skills`.

**[Attention Control](https://github.com/aaddrick/attention-control)** — an output style and skill that applies air traffic control discipline to coding-agent replies. ATC phraseology exists because a distracted human under load mishears an instruction, and aviation solved it with two disciplines: controlled vocabulary, so each word means one thing, and fixed message shape, so the instruction leads and the background trails. Those are the two layers.

It is not a "be terse" prompt. The rules keep every fact, number, and condition, because terseness that drops the command costs the reader a round trip.

**Why this section.** It changes how the coding agent presents itself rather than what it builds, which is the same category as `Claude Code Terminal Title` already in this section. It is not content-production tooling, so Communication & Writing is the wrong shelf.

**Provenance.** The shape layer adapts [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) by Ayoub G. (MIT). The language layer derives from [L1nefeed's `asd-ste100` output style](https://gist.github.com/L1nefeed/4164ecaaf77879e76dca3c06f142f1c2), itself condensed from ASD-STE100 Simplified Technical English, Issue 9. Both are credited in the repo's README and NOTICE.md. The project reproduces no text from the ASD specification, and the ASD does not certify, endorse, or sponsor it.

**Against your contribution steps.** Real use case, no duplicate in this list, MIT licensed, installs on seven agents (Claude Code as a native output style, the rest as a skill, rules file, or AGENTS.md block). Ships an eval harness that scores it against an unstyled baseline across 24 cases and 6 dimensions.