### PR TITLE
Add mubu-integration (Mubu/幕布 outline CLI & AI Agent Skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 
+- [Mubu (幕布) Integration](https://github.com/liuboacean/mubu-integration) - Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export. *By [@liuboacean](https://github.com/liuboacean)*
 ### Development & Code Tools
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).


### PR DESCRIPTION
Hi! I'd like to add **mubu-integration** to this list.

**What it is:** Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export.

- Repo: https://github.com/liuboacean/mubu-integration
- 中文落地页: https://github.com/liuboacean/mubu-integration/blob/main/README.zh-CN.md
- Positioned as an AI Agent Skill (Claude Code / Agents), not just a CLI.

Accurate description (no exaggeration): outline↔Markdown sync with lossless round-trip, OPML/FreeMind export.

Thanks for maintaining this awesome list!
