### PR TITLE
Add AgentScan: deterministic security scanner for AI agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [AgentScan](https://github.com/thesfb/scanaskill) - Deterministic local scanner for AI agent skills: detects prompt injection, secrets, network calls, and malware patterns before you install. Never runs the skill, works offline.
 
 ### Assistive Technology
 


### PR DESCRIPTION
Adds [AgentScan](https://github.com/thesfb/scanaskill) to the Security & Systems section. It is a deterministic, local scanner for AI agent skills (Claude Code, Codex, OpenCode) that detects prompt injection, secrets, network calls, and malware patterns before install. It never runs the skill and works offline — no cloud upload, no API key.