### PR TITLE
Add luopan travel planning skill to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
+- [luopan](https://github.com/saudademjj/luopan) - Travel itinerary planning skill: budget-first scoping, strict destination scope, source-verified facts with query dates, self-check before delivery. Chinese-first output; install via plugin marketplace. *By [@saudademjj](https://github.com/saudademjj)*
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.


### PR DESCRIPTION
Adds [luopan](https://github.com/saudademjj/luopan) to the Productivity & Organization section.

luopan is a travel itinerary planning skill (Chinese-first): budget must be confirmed before any draft output, itinerary stays within the stated destination, factual data (tickets, hours) carries sources and query dates, and a rule self-check table is delivered with every plan. It ships as a plugin marketplace (`plugin marketplace add saudademjj/luopan` → `plugin install travel-planner`) with a full example output (10-day Xinjiang road trip with the self-check table and source index).

Real use case: built through iterative review rounds against Nanjing, Suzhou, Hangzhou, Beijing, and a Xinjiang self-drive trip; rules were written back from actual planning mistakes, not hypotheticals.
