### PR TITLE
Add Neuro-NLP Booster skill (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Neuro-NLP Booster](https://github.com/dankofly/Neuro-NLP-booster) - Turns Claude into a neuromarketing copywriter: Limbic motive targeting, Milton Model language, neuro-scoring, and a 5-voice council that vetoes cringe and manipulative copy before it ships. *By [@dankofly](https://github.com/dankofly)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [Neuro-NLP Booster](https://github.com/dankofly/Neuro-NLP-booster), a copywriting skill that turns Claude into a neuromarketing copywriter: Limbic motive targeting, Milton Model patterns, Sleight of Mouth reframes, 0-100 neuro-scoring, and a 5-voice council (3 optimists, 2 critics) that vetoes cringe and manipulative copy before it ships. Grounded in published sources (Häusel, O'Connor, Dilts). Covers copy and matching design specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)