### PR TITLE
Add claude-code-security-baseline skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Security & Systems
 
+- [claude-code-security-baseline](https://github.com/mikobuilds/claude-code-security-checklist) - Sets up the security baseline before an AI agent starts working in a repo: a permissions.deny list, a gitleaks pre-commit hook, a read-only database role in .env.example and prompt-injection rules in CLAUDE.md. Never overwrites, and --check reports what's missing without writing. *By [@mikobuilds](https://github.com/mikobuilds)*
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.


### PR DESCRIPTION
**What it does**

`claude-code-security-baseline` sets up the security baseline for a project before an agent starts working in it: a `permissions.deny` list in `.claude/settings.json`, a gitleaks pre-commit hook, an `.env.example` that documents a read-only database role, prompt-injection rules appended to `CLAUDE.md`, and `.env` added to `.gitignore`.

**The problem it solves**

Letting an agent into a repo is fine until it isn't - `git reset --hard` over uncommitted work, a key that lands in a public repo, a destructive query against production because a stale migration looked wrong to it. None of that takes a clever attack. It takes one confident agent and one tired developer clicking "yes" at two in the morning. Everyone means to set those four files up, nobody remembers the exact syntax, so it gets skipped.

**Who uses it**

Solo devs and small teams starting a repo, or pointing Claude Code at an existing one. The checklist behind it came out of my own projects and was published first; this skill is that checklist automated.

**Safety**

Nothing is ever overwritten. An existing `settings.json` keeps its own keys and gains only the deny rules it's missing, an existing `CLAUDE.md` gets a section appended, and a second run reports "left alone" and changes nothing. `--check` writes nothing at all and only reports what's missing. Standard library Python, no network calls, no telemetry - which matters, given what it's touching.

**Example**

```
$ python ~/.claude/skills/claude-code-security-baseline/scripts/harden.py --check

[ ] .claude/settings.json    no deny list - nothing stops rm -rf or a read of .env
[ ] .pre-commit-config.yaml  no secret scanner - a forgotten key would reach git
[i] .env.example             already there, left alone
[ ] CLAUDE.md                no security section
[ ] .gitignore               missing: .env.local, .env.*.local

4 of 5 items need attention.
```

It also prints the two traps that make the whole setup silently useless: edits to `.claude/settings.json` only take effect from the next session, and a pre-commit config scans nothing until `pre-commit install` has actually been run. Related trap, since people test it this way: don't check gitleaks with `AKIAIOSFODNN7EXAMPLE`, it's on the allow-list and sails straight through.

**Where I put it**

Security & Systems, first alphabetically. Linked to the source repo rather than vendored here, same as the other entries in that section.

Repo: https://github.com/mikobuilds/claude-code-security-checklist (MIT)