### PR TITLE
Add Indian Stocks Fundamental Analysis (Data & Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [Indian Stocks Fundamental Analysis](https://github.com/AlenSarangSatheesh/Indian-Stocks-Fundamental-Analysis-SKILL) - Sector-relative, multi-factor fundamental analysis of listed companies (India-first, works globally); document-first ("never invent a number"), with forensic and IPO modes. *By [@AlenSarangSatheesh](https://github.com/AlenSarangSatheesh)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds **Indian Stocks Fundamental Analysis** under **Data & Analysis**.

Repo: https://github.com/AlenSarangSatheesh/Indian-Stocks-Fundamental-Analysis-SKILL

Sector-relative, multi-factor fundamental analysis of listed companies (India-first, works globally). Document-first ("never invent a number"), with Screen/Standard/Deep-dive/Forensic/IPO modes, 25 sector playbooks, and dependency-free Python helpers. Proper SKILL.md with YAML frontmatter, MIT-licensed. Research, not investment advice.