### PR TITLE
Add Alter — digital persona skill (Communication & Writing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Communication & Writing
 
+- [alter](https://github.com/alter-persona/alter) - Builds and runs a digital persona of the user from a chat interview, their documents, and AI chat exports, then chats and drafts messages and emails in their voice. Local-first (Postgres + whisper.cpp + Ollama) and improves from every correction.
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.


### PR DESCRIPTION
Adds [Alter](https://github.com/alter-persona/alter) (Apache-2.0) to **Communication & Writing**, alphabetically first.

Alter builds a digital persona of the user from a chat interview (voice memos transcribed locally with whisper.cpp), their documents, and exported AI chats — then chats and drafts messages/emails in their voice. It improves from corrections, asks instead of overwriting on contradictions, and benchmarks itself against eight sealed hold-out questions.

Install: `npx skills add alter-persona/alter` (agentskills.io layout, `skills/alter/SKILL.md`) — listed on [skills.sh](https://skills.sh/alter-persona/alter); also loads on OpenClaw and Hermes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)