### PR TITLE
Add rams-braun-ui to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [rams-braun-ui](https://github.com/yangyue1974/rams-braun-ui) - A Braun-era Dieter Rams design system for web/app UI, quantified into color tokens, a type scale, spacing ratios, component specs and a forbidden list, so generated interfaces read as Braun rather than as generic minimal. *By [@yangyue1974](https://github.com/yangyue1974)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
Adds one line under **Creative & Media**.

**[rams-braun-ui](https://github.com/yangyue1974/rams-braun-ui)** — a Braun-era Dieter Rams design system for web/app UI, packaged as an Agent Skill.

Most "Rams style" prompts fail because the ten principles are a verdict, not a recipe — an agent given them produces generic minimal. This skill is the recipe: rules reverse-engineered from Braun hardware (SK4, TP1, ET66, T3, TG60, regie 510) and Vitsoe 606, quantified into hex tokens, a type scale, spacing ratios, component specs and a forbidden list, with the ten principles put back where they belong — as the final QA gate.

- `SKILL.md` with a 7-step build order and non-negotiable rules
- `references/` — tokens (paste-ready CSS), component specs, anti-patterns, QA checklist
- Live specimen page built entirely from these tokens: https://yangyue1974.github.io/rams-braun-ui/
- Tested on Claude Code and Claude.ai; MIT licensed; v1.0.0 released with a zip for claude.ai upload

Checked for duplicates — no Rams/Braun design-system entry currently in the list.