### PR TITLE
Add Create a Meme skill (Creative & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [Create a Meme](https://github.com/RiskAverseTech/createa-meme-skill) - Turn any idea into a finished meme — picks the format, writes captions that land, generates via the Create a Meme MCP, and offers variations. Works in Claude Code, Cursor, and any MCP agent. *By [@RiskAverseTech](https://github.com/RiskAverseTech)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds **Create a Meme** to the Creative & Media section.

A skill that turns any idea into a finished meme — picks the format, writes captions that land, generates via the `@createa/meme-mcp` tools, and offers variations. Text-to-meme, template captioning, AI meme images, and face-preserving remix. Works in Claude Code, Cursor, and any MCP agent.

Repo: https://github.com/RiskAverseTech/createa-meme-skill