### PR TITLE
Add Wix to Astro Migration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [Wix to Astro Migration](./wix-to-astro/) - Migrate a full Wix site to Astro on Cloudflare Workers: code-first extraction from the live DOM, four verification passes, SEO hardening, cutover plan.
 
 ### Data & Analysis
 

--- a/wix-to-astro/SKILL.md
+++ b/wix-to-astro/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: wix-to-astro
+description: Migrate, rebuild, duplicate, or clone a website from Wix (or any page builder) into Astro on Cloudflare Workers — pixel-faithful, measured, and SEO-stronger than the original. Use this whenever the user wants to leave Wix, rebuild a builder-made site in code, match an existing page's look and feel exactly, extract real animations or interactivity from a live site, verify fidelity of a rebuild against an original, or plan a Wix-to-Astro cutover — even when they don't say "Wix" or "Astro", e.g. "rebuild our landing page so we can leave our page builder", "make the new page match the old one exactly, animations included", "move our site off Squarespace/Webflow into code". Also use it for any single phase alone: reconnaissance of a builder site, brand/design extraction, per-section rebuild, verification passes, or DNS/route cutover planning.
+---
+
+# Wix → Astro migration
+
+Version 1.1 · 2026-08-09
+
+> Distilled from two production migrations run with this exact method: engineeringleaders.io
+> and elc-conference.io. The second rebuilt 51 URLs in one overnight run and landed Lighthouse
+> 100/100/100 (performance / accessibility / best practices, mobile) with LCP under 800 ms —
+> then the owner's morning review still found four fidelity gaps, which is why Step 4.8 exists.
+
+Migrate a live Wix site into a code-owned Astro site on Cloudflare Workers, so faithfully that
+the owner struggles to tell them apart — then beat the original on performance and SEO.
+
+The core discipline: **code-first, not screenshot-first.** The primary source of truth is the
+live page's rendered DOM + computed CSS — exact px, hex, font metrics, spacing — extracted per
+section and rebuilt from those real values. Screenshots are a secondary sanity check. A
+screenshot-diff approach tells you *that* something looks different, not *which property* is
+wrong.
+
+## Before starting
+
+Read `references/setup.md` and confirm the required tools are installed (Node, wrangler, ffmpeg,
+Python + fontTools/Pillow, a real-browser automation tool). Every phase below assumes they exist;
+`setup.md` has one install line and one verify command per tool.
+
+## Workflow
+
+Each step below is a summary with a pointer. Load only the reference you are executing.
+
+### 1. Reconnaissance — `references/playbook.md` Steps 1–2
+Map every URL (sitemap.xml, don't assume "just a landing page"), inventory each page's sections /
+interactive elements / fonts / colors / CMS-driven parts, and check the deploy target's hard
+limits before choosing media quality (Cloudflare Workers rejects any static asset over 25 MiB).
+The font trap: page builders ship huge unused font libraries — only `getComputedStyle` on real
+rendered elements tells you what's actually painted; identify the real files by downloading them
+and reading their name tables, never by grepping markup.
+
+### 2. Scaffold — `references/playbook.md` Step 3
+Reuse an existing Astro + Wrangler config if one exists; otherwise scaffold Astro 5+ with the
+Cloudflare adapter. Deploy to a **staging URL (workers.dev) first** — never point new infra at a
+live domain's routes until an explicit, separately-approved cutover. Set the staging host
+`noindex` from the first deploy (`references/seo.md` — the static-build `_headers` trap).
+
+### 3. Per-section, code-first rebuild loop — `references/playbook.md` Step 4
+Extract the live DOM + computed CSS per section, rebuild from those exact values, glance-check
+with a screenshot, log every delta. On a second or later page, check for reused sections FIRST
+and extract shared components instead of duplicating. Once the loop is proven on one section by
+hand, parallelize independent sections across subagents (Step 6.5 has the safety rules: hard
+per-agent file scopes, own browser context per agent, verify against static build output).
+
+### 4. Verification — four distinct passes, budget for all four
+These catch non-overlapping error classes; skipping one ships its whole class:
+- **Side-by-side scroll-through** (Step 4.5) — gaps *between* sections, over-narrow queries.
+- **Typography audit** (Step 4.6) — all six computed text properties per role, not just
+  size + family.
+- **Interactivity extraction** (Step 5 + `references/interactivity.md`) — real animations via
+  `document.getAnimations()`, never attribute-counting; parallax checked separately (it doesn't
+  use the Animation API); the button interaction baseline.
+- **Tweaking round** (Step 4.8) — after content + visual passes, a sequential section-by-section
+  sweep at source level: content↔visual correspondence, positioning re-measured against recon
+  (rendered boxes win over recon tables), ALL background media including videos, and per-element
+  scroll/interactive effects against the original's source.
+
+### 5. Owner review — `references/playbook.md` Step 4.7
+Even four automated passes miss a class of gap only the owner's eyes catch. Step 4.7 lists the
+recurring patterns (stretched media frames, pills built as circles, missed `<img>` background
+layers, flattened carousels, undercounted CTA rows…). When the owner flags something, verify with
+real data before changing code; when a claim doesn't hold up under measurement, show the evidence
+— but on perception calls (e.g. "add parallax"), the owner's perception decides
+(`references/interactivity.md`).
+
+### 6. SEO + AI SEO — `references/seo.md`
+Make the rebuild *outperform* the Wix original, not just match it: production canonicals from day
+one, staging noindex that survives a static build (headers, not middleware, on static builds), a 5-type
+schema cap, sitemap hygiene, a tiered robots.txt that allows AI retrieval bots, crawler-delivery
+verification with curl, and a Lighthouse mobile ≥95 gate. No keyword research required — this is
+structural SEO, not content strategy.
+
+### 7. Cutover — `references/playbook.md` "Cutover considerations"
+Redirect map from a programmatic slug diff, route-specificity verification with curl (not
+assumption), staged + reversible route change, old platform kept live and paid through a soak
+period. Indexing pings only AFTER production returns 200 + indexable to bots.
+
+## Principles that cut across every step
+
+- **Don't invent values.** Every color, font, spacing, copy string, and animation timing traces
+  to something measured on the live site. If a value can't be recovered, ask the owner — never
+  ship a guess. That includes copy: migrate typos verbatim and flag them; fixing content is the
+  owner's call, not the migration's.
+- **A "no evidence found" result deserves the same scrutiny as a positive one.** An empty query
+  result means "doesn't exist" or "my query was too narrow" — indistinguishable until you widen
+  the search or check by another method.
+- **When a recon table and a rendered box disagree, the box wins.** Re-measure the built page in
+  a real browser; CSS that encodes the right numbers does not guarantee rendering them.
+- **Log corrections, not just successes.** Keep an append-only `BUILD-LOG.md` recording "first
+  pass assumed X, measurement showed Y" — it turns the next correction into a lookup instead of a
+  re-investigation, and stops later sessions from "fixing" verified-deliberate choices.

--- a/wix-to-astro/references/interactivity.md
+++ b/wix-to-astro/references/interactivity.md
@@ -1,0 +1,249 @@
+# Interactivity extraction: method + how to verify you got everything
+
+How to reverse-engineer real interactivity/animation from a live Wix site and apply it to the
+Astro rebuild, instead of guessing from `data-motion`-style attributes (which wildly overstate the
+real animation surface — most instances are structural markers, not choreography).
+
+## The method: `document.getAnimations()`, not attribute-counting
+
+Wix pages carry attributes like `data-motion-part`, `data-animation-name`, `data-animation-state`
+on hundreds of elements. Counting these overstates the real animation surface: most instances
+(background-layer markers like `BG_LAYER` / `BG_MEDIA`) have no animation attached, not evidence
+of choreography. A raw attribute count can suggest "hundreds of animated elements" when the real,
+verified figure is far smaller and simpler.
+
+The reliable method is the browser's own **Web Animations API**:
+
+```js
+document.getAnimations().length; // every real Animation object currently on the page
+```
+
+For each animation, `.effect.getComputedTiming()` gives real `duration`/`delay`/`easing`/`fill`,
+and `.effect.getKeyframes()` gives the actual `from`/`to` property values — not an estimate, the
+literal numbers the browser is using. Group by a signature (duration + animated properties +
+from/to values) to find the real, distinct "recipes" in use:
+
+```js
+const recipes = new Map();
+document.getAnimations().forEach((a) => {
+  const t = a.effect.getComputedTiming();
+  const kf = a.effect.getKeyframes();
+  if (kf.length < 2) return;
+  const key = `dur=${t.duration} props=${Object.keys(kf[0]).filter(k => !['offset','easing','composite','computedOffset'].includes(k)).join(',')} ${kf[0].opacity}->${kf[kf.length-1].opacity}`;
+  recipes.set(key, (recipes.get(key) || 0) + 1);
+});
+Array.from(recipes.entries()).map(([k, v]) => `${v}x  ${k}`).join('\n');
+```
+
+This surfaces the dominant, real pattern by frequency instead of by attribute presence. Implement
+the dominant recipe(s); small identity/reset animations (`transform: none → translate(0px)...`,
+opacity `1 → 1`) are internal tooling artifacts, not visible choreography — safe to ignore.
+
+**Caveat found in practice:** background/inactive browser tabs (common when driving a page via
+browser automation with several tabs open) can silently throttle `IntersectionObserver` callbacks
+and leave `getAnimations()`-based checks hanging indefinitely, or make a correctly-implemented
+reveal system look broken in your own rebuild. If a check seems to hang, or a reveal system you
+just built appears not to fire, force a real paint first (a screenshot action, or an actual
+scroll) before concluding anything is broken — it may just be a throttled background tab.
+
+## `getAnimations()` does NOT catch everything — check parallax separately
+
+This is the most important gap to know about. `getAnimations()` only surfaces effects implemented
+via CSS transitions/animations or the Web Animations API. **Parallax** (background moving at a
+different rate than the foreground as the user scrolls) is typically implemented one of two other
+ways, neither of which produces an `Animation` object:
+
+- `background-attachment: fixed` — pure CSS, no JS, no Animation object.
+- A scroll event listener directly mutating an element's `transform` on every scroll tick —
+  imperative style mutation, not the Animation API.
+
+**Don't conclude "no parallax" just because the `getAnimations()` sweep is fully explained by
+scroll-reveal and dropdown recipes.** Check for it directly and separately:
+
+```js
+// Record position before/after a scroll, compare each element's movement to the page's own
+// scroll delta. If any element moves a DIFFERENT amount, that's parallax.
+window.scrollTo(0, START);
+await new Promise(r => setTimeout(r, 150));
+const imgs = Array.from(document.querySelectorAll('img, video')).filter(el => el.getBoundingClientRect().width > 40);
+const before = imgs.map(el => el.getBoundingClientRect().top);
+window.scrollTo(0, START + 300);
+await new Promise(r => setTimeout(r, 150));
+const after = imgs.map(el => el.getBoundingClientRect().top);
+const scrollDelta = 300;
+const nonMatching = before.map((b, i) => Math.round(b - after[i]) - scrollDelta).filter(d => Math.abs(d) > 3);
+// nonMatching.length === 0 across a few ranges spanning the whole page -> genuinely no parallax.
+
+// Also check for the pure-CSS version:
+Array.from(document.querySelectorAll('*')).filter(el => getComputedStyle(el).backgroundAttachment === 'fixed').length;
+```
+
+Run this across several scroll ranges spanning the full page (not just one spot), on a fresh page
+load. A real worked example: 55 `img`/`video` elements checked across four ranges spanning an
+entire landing page, zero moved at a different rate than the page scrolled, zero elements used
+`background-attachment: fixed` — genuinely no parallax existed on that site, confirmed by
+measurement rather than assumed from an animation-object count.
+
+**"No parallax measured" ≠ "no perceived parallax" — and the owner's perception decides.** On
+that same site the owner later described a section as having "pictures with a parallax effect".
+The measurement was correct (zero scroll-linked deltas); what the owner was perceiving was the
+combination of float-in reveals (`translateY(-50%)→0` on entry) and two infinite slow rotations
+on decorative layers, which together read as depth. Two consequences:
+
+1. Reproduce those float/rotation recipes faithfully — if they're skipped, the section feels
+   flat and the owner reports "the parallax is missing" even though none existed.
+2. If the owner explicitly asks for parallax, add a subtle scroll-linked drift (rAF, per-layer
+   rate, centred on the section midpoint, disabled under `prefers-reduced-motion`) and log it as
+   a **perception-matching deviation**, not a measurement. Don't argue the measurement at the
+   owner; the measurement explains *why* they perceive it, it doesn't override what they want.
+
+## Verifying a specific font "looks different" claim
+
+If a rebuilt page's text looks visually different from live even though the computed
+`font-family`/`size`/`weight` values match, don't guess — resolve the actual font identity:
+
+1. Read `getComputedStyle(el).fontFamily` on the live element — it's usually a comma-separated
+   fallback chain starting with a page-builder-generated hash name (e.g. `wfont_23c8a5_...`) and
+   ending in a more human-readable fallback name.
+2. Find the real font FILE: check `performance.getEntriesByType('resource')` for `.woff`/`.woff2`
+   requests matching that hash — Wix serves custom/uploaded fonts from a `ufonts` CDN path.
+3. Download the file and read its own internal name table (don't trust the CDN URL or CSS class
+   name alone — those are opaque hashes) — e.g. with Python's `fontTools`:
+   ```python
+   from fontTools.ttLib import TTFont
+   f = TTFont('downloaded-font.woff2')
+   for rec in f['name'].names:
+       if rec.nameID in (1, 4, 6, 16, 17):  # family, full name, postscript name, etc.
+           print(rec.nameID, rec.toUnicode())
+   ```
+   This gives the font's own claimed identity (e.g. "Inter Medium"), which is authoritative —
+   more reliable than any hash or filename.
+4. Compare against what the rebuild actually has loaded: `document.fonts` lists every `FontFace`
+   with its `family`/`weight`/`status` — confirm the matching weight shows `status: "loaded"`, not
+   silently falling back to a system font.
+5. If the font family, computed size/weight/line-height/letter-spacing, and loaded-font-status all
+   match, the rebuild is correct — the visual impression of "different font" may be a false alarm
+   (screenshot compression, a different scroll/animation state, viewing conditions) rather than a
+   real gap. Report the verification data, don't silently "fix" something that measures identical.
+
+## What a real migration found (worked example, for calibration)
+
+On one real Wix → Astro migration: 152 real `Animation` objects present at page load. Grouped by
+recipe, the dominant patterns were a scroll-triggered fade (opacity 0→1, 1200ms,
+`cubic-bezier(0.445, 0.05, 0.55, 0.95)`, `fill: "backwards"` — paused until scrolled into view) and
+a nav-dropdown reveal (`opacity` + `clip-path`, 0.4s, `cubic-bezier(0.645, 0.045, 0.355, 1)`,
+confirmed by hovering live and reading both the closed and open computed styles — a single read
+only gives you one side of a hover transition). No stagger delay on repeated grid items. No
+scroll-jack. No parallax anywhere on the page, confirmed by direct measurement. The "hundreds of
+motion-looking attributes" on the live DOM did not correspond to hundreds of real animations.
+
+**A second page on that same site DID have real parallax** — this is why the parallax check must
+run per page, not once for the whole site. The landing page had none; a secondary page's hero had
+two flanking photos with a genuine scroll-linked `transform: matrix(...)` mutated by a scroll
+listener (confirmed via `getBoundingClientRect()` inspection up the ancestor chain — no
+`data-parallax`-style attribute exposed it directly). The movement-delta test gave a stable,
+reproducible ratio per element (0.792 and 0.865 — i.e. each photo lags behind the page scroll by a
+different amount), re-verified after a settle wait to rule out a load-in-animation artifact rather
+than genuine scroll-linked movement. Implemented as `translateY` computed from each element's
+scroll position *at mount* (not a live `getBoundingClientRect()` read on every frame, which would
+include the transform this same script just applied and double-count it): `offset = (currentScrollY
+- mountScrollY) * factor`, where `factor = 1 - measuredRatio`. The rebuilt result matched live's
+ratio exactly, at every tested scroll position.
+
+## Implementation checklist
+
+1. Load the live page fresh (not a stale, heavily-scrolled tab — animations that already played
+   once read as `finished`/`opacity: 1`, masking the real pre-reveal state).
+2. Run `document.getAnimations().length` immediately after load. Group by recipe (script above).
+   Implement the dominant recipe(s) by frequency, not every unique value.
+3. For hover-triggered UI (dropdowns, accordions), search for `[data-animation-name]` /
+   `[data-motion-enter]` attributes, then hover the live element and re-read `getComputedStyle` to
+   capture both the closed AND open state.
+4. Separately, run the parallax movement-delta check (above) across a few scroll ranges spanning
+   the whole page, and check for `background-attachment: fixed`. Do this even if step 2 already
+   found and explained every `Animation` object — parallax uses a different mechanism entirely.
+5. Implement with a progressive-enhancement guard: content visible by default (no-JS-safe), a
+   script only opts elements into the pre-reveal hidden state once it actually runs. A script
+   failure should never permanently hide real content.
+6. Respect `prefers-reduced-motion` even if the source site doesn't — this is an accessibility
+   default worth keeping regardless of source-site fidelity.
+7. After implementing, verify against the live site's real behavior (not just "it fades in, looks
+   about right") — compare duration/easing by eye at slow motion if needed, confirm hover states
+   open AND close correctly, confirm the reveal fires once (not repeatedly) as content re-enters
+   view unless the source site genuinely re-triggers.
+
+
+## Buttons: the migration's most-missed interaction
+
+Wix renders its own hover states from the page builder, so they exist on the live site but live
+NOWHERE in anything you extract — `document.getAnimations()` will not report them (they are CSS
+transitions on `:hover`, not Web Animations), and a DOM/computed-CSS dump taken at rest captures
+the resting state only. The result is a rebuild that looks pixel-identical in a screenshot and is
+completely dead to the pointer.
+
+Do not try to extract them. Ship the baseline below on the canonical button class as part of the
+rebuild, then compare against live by actually hovering, pressing and TABBING to a button on both.
+
+### Button interaction baseline — NON-NEGOTIABLE, define once, never per component
+
+A button with no states is a rectangle. Every button ships with FOUR states or it is not done,
+and they are defined ONCE on the canonical class in global CSS, never per section.
+
+Why this is a hard rule and not advice: an audit of engineeringleaders.io on 2026-08-06 found
+**183 button instances across 47 files and not one `:hover`, `:active`, `:focus-visible` or
+`transition` on either canonical class**. Every button on a whole production estate was inert,
+including under keyboard focus. It passed every other gate. Nothing catches this unless it is
+checked explicitly, because an inert button looks completely correct in a screenshot.
+
+```css
+.btn-primary, .btn-secondary {
+  cursor: pointer;
+  -webkit-user-select: none; user-select: none;  /* double-tap selecting the label reads as broken */
+  transition:
+    transform 180ms cubic-bezier(0.34, 1.4, 0.64, 1),   /* slight overshoot = "attached to the pointer" */
+    background-color 220ms ease, border-color 220ms ease, color 220ms ease, box-shadow 220ms ease;
+}
+
+/* GUARD hover behind (hover: hover). Without it a tap leaves a touch device stuck in the hover
+   state until the user taps elsewhere — the single most common mobile button bug. */
+@media (hover: hover) {
+  .btn-primary:hover  { transform: translateY(-2px); background: <one step brighter>;
+                        box-shadow: 0 10px 22px -12px <fill colour at ~55%>; }
+  .btn-secondary:hover{ transform: translateY(-2px); border-color: <text colour>;
+                        background: <text colour at 7%>; }
+}
+
+/* :active is not optional — on touch it is the ONLY feedback, since :hover never fires. */
+.btn-primary:active, .btn-secondary:active { transform: translateY(0) scale(0.97); transition-duration: 90ms; }
+
+/* focus-visible, NOT focus: a mouse click must not leave a ring behind. Missing entirely is an
+   accessibility failure, not a polish gap — a keyboard user cannot see where they are. */
+.btn-primary:focus-visible, .btn-secondary:focus-visible { outline: 2px solid <accent>; outline-offset: 3px; }
+
+.btn-primary[disabled], .btn-secondary[disabled],
+.btn-primary[aria-disabled='true'], .btn-secondary[aria-disabled='true'] {
+  opacity: 0.45; cursor: not-allowed; transform: none; box-shadow: none;
+}
+
+/* Drop the MOVEMENT only. Colour, ring and press feedback stay — a reduced-motion user still
+   needs full affordance. Killing every state here is the common over-correction. */
+@media (prefers-reduced-motion: reduce) {
+  .btn-primary, .btn-secondary { transition: background-color 220ms ease, border-color 220ms ease, color 220ms ease; }
+  .btn-primary:hover, .btn-secondary:hover,
+  .btn-primary:active, .btn-secondary:active { transform: none; }
+}
+```
+
+Define this on the canonical class and all N instances get it in one edit; per-component hover
+classes guarantee drift and guarantee some component gets missed. If a section genuinely needs a
+different size, override `font-size`/`padding` in that component and inherit every state.
+
+**Verify before shipping — an inert button is invisible in review:**
+
+```bash
+# Against the BUILT html/css, not the source: catches states lost to a scoped-style mistake.
+for s in ':hover' ':active' 'focus-visible' 'aria-disabled' 'hover: hover' 'prefers-reduced-motion'; do
+  printf '%-24s %s\n' "$s" "$(grep -c -- "$s" dist/**/index.html 2>/dev/null | head -1)"
+done
+# Then tab to a button in a real browser. If you cannot see where focus is, it is not shipped.
+```

--- a/wix-to-astro/references/playbook.md
+++ b/wix-to-astro/references/playbook.md
@@ -1,0 +1,382 @@
+# Playbook: Duplicating a Website (Code-First Method)
+
+Generalized from a real Wix → Astro migration. A site-agnostic method for rebuilding an existing
+website in code with pixel/behavior fidelity — the source doesn't have to be Wix and the target
+doesn't have to be Astro, but this is written with that pairing in mind since it's the most common
+case: Wix's page-builder output makes naive approaches (copy the HTML, eyeball the styles) fail in
+specific, recurring ways this playbook exists to catch.
+
+## Method summary
+
+**Code-first, not screenshot-first.** Screenshots are a secondary sanity check, not the primary
+measurement. The primary source of truth is the live page's actual rendered DOM + computed CSS —
+exact px, hex, font metrics, spacing — extracted per section and rebuilt from those real values.
+A screenshot-diff approach is too slow and fuzzy for real fidelity: it tells you *that* something
+looks different, not *which property* is wrong or by how much.
+
+## Step 1 — Reconnaissance (before writing any code)
+
+1. Map the site (all URLs, template count) — don't assume "it's just a landing page."
+2. Scrape/read the target page for: section inventory + order, interactive elements, fonts,
+   colors, dynamic/CMS-driven parts, third-party widgets, single vs multi-page scope.
+3. Separate **design** (copy this) from **backend** (this is a data model, not a pixel — decide
+   deliberately whether to snapshot it statically or model it properly, e.g. as an Astro content
+   collection).
+4. Check what's already reusable in-house before building anything new: existing brand kits,
+   existing framework+deploy stack, existing i18n solutions. Don't rebuild solved problems.
+5. Know the deploy target's hard platform limits up front (max asset size, request size, etc.) —
+   e.g. Cloudflare Workers rejects any single static asset over 25 MiB. Check this before choosing
+   media quality/resolution for anything heavy (video especially), not after a failed deploy. A
+   five-minute check here avoids a rework cycle at the deploy step.
+
+## Step 2 — Brand kit extraction
+
+- Pull real values, not eyeballed ones: hex codes from computed styles, exact font-family names
+  and weights from `getComputedStyle`, spacing rhythm from repeated measurements across sections.
+- **Fonts: never trust a grep of raw HTML/CSS text for "what font does this site use."** Page
+  builders (Wix, Squarespace, ...) ship a large global font library in every site's stylesheet —
+  most of it declared but never assigned to any element. Grepping font-family strings out of the
+  markup surfaces that whole unused library, not what's actually painted. The only reliable
+  answer: walk the rendered DOM and read `getComputedStyle(el).fontFamily` on real elements
+  (headings, body, buttons, quotes/emphasis). Cross-check a handful of element types before
+  concluding — one element could be an outlier, four agreeing is a pattern.
+  (Real example: a live-site scan initially reported "Helvetica Neue + Poppins" from a raw-HTML
+  pass; the computed-style pass showed 100% of rendered text was actually a different family
+  entirely, reversing a "must accept a font-license risk" decision into "no risk exists.")
+- Once the real fonts are identified, extract the actual `.woff2` files from the site's own CDN
+  (visible in `@font-face src` URLs) rather than substituting a Google Fonts / Fontsource lookalike
+  — the site's own file IS the exact match, and is usually a direct, licensable download.
+- Note where the live site uses baked images (e.g. gradient PNGs) vs live CSS — baked images are
+  *easier* to reproduce (just re-host the asset) than reverse-engineering a CSS effect.
+
+## Step 3 — Scaffold from an existing stack, don't start from zero
+
+- If a matching framework+deploy pattern already exists elsewhere (a sibling project, a template),
+  clone the config (build tool, deploy config, i18n plumbing) — not the components. Components are
+  usually page-specific; config/tooling is usually fully reusable.
+- Deploy target: stand up on a **staging URL** first. Never point new infra at a live domain's
+  routes until an explicit, separately-approved cutover step. This is a hard rule, not a
+  suggestion — the whole point of rebuilding in parallel is that the live site keeps serving
+  traffic untouched until you're ready.
+
+## Step 3.5 — Extraction hygiene
+
+- **Resize the extraction viewport explicitly before measuring anything.** A browser tab's default
+  window size is whatever the OS/display gives it, not a standard breakpoint. Every pixel
+  measurement taken before resizing to your target breakpoint (1440, 390, etc.) is wrong. Resize
+  first, confirm `window.innerWidth`, then measure.
+- **Check actual scroll/interactive behavior, not just one element's own computed style.** A
+  "sticky header" may report `position: relative` on the header itself while an ancestor wrapper
+  actually does the pinning (common in page-builder output). Verify by scrolling and re-measuring
+  `getBoundingClientRect()`, not by reading one property once.
+- **For large inline assets (long SVGs, etc.) that a tool's output limit truncates:** don't burn
+  many round trips reconstructing raw markup chunk by chunk. Check the project's own existing asset
+  library for a match first — compare distinguishing features (exact color palette, aspect ratio)
+  to confirm it's the same asset, then use that file directly.
+- **Treat a prior brand-kit/design doc as a snapshot in time, not a permanent fact.** Section
+  counts, row layouts, and structure claims can go stale between the doc's capture date and today.
+  Re-verify against the live DOM rather than trusting the document — it's a hypothesis, the live
+  page is ground truth.
+- **When climbing the DOM to find "the card/section containing this element," scope by a
+  structural signal, never a fixed hop count.** A fixed `for (i=0;i<N;i++) el = el.parentElement`
+  that correctly reaches one card's container will silently over- or under-shoot on a
+  differently-nested repeated item elsewhere on the same page — every item then returns the SAME
+  (wrong) data, which reads as success (no error, plausible-looking output) until you check for
+  duplicates. Scope instead by a real structural condition: "the closest ancestor containing
+  exactly one of [the marker I'm querying for]." This is a recurring failure mode across sections
+  with repeated card layouts (testimonials, meetup/event grids, team grids) — treat any fixed-hop-
+  count DOM climb as a known trap to actively avoid, not a one-off mistake.
+- **MD5-compare any batch of downloaded assets when there's any chance of a copy/transcription
+  slip** (manually copying N extracted URLs into N download commands is exactly that chance). An
+  off-by-one shift is invisible by eye in a list of hashes/filenames but immediately obvious the
+  moment you diff file hashes and two match that shouldn't.
+
+## Step 4 — Per-section, code-first rebuild loop
+
+**Before rebuilding a section from scratch, check whether it already exists as a component from
+an earlier page in this same migration.** Wix (and page builders generally) let an editor drop the
+same visual block onto multiple pages — a conference promo banner, a partner-logo wall, a
+cross-property card row — and each placement looks byte-identical on the live site even though
+Wix's own internal representation treats them as independent instances with no shared source. If
+page 2's Section C looks pixel-identical to page 1's Section C already built, don't re-extract and
+re-build it as new markup: import the existing component and reuse it. Concretely:
+
+- Before starting a section, scan already-built pages' sections for a visual match (same copy,
+  same layout, same assets) — not just "looks similar," genuinely identical.
+- If a match exists, confirm it's really the same content on live (not two sections that happen to
+  share a layout but differ in copy/links) by diffing the actual text and hrefs, not just the
+  screenshot.
+- Extract that section into a shared component (if it wasn't already one) and import it on the new
+  page, rather than copy-pasting the component file. Copy-pasting means every future correction has
+  to be applied twice (or drifts silently when it isn't) — one shared component means one fix
+  location.
+- If the sections are ALMOST but not quite identical (same layout, different copy/links per page),
+  that's a parameterization signal, not a reuse-as-is signal: build one component that accepts the
+  varying parts as props, rather than either duplicating the whole section or forcing a false
+  "identical" merge that loses the real per-page differences.
+
+For each genuinely new section, in order:
+1. Extract the live section's DOM structure + computed CSS per element (not just a screenshot).
+2. Rebuild the section from those exact values.
+3. Confirm with a quick screenshot glance (secondary check, not the primary measurement).
+4. If it doesn't match, correct the specific extracted value that's wrong and repeat.
+5. Log the section in a build log: started-with delta, what changed, whether it helped. This log
+   pays for itself the moment a later correction needs to explain *why* a value changed — "the
+   first pass eyeballed it, the second pass measured it" is a very different situation from "we
+   don't know why this value is what it is."
+
+## Step 4.5 — Full side-by-side comparison pass (do this even after every section is "done")
+
+Isolated per-section extraction is efficient but structurally blind to two classes of error a
+dedicated final pass catches:
+
+- **Gaps *between* sections.** A stray link, badge, or small element sitting in the "dead zone"
+  between one obvious section and the next gets missed because no single extraction query's scope
+  covers it — each section extraction correctly covers its own section and nothing sitting just
+  outside it.
+- **Wrong negative results.** "I checked for X and found none" needs the SAME scrutiny as a
+  positive finding, not less — especially when a human glancing at the live site can see X right
+  there. A query scoped too narrowly (e.g. `heroSection.querySelectorAll('video')` when the video
+  element actually lives in a wrapper the query didn't include) silently returns an empty, falsely
+  confident result.
+
+Do a full scroll-through with the rebuild and the live site open side by side, at matching scroll
+positions, after the section-by-section builds are complete. This is a distinct verification step,
+not a redundant repeat of Step 4 — budget for it as a standard part of the process, not an optional
+extra. If the live site ignores synthetic wheel-scroll/keyboard events (some Wix sites use a
+custom scroll-jack mechanism that doesn't respond to automation-synthesized gestures even though
+the page isn't frozen), drive scroll position via `window.scrollTo()` directly instead of
+simulated input; confirm with `window.scrollY` that it actually moved before concluding a section
+doesn't exist or a screenshot is stale.
+
+## Step 4.6 — Dedicated typography audit (a third, distinct verification pass)
+
+Neither the per-section code-first build (Step 4) nor the full-page visual scroll-through
+(Step 4.5) reliably catches font-metric gaps — they're rarely visually obvious at normal reading
+distance but are load-bearing for true fidelity. Run a dedicated pass, per section, checking all
+six computed properties for every distinct text role: `font-family`, `font-size`, `font-weight`,
+`font-style`, `line-height`, `letter-spacing`. Match live elements to rebuilt elements by visible
+text content, not DOM position.
+
+- **Never trust a framework's default line-height for an arbitrary font-size.** Setting an
+  arbitrary size only sets size; line-height silently falls back to the framework default (e.g.
+  Tailwind's 1.5), which is very often wrong. Live sites use different ratios per role (tight
+  ~1.0 for large display headings, ~1.4 for labels/names, ~1.6 for body copy/buttons) — always
+  pair an arbitrary size with an explicit, measured line-height.
+- **Check letter-spacing explicitly, every time — don't wait for something to "look tight."** Real
+  negative tracking on headlines/numbers/labels is easy to miss entirely if you only check it when
+  a mismatch is visually suspected.
+- **Re-verify every `clamp()`/fluid-size formula resolves to its intended value at the actual
+  target viewport** — a coefficient that looks reasonable can silently fall short of (or overshoot)
+  its own cap. This recurs across unrelated sections; treat it as a standing checklist item, not a
+  one-off catch.
+- **A platform's raw `font-weight`/`font-style` CSS properties may not be trustworthy signals.**
+  Wix, for one, bakes real weight/style into which uniquely-named static font file gets loaded
+  (`orig_inter_medium`, `orig_lora_semibold_italic`, etc.) and its literal CSS properties report
+  generic values (`400`/`normal`) almost everywhere regardless of visual weight or slant. Diff on
+  the font-family identity/suffix, not the numeric property, when the platform does this.
+- **Don't assume one shared button/CTA class covers every context.** Different contexts on the
+  same live site (e.g. a compact nav pill vs. an in-page marketing CTA) can genuinely use different
+  font metrics for what looks like "the same button style." Confirm this with data before either
+  (a) editing a shared/global style broadly or (b) concluding every instance needs its own
+  bespoke fix — check enough distinct usages to tell whether the values cluster (one shared fix
+  needed) or genuinely diverge by context (per-context scoped overrides are correct, not a
+  workaround). Getting this backwards means either a wrong global change with wide blast radius or
+  needless duplicated one-off overrides.
+- **A window-resize automation call can silently no-op on a browser tab that's been reused across
+  a long session** (window stuck at its original size regardless of the requested dimensions).
+  Always confirm `window.innerWidth` actually changed after resizing before trusting any
+  measurement taken in that tab; if it didn't change, abandon that tab and open a fresh one rather
+  than debugging the resize.
+
+Scope discipline: decide upfront which fidelity dimensions are in scope for this pass (e.g.
+static layout/type/color now, animation later) and hold that line — don't let one section's
+extra polish creep into every section's budget.
+
+## Step 4.7 — Owner spot-check pass (the human verification layer — run it AFTER Step 4.8)
+
+Steps 4, 4.5, and 4.6 are all automatable — DOM extraction, scroll-through, computed-style diff.
+Even run well, they miss a real class of gap that only surfaces when the site owner compares the
+rebuild against live with their own eyes, item by item. Budget for this pass explicitly rather
+than treating owner feedback as a signal something upstream failed. Concrete, recurring failure
+patterns from real rebuilds, generalized so the next one checks for them proactively instead of
+waiting to be told:
+
+- **Media frames: check for a fixed aspect ratio before assuming full-bleed or full-stretch.**
+  A background video/image inset from the section edge (a rounded card) is one gap; a SEPARATE
+  gap is whether that frame's height is a fixed aspect ratio (common on page-builder platforms) or
+  genuinely stretches to fill its container. Measure both `width` and `height` of the frame, not
+  just its inset from the edges — `aspect-ratio` in the live computed style is the direct signal;
+  don't infer height from "fills the section."
+- **A landscape "pill" shape is not a circle.** `border-radius` clamped to a huge value (e.g.
+  9999px, or a platform's own huge px number) on a NON-square box produces a stadium/pill/oval —
+  visually distinct from a circle. If a thumbnail's wrapper box isn't square (check computed
+  `width` vs `height`, not just the class name), don't reach for a square-crop-plus-full-round
+  utility by habit — measure the real aspect ratio and keep it non-square with the same rounding.
+- **A decorative background can be a real `<img>` sibling, not a CSS `background-image`.** If a
+  glow/wash/watermark is visible behind text but `getComputedStyle(el).backgroundImage` is `none`
+  on every ancestor up to the section, don't conclude there's no background asset — search the
+  section for `img`/`canvas`/`video` elements positioned behind the text by z-index or DOM order
+  instead. Platforms differ in which mechanism they use for the "same-looking" effect.
+- **`getComputedStyle(...).color` alone doesn't capture text styling — check `textDecorationLine`
+  too.** A near-invisible "ghost" color and a genuine strikethrough can share the exact same color
+  value; matching the color while missing `text-decoration-line: line-through` produces a visually
+  very different (and wrong) result even though the one property that was checked matches exactly.
+  When a text role looks unusually faint or stylized in a live screenshot, check the full
+  text-decoration/text-transform property group, not just color and font metrics.
+- **"No visible controls" on a carousel/rotator is a suspect finding, not a confident one.**
+  Hover-revealed or focus-revealed controls (common for carousel arrows) don't exist in the DOM,
+  or exist with `opacity:0`/`visibility:hidden`, until the live page is actually hovered/focused —
+  a static `querySelectorAll` pass finds nothing and can wrongly conclude "static grid, no
+  controls, build it as a static grid." If a section behaves like a carousel (auto-advancing
+  content, one item visible at a time) treat it as one — with real prev/next controls, even if a
+  static DOM scan reports none — rather than flattening it into a static multi-column grid.
+- **Recount every CTA row against live before shipping it as "done."** It's easy to build the
+  buttons/links you found and stop, without re-confirming the exact count and order against the
+  live page one more time. A row with "1 button + 1 link" and a row with "2 buttons + 1 link" look
+  similar enough in a quick pass to miss the difference; explicitly count and compare, per CTA
+  row, as its own checklist item. This includes the actual `href` attribute-search — a grep for
+  `href="..."` misses links whose destination is a runtime expression (e.g. an array-driven
+  `href={item.url}` in a repeated card component), so also grep for the *pattern*, not just
+  literal-string hrefs, before declaring a link inventory complete.
+- **A `max-width` measured on one element doesn't necessarily apply to its siblings.** A heading
+  and the body copy directly below it can legitimately have different container widths on live
+  (e.g. a wide heading over a narrower paragraph) — measure each text role's own rendered width
+  independently rather than reusing one "the text block is Npx wide" number for the whole group.
+
+## Step 4.8 — Tweaking round (the last automated pass, before the owner sees it)
+
+When the content migration and visual transition are finished, go again **sequentially, section
+by section** — not spot-checking, a full ordered sweep. For each section:
+
+1. **Content ↔ visual correspondence.** Does every string, image, and video that the original
+   section shows appear here, in the same position? Verify at SOURCE level, not screenshot level:
+   diff the rebuilt markup against the original section's DOM, including background media —
+   images AND videos. Background media is where this round earns its keep: a `<video>` behind a
+   headline, a wash `<img>` behind a card.
+2. **Positioning, measured.** Re-measure the rendered boxes of the rebuilt section in a real
+   browser and diff against the recon values. Do not trust that CSS which *encodes* the right
+   numbers *renders* the right numbers — three real failure modes from one migration:
+   - A square source video with `height: 100%` rendered 1287×1287 in a 710px box (intrinsic
+     ratio won); the fix is a fixed height on both box and element. Measure the rendered box
+     of every `<video>`/`<img>`, never assume the CSS constrained it.
+   - Vertically centering a hero content column instead of using the measured page offsets
+     drifted every element 20–40px. If the original positions content at absolute coords,
+     reproduce the coords as explicit margins, then re-measure.
+   - Two adjacent original sections merged into one component silently collapsed their summed
+     paddings (29.9 + 28.1 ≈ 59px of air became 4px). **Inter-section spacing is the SUM of the
+     lower section's top padding and the upper section's bottom padding** — when merging
+     sections, transfer the sum, then re-measure the rendered gap.
+3. **Interactivity, per element.** For each element and for the section as a whole, inspect the
+   scrolling and interactive effects **in the original's source**: the `document.getAnimations()`
+   recipes for that section, stacking order of decorative layers, scroll behaviour, hover/focus
+   states. Rebuild what runs, not what the markup's attributes imply (see `interactivity.md`).
+4. **When a recon table disagrees with a rendered box, the box wins.** A recorded padding of
+   `9.36px 17.54px` alongside a recorded box of `327×84` cannot both describe the same element —
+   the padding belonged to an inner span. Re-measure the outer element and derive the padding
+   from the box.
+
+Two content-parity items that hide in plain sight during this round:
+
+- **The consent/cookie banner is content, not chrome.** If the original shows one, the rebuild
+  ships one — same copy, same controls. A dismissal without an explicit choice must NOT be stored
+  as consent.
+- **Scattered decorative layers are load-bearing to the owner.** A composition of small photos /
+  illustrations around a video may look skippable and will be flagged in the first owner review.
+  Never simplify it silently: either rebuild it (convert absolute offsets to percentages of the
+  measured stage so it scales) or defer it loudly per Step 5.
+
+## Step 5 — Defer expensive fidelity dimensions explicitly, don't skip them silently
+
+Some fidelity dimensions (exact scroll-animation choreography, complex gallery widgets) are
+disproportionately expensive relative to their visual payoff in an early pass. When deferring:
+- Say so explicitly and log it as a decision, not an oversight.
+- Leave structural hooks (stable class/data attributes) so the deferred layer can attach later
+  without reworking the markup.
+
+**When it's time to stop deferring animation, use `document.getAnimations()`, not the source
+site's `data-motion`-style attributes, to find the real choreography.** See `interactivity.md` in
+this skill's references for the full method and a worked example.
+
+## Step 5.5 — Check for a full-resolution-original URL trick before asking the owner
+
+Some platforms serve a resized/cropped/compressed copy on the page but expose the untouched
+original at a predictable, unauthenticated URL. **Wix:** strip the `/v1/fill/...` or `/v1/fit/...`
+transform segment from any `static.wixstatic.com/media/<id>~mv2.<ext>` URL — what's left is the
+original upload at full resolution, no login required. Check for an equivalent on other platforms
+(Squarespace, Webflow, Shopify all have their own CDN URL conventions) before asking the site owner
+for a manual media export — it may already be unnecessary for anything currently published.
+
+## Step 6.5 — Parallelizing across sections with subagents
+
+Once the method is proven on one section (build it yourself first — don't parallelize before you
+know the loop works), the remaining sections are independent and can be dispatched in parallel,
+one subagent per section, for large wall-clock savings. What makes this safe in practice:
+
+- **Hard scope boundaries per agent.** Each agent may only create/edit its own new component file
+  and its own new asset folder. It must never touch shared files: the page(s) that assemble
+  sections, the shared build/change log, nav/footer, or any other agent's section. One coordinator
+  (you) does the integration pass afterward. This is what makes lock-free parallel writes safe —
+  there's no shared-file contention if no agent touches a shared file.
+- **Own browser tab per agent.** If extraction needs a live browser, each agent creates its own new
+  tab rather than reusing one — concurrent agents on the same tab will step on each other's
+  navigation/state.
+- **Don't rely on a shared long-lived dev server for verification.** A dev server is a mutable
+  shared resource: one agent restarting it (e.g. to pick up new CSS classes) can break another
+  agent's in-flight check. Prefer verifying against the **static build output** (e.g. `pnpm build`,
+  then inspect the generated HTML/CSS) — every agent can run this independently without
+  interfering with others.
+- **Each agent returns a paste-ready log entry instead of writing to the shared log itself** —
+  avoids concurrent-write races on one file. The coordinator appends them all in one pass afterward.
+- **Give every agent the same structural reference** (e.g. "look at this already-built section,
+  match its header-comment convention and code style") so parallel output is stylistically
+  consistent without needing a cleanup pass.
+- **After all agents land:** sweep for stray artifacts (`git status --porcelain`, leftover browser
+  tabs pointing at deleted temp routes, stray dev-server processes on other ports) before
+  integrating — parallel agents each doing their own verify-then-delete cycle can leave session
+  debris even when each one individually cleaned up after itself.
+- **Do ONE authoritative full-page structural pass yourself before integrating**, even though each
+  agent verified its own section. A section-order or adjacency claim from a design doc (or from one
+  agent's local context) is a hypothesis until a single walk of the whole live page confirms it —
+  individual per-section checks can each be locally correct about their own boundaries and still
+  collectively disagree about global order.
+
+## Step 6 — What only the site owner can provide (ask early)
+
+- Full-resolution original media (site's own CMS/media-manager export beats scraped/CDN-resized
+  copies every time).
+- Editor/source access for anything whose *exact* behavior isn't recoverable from rendered output
+  alone (e.g. an animation editor's timing/easing values).
+- Original design source (Figma, brand guide) if it exists — turns "measured approximation" into
+  "exact value."
+
+## Cutover considerations (once the rebuild passes owner review)
+
+- Inventory the FULL live URL surface before assuming scope — sitemap XML files, robots.txt, and
+  a raw page/template count from the source platform's own admin are all more reliable than
+  guessing from the nav menu. A "just the landing page" migration often turns out to have a much
+  smaller (or larger) real remaining URL surface than assumed once actually counted.
+- Build a redirect map for every URL whose slug changes between old and new — this is not
+  optional for SEO continuity. Page-builder platforms often generate slugs with different escaping
+  rules than a hand-built router (e.g. keeping punctuation/apostrophes URL-encoded where a rebuild
+  strips them) — diff the two slug sets programmatically, don't eyeball a sample.
+  Numeric/ID-based aliases (e.g. `/post/42`) are worth keeping stable across rebuilds regardless of
+  slug changes, since they're the most likely to be linked from outside the site.
+  Also check the destination when following the *pattern* not just the literal string — see the
+  CTA-row note in Step 4.7 about `href={item.url}`-style dynamic links.
+- Check for existing routes already carved out of the source domain before adding new ones (a
+  previous partial migration, a form handler, a subdomain) — a route that's too broad can
+  accidentally swallow traffic meant for something already working.
+- Stage the deploy with a redirect/route change that's reversible in seconds (e.g. deleting a
+  Worker route reverts every request to the old origin) and keep the old platform live and paid
+  for a soak period — don't cancel the old hosting the same day as cutover.
+- Re-run the redirect map as an actual verification pass after cutover: curl every old URL and
+  confirm it resolves to a 200, not just that the redirect rule exists.
+
+## Open questions / not yet validated
+
+- Best concrete tooling for "computed CSS per element" extraction at scale (one node at a time
+  vs a bulk per-page dump) — case-by-case so far.
+- How to handle CMS-driven sections (event feeds, galleries) generally — content-collection
+  modeling vs static snapshot vs live API wiring — decide per-project based on how often the
+  source content actually changes and who needs to edit it going forward.

--- a/wix-to-astro/references/seo.md
+++ b/wix-to-astro/references/seo.md
@@ -1,0 +1,120 @@
+# SEO + AI SEO for a migrated site
+
+The point of leaving Wix is not parity — it's advantage. A code-owned Astro site can beat the
+builder original on every structural signal: paint speed, markup quality, schema, crawler
+delivery. This file is the structural layer only; it deliberately involves **no keyword or query
+research** — content strategy is a separate discipline.
+
+Everything here is verifiable with curl or Lighthouse. Run the checks; don't assume.
+
+## 1. Staging discipline: production canonicals + a noindex that actually delivers
+
+Set `site` in `astro.config.mjs` to the FINAL production origin from day one, and build every
+canonical/OG/sitemap URL from it. The markup then needs zero edits at cutover. Consequence: an
+indexed staging copy would compete with the live original using its own canonical — so staging
+must be provably unindexable:
+
+- **On a fully static build, Astro middleware never runs for page requests** — Cloudflare's
+  static-asset handler serves them and the Worker is not invoked. A middleware-based
+  `X-Robots-Tag` silently does nothing. Put the header in `public/_headers` instead:
+  ```
+  /*
+    X-Robots-Tag: noindex, nofollow
+  ```
+- Also ship a staging `public/robots.txt` with `Disallow: /`. Belt and braces: the header stops
+  indexing, the robots stops crawling.
+- Both are removed at cutover; removal is THE step that makes the site visible, so write it into
+  the cutover checklist in capitals, with the verify command:
+  `curl -sI https://<prod>/ | grep -i x-robots-tag` → must return nothing.
+- Never submit staging URLs to any index or ping service. Indexing pings happen only after
+  production returns 200 + indexable to bots.
+
+## 2. Metadata
+
+Per page: unique `<title>`, meta description, canonical (absolute, production origin), OG
+(`og:type/site_name/title/description/url/image` + width/height 1200×630), Twitter
+`summary_large_image`. Migrate the original's titles/descriptions verbatim where they exist —
+inventing "better" ones mid-migration mixes two jobs. Where the original HAS no description,
+assemble one from facts already on the page; never invent positioning copy.
+
+Render the OG card from the site's real brand fonts with headless Chrome (an HTML file +
+`--headless --screenshot`) rather than hand-drawing — it looks like the brand because it IS the
+brand's CSS.
+
+## 3. Structured data — a hard 5-type cap
+
+One JSON-LD `@graph` per page containing at most: `Organization` (one, with `@id`, referenced by
+the others — never restated per page), `WebPage`, `BreadcrumbList`, and where genuinely
+applicable `Event` and/or `Person`. That's the whole list.
+
+- **No `FAQPage`, no `HowTo`** — Google retired those rich results; a schema node describing
+  content is now pure liability if the content isn't visible on the page.
+- **Thin where the source is thin.** No published date → month-precision `startDate` or none. No
+  price → no `offers`. A validator-pleasing invented date is a wrong answer served to every
+  crawler and every AI engine.
+- `Organization.logo` needs a real ≥112px logo image, not the OG card; render the wordmark on a
+  background it survives (a cream logo vanishes on white).
+
+## 4. Sitemap hygiene
+
+- `@astrojs/sitemap` + a `filter` that excludes every noindex page. The generator crawls build
+  output and knows nothing about your meta tags — a noindexed URL in the sitemap is a
+  contradiction that gets the whole file distrusted.
+- One sitemap per host. A sitemap may only list URLs on its own host.
+- Post-action pages (thank-you, subscribed) are noindex AND filtered out.
+- A sitemap URL must never redirect. Declare on whichever host the site canonicalizes to.
+
+## 5. robots.txt — tiered, allow-by-default, and check who actually serves it
+
+Production robots.txt names bots explicitly in tiers, all allowed: classic search (Googlebot,
+Bingbot, regional engines your market needs), **AI retrieval bots** (OAI-SearchBot, ChatGPT-User,
+Claude-SearchBot, Claude-User, PerplexityBot, Perplexity-User, Google-Extended…), AI training
+bots (GPTBot, ClaudeBot, CCBot…), link unfurlers (facebookexternalhit, LinkedInBot, Slackbot…),
+then `User-agent: *` + your genuine disallows (`/api/`, intake paths). Rationale: blocking AI
+retrieval bots removes you from AI answers without stopping training; naming bots explicitly
+makes a future block a deliberate one-line edit instead of a silent gap. Two traps:
+
+- **Check which file actually serves the domain root.** A Worker route or another platform layer
+  can shadow your repo's `public/robots.txt` — a repo edit is then a no-op. Verify with curl
+  before AND after any change, never by reading the repo.
+- `llms.txt` is referenced as a comment, never a `Sitemap:` line (it's markdown, not XML). Treat
+  it as an optional agent-tooling surface, not a citation lever.
+
+## 6. Crawler-delivery verification — the file is policy, the edge is law
+
+A robots.txt that allows a bot means nothing if the edge (WAF, bot-fight mode, rate limits)
+403/429s the actual fetch. After deploying to production, fetch the homepage + key deep URLs AS
+each major bot and assert 200:
+
+```bash
+for UA in "Googlebot/2.1" "Bingbot/2.0" "GPTBot/1.0" "OAI-SearchBot/1.0" "ClaudeBot/1.0" "PerplexityBot/1.0"; do
+  for P in / /key-page/; do
+    printf "%-20s %-14s %s\n" "$UA" "$P" \
+      "$(curl -s -o /dev/null -w '%{http_code}' -A "Mozilla/5.0 (compatible; $UA)" "https://<prod>$P")"
+  done
+done
+```
+
+Run it against staging before cutover and against production after — edge-level failures exist
+that staging cannot reproduce.
+
+## 7. Performance gates (this is where you beat Wix)
+
+- **Lighthouse mobile ≥ 95 — treat as a gate, not a target.** A measured Astro rebuild of a Wix
+  page routinely lands at 100/100/100 with LCP under 800 ms; Wix originals rarely clear 60.
+- `build.inlineStylesheets: 'always'`; self-host the real font files (extracted in recon) with
+  `font-display: swap` and preload the 1–2 above-the-fold faces.
+- Build-time image optimization (sharp), NOT the adapter's runtime `/_image` route (it 404s on
+  static Worker assets).
+- **Never re-pipe an already-optimized asset through the image pipeline** — re-encoding a
+  hand-tuned WebP can double its size. Serve those from `public/` with a cache rule.
+- Media budget: every static asset under 25 MiB (Workers hard limit) and every video re-encoded
+  (CRF ~28–31, `+faststart`, poster frame, `preload="none"` for anything heavy). Check whether a
+  "silent" video actually has audio before stripping it.
+- Verify weight after each build: `find dist -type f -size +400k` and justify every hit.
+
+## 8. The scoreboard
+
+Before cutover, capture for the report: Lighthouse (all four categories, mobile), LCP/CLS,
+total page weight, and the same numbers for the live Wix original. The migration's pitch — to
+the owner and to anyone reading the case study — is that delta.

--- a/wix-to-astro/references/setup.md
+++ b/wix-to-astro/references/setup.md
@@ -1,0 +1,40 @@
+# Setup — tools this skill assumes, with install + verify commands
+
+The skill presumes two accounts: **Cloudflare** (Workers, free tier is enough for staging) and
+nothing else. No Wix account or API access is needed — everything is extracted from the public
+live site.
+
+Run the verify column before starting a migration. A missing tool discovered mid-migration costs
+a context switch at the worst time; a missing tool discovered here costs one install command.
+
+| Tool | Why the migration needs it | Install (macOS / general) | Verify |
+|---|---|---|---|
+| Node.js ≥ 20 | Astro 5+ requires it | `brew install node` or nvm | `node -v` |
+| A package manager | Project deps (examples below use pnpm; npm works) | `corepack enable` | `pnpm -v` |
+| Astro 5+ | The target framework | created per-project: `pnpm create astro@latest` | `pnpm astro --version` (in project) |
+| Wrangler 4+ | Build + deploy to Cloudflare Workers | comes as a project dev-dep; login once | `npx wrangler whoami` |
+| ffmpeg | Re-encode builder videos under the 25 MiB Workers asset limit; extract poster frames | `brew install ffmpeg` | `ffmpeg -version` |
+| Python 3 + `fonttools`, `brotli`, `Pillow` | Identify obfuscated font files by their name table (the ONLY reliable way — see playbook Step 2); resize/flatten images | `pip3 install fonttools brotli Pillow` | `python3 -c "import fontTools, PIL; print('ok')"` |
+| Real-browser automation | Extract computed CSS, run `document.getAnimations()`, measure rendered boxes. Any tool that executes JS in a live page works: Claude in Chrome MCP, Playwright MCP, or a Playwright script | e.g. `npm i -g playwright && playwright install chromium` | open any page, run `1+1` in its context |
+| curl | URL matrices, crawler-delivery checks, media downloads | preinstalled on macOS/Linux | `curl --version` |
+| Headless screenshot capability *(optional but recommended)* | Full-page side-by-side comparisons at exact viewport widths | a screenshot API (e.g. Firecrawl) or Playwright's `page.screenshot` | one full-page capture at width 402 |
+| Headless Chrome *(optional)* | Rendering OG cards from real brand fonts (better than drawing them) | ships with Chrome/Chromium | `chrome --headless --screenshot=... <file://…>` |
+
+## Notes that save real time
+
+- **Browser automation is the load-bearing tool.** Screenshots alone cannot run this skill —
+  the method is computed-style extraction, and that requires executing JS in a real rendered
+  page. If you have to choose one optional install, choose Playwright.
+- **DOM reads survive an occluded window; paints don't.** If using an extension that drives the
+  user's own browser (e.g. Claude in Chrome): `getComputedStyle` and `getBoundingClientRect`
+  keep working when the window is covered or the display sleeps, but screenshots come back blank
+  and CSS transitions freeze at t=0. Use the user's browser for measurement, a headless tool for
+  screenshots.
+- **JS-bridge output limits.** Browser-automation bridges truncate long results (~1.5 KB is
+  common) and may block strings containing URL query params. Strip query strings
+  (`new URL(u).origin + new URL(u).pathname`) and page through large results via a `window.__X`
+  variable rather than returning everything at once.
+- **Secrets.** The only secrets a plain migration needs are Cloudflare credentials (via
+  `wrangler login` or an API token in the environment). Forms/integrations (Turnstile, a CRM,
+  transactional email) each bring their own keys — set them with `npx wrangler secret put`, never
+  commit them, and keep local ones in a gitignored `.dev.vars`.


### PR DESCRIPTION
## What this skill does

Migrates a full Wix site into Astro on Cloudflare Workers with a coding agent — the whole site, not just blog content: layout, fonts, animations, forms, redirects, SEO. The method is code-first: the agent extracts each section's rendered DOM and computed CSS from the live page and rebuilds from those measured values, with four verification passes (side-by-side scroll, typography audit across six computed properties, real animation extraction via `document.getAnimations()`, and a source-level tweaking round) before the site owner ever reviews it.

## Who it's for

Anyone stuck on Wix (or a similar page builder) who wants to own their site in code without losing the design or the rankings. Also useful standalone for single phases: brand/design extraction from a live site, fidelity verification of any rebuild, or planning a builder-to-code cutover.

## Why it's credible

Corrected against two production migrations (engineeringleaders.io, elc-conference.io). The second run rebuilt 51 URLs overnight and landed Lighthouse 100/100/100 on mobile with LCP under 800 ms — and the playbook documents the four fidelity gaps the automated passes missed, not just the wins.

## Attribution

By [Marian Kamenistak](https://github.com/marian-kamenistak). Canonical repo (source of truth for updates): https://github.com/marian-kamenistak/wix-to-astro (MIT).

## Example

> "Migrate https://www.example-on-wix.com to Astro. Keep every URL, match the design exactly, deploy to a staging Worker, and give me a cutover checklist."

The skill drives recon (sitemap + per-section DOM extraction), scaffold, per-section rebuild, the four verification passes, SEO hardening (staging noindex, schema, robots, crawler-delivery checks), and a reversible cutover plan.
