### PR TITLE
Add MemoryPlugin skill to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
+- [MemoryPlugin](https://github.com/memoryplugin/agent-skills) - Connects Claude to the user's MemoryPlugin long-term memory, shared across 21+ AI tools: recalls and stores memories and searches imported chat history automatically during sessions. *By [@memoryplugin](https://github.com/memoryplugin)*
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.


### PR DESCRIPTION
Adds the MemoryPlugin skill to Productivity & Organization (inserted alphabetically between kaizen and n8n-skills).

Real use case: the skill teaches Claude (Claude Code, Claude.ai, and other skill-supporting agents) to use the user's MemoryPlugin account — a hosted long-term memory shared across 21+ AI tools — recalling relevant memories at task start, storing new ones as they come up, and searching imported ChatGPT/Claude/Gemini chat history. It ships as both a standard SKILL.md agent skill and a Claude Code plugin, with documentation and setup instructions in the repo, and is in production use by MemoryPlugin customers ([product page](https://www.memoryplugin.com/agent-skill), [setup docs](https://help.memoryplugin.com/integrations/remote-mcp-server)).

Disclosure: I'm the maker of MemoryPlugin. Submission prepared with the help of an AI agent.