### PR TITLE
Add PM Skills to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [PM Skills](https://github.com/product-on-purpose/pm-skills) - 68-skill product management library covering discovery, definition, delivery, measurement, and iteration, with 6 sub-agents, 12 workflows, and 200+ sample outputs
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds `PM Skills` to **Business & Marketing**, in alphabetical order after "Lead Research Assistant".

Placed alongside "Brand Build Skills", which is the closest precedent in that section: an externally hosted, multi-skill library rather than a single skill vendored into this repo.

### Following the existing format

- Alphabetical order within the category
- Single-line entry, one-sentence description
- No emojis, punctuation consistent with neighbouring entries
- One insertion, zero deletions

### About the library

68 product management skills spanning the full lifecycle: discovery, problem definition, solution design, delivery, measurement, and iteration. It also ships 6 sub-agents, 12 multi-skill workflows, and 200+ real sample outputs.

Every skill is held to a contract validated in CI and versioned with SemVer, so this entry will stay accurate as the library changes. Apache 2.0, follows the agentskills.io specification.

523 stars, 31.1K installs on skills.sh, 66 tagged releases since January 2026.

Note this is a separate project from the similarly named `phuryn/pm-skills`.
