### PR TITLE
Add unity-cli-skill (Unity Editor automation via the official Unity CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [unity-cli-skill](https://github.com/ZHAO0424/unity-cli-skill) - Unity Editor automation via the official Unity CLI: 140+ editor commands for scene editing, tests, headless builds, and C# eval, with a screenshot self-verification loop.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 


### PR DESCRIPTION
Adds **[unity-cli-skill](https://github.com/ZHAO0424/unity-cli-skill)** to Development & Code Tools.

A field-tested Claude Code skill that drives the Unity Editor through the **official Unity CLI** (`unity` command + `com.unity.pipeline` package) — no third-party editor plugins, no MCP server:

- 140+ built-in editor commands (scenes, GameObjects, components, materials, prefabs, console, packages)
- EditMode/PlayMode tests and headless batch builds
- Arbitrary C# via `eval` for sub-second batched operations (no domain reload)
- A screenshot self-verification loop: the agent captures the Game view, reads the image, and iterates
- Every command name, parameter format, and pitfall verified against a live Unity 6 project; includes a full generated command reference and an eval snippet library

Bilingual README (EN/中文), MIT licensed. Also ships an AGENTS.md bridge so the same playbook works in other agent CLIs.