### PR TITLE
Add bid-gen: Chinese construction tender proposal generation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 
+- [bid-gen](https://github.com/tiettuo/claude-bid-gen) - Generates Chinese construction tender technical proposals (施工组织设计, 60-400 pages) from raw tender PDFs: extracts evaluation scoring tables / mandatory outlines / disqualification rules, anchors chapter titles verbatim to them, then LLM writing behind machine compliance gates (blind-bid, fabricated-standards scan, page caps, real-DOCX format audit). Batch mode differentiates multi-bidder submissions and screens similarity against bid-rigging flags. 46 scripts, 264 passing tests, sanitized real-project case studies in memory/. Runs on Claude Code, Codex, pi, hermas. *By [@tiettuo](https://github.com/tiettuo)*
+
 ### Development & Code Tools
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).


### PR DESCRIPTION
Add [bid-gen](https://github.com/tiettuo/claude-bid-gen) to Document Processing — a production-grade pipeline generating Chinese construction tender technical proposals (60-400 pages). Extract-first methodology, machine compliance gates, batch multi-bidder mode, 46 scripts, 264 tests, real-project case studies. MIT.