### PR TITLE
Add research-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [research-skills](https://github.com/Alexyskoutnev/research-skills) - Ten skills for writing an ML paper, abstract to rebuttal, with recipes, axioms, and mechanical checklists drawn from accepted papers. *By [@Alexyskoutnev](https://github.com/Alexyskoutnev)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
 
 ### Creative & Media


### PR DESCRIPTION
Adds `research-skills` to Communication & Writing as an external link, matching the pattern used by article-extractor, brainstorming, family-history-research, and NotebookLM Integration.

**What problem it solves.** A paper section fails for boring, findable reasons: the abstract buries the contribution in sentence four, a number appears with nothing to compare it against, a caption reads "Results on the benchmark." Reviewers notice every time, and nobody tells you which one it was. Generic advice to "be clear" is not actionable three days before a deadline.

**Who uses this workflow.** Anyone writing an ML paper for NeurIPS, ICML, ICLR, or a similar venue. The set covers one paper section per skill, abstract through rebuttal, plus a sentence-level audit pass and a review-triage skill for when reviews land.

**How it was built.** Two passes. First, accepted papers from leading ML groups read line by line for construction rather than content: where the contribution sentence sits, how many words before the first number, what the last sentence of a conclusion does. Patterns that held across authors became rules; patterns where strong authors disagreed became documented judgment calls with both options and the trade-off. Second, a real submission cycle, where rules that survived faculty review stayed and rules that produced stilted prose were cut.

**Details.** Ten skills, each a `SKILL.md` operating summary plus a long-form guide beside it. Plain Markdown with YAML frontmatter, no dependencies, so it works in Claude Code, Codex, and Cursor. MIT licensed. Ships with `scripts/audit.py`, a standard-library linter that checks the mechanical rules (bare demonstratives, hedges, unpaired numbers, agentless passives) over a `.tex` or `.md` file.