### PR TITLE
Add Swedish Mentor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
+- [Swedish Mentor](https://github.com/mh-mansouri/help_with_swedish) - Recommends CEFR-leveled Swedish YouTube clips and podcast episodes, building a listening/reading/writing/speaking learning path. *By [@mh-mansouri](https://github.com/mh-mansouri)*
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.


### PR DESCRIPTION
Recommends CEFR-leveled Swedish YouTube clips and podcast episodes and builds a listening/reading/writing/speaking learning path.

- What problem it solves: most language-learning advice is too vague or too overwhelming — this asks what level you're at and what you want to improve, then gives focused resources instead of random videos.
- Who uses this workflow: self-directed Swedish learners, A1 through C2.
- Also works via a copy-paste universal prompt in any AI chat, no install required.