### PR TITLE
Add unillm-sdk: unified LLM integration skill (14 providers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [unillm-sdk](https://github.com/DanZai233/unillm-sdk) - Zero-dependency unified LLM integration for 14 providers (OpenAI, Claude, Gemini, Volcengine Doubao, DeepSeek, Kimi, Qwen, GLM, Grok, Ollama, ...): chat/stream/JSON calls, real model listing, visual dashboard, and zero-rename migration from hand-written per-provider adapters. *By [@DanZai233](https://github.com/DanZai233)*
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
Adds the [unillm-sdk](https://github.com/DanZai233/unillm-sdk) skill to Development & Code Tools — a zero-dependency unified LLM integration package (OpenAI / Claude / Gemini / Doubao / DeepSeek / Kimi / Qwen / GLM / Grok / Ollama / ...) with a ready-to-install Agent Skill, npm package, and dashboard.