### PR TITLE
Add REA skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
+- [REA](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything) - Reverse-engineer native, managed, Electron/JavaScript, packaged, and browser applications with REA's local CLI and MCP tools.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 
 ### Assistive Technology


### PR DESCRIPTION
## What problem it solves

Reverse engineering a shipped application often spans native binaries, managed PE/CLI files, Electron/JavaScript packages, and browser runtimes. REA's existing `reverse-engineer-anything` skill gives an agent a structured workflow for choosing the relevant analysis path and keeping observations separate from inferences.

## Who uses this workflow

- Security researchers investigating native or packaged applications.
- Engineers comparing shipped application versions or reconstructing behavior from artifacts.
- Analysts working with Hopper, Ghidra, managed PE/CLI files, Electron applications, or browser runtimes.

## How it is used

The skill is available at [morluto/rea/skills/reverse-engineer-anything](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything). It is loaded by a compatible agent, which then uses REA's local CLI and MCP tools for the target-specific workflow.

## Example

**User**: "Reverse engineer this Electron application and explain which behavior is established by evidence."

**Workflow**: Inspect the shipped application, select the bounded JavaScript or runtime-observation path, and report observations, inferences, and unknowns with the supporting artifact context.

## Repository

https://github.com/morluto/rea

## Attribution

**Inspired by:** The source-owned REA reverse-engineering workflow and its public CLI/MCP implementation.

## Checklist

- [x] The skill is based on a real use case.
- [x] The current list and GitHub issues/PRs were checked for duplicates.
- [x] The linked public skill includes a `SKILL.md` and supporting references.
- [x] The README entry is in the Security & Systems category.
- [x] The repository and skill links are publicly accessible.