### PR TITLE
Add seedance-25-prompting to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [seedance-25-prompting](https://github.com/gbeyrouti/seedance-prompting-claude-skill) - Write, optimize, and debug prompts for ByteDance's Seedance 2.5 / 2.0 video model (Dreamina, Jimeng, Doubao, BytePlus, fal.ai) — 6-block formula, `@` reference roles, time staging, a realism layer that keeps AI UGC from looking like an ad, native audio and lip-sync syntax, and a symptom → fix debug matrix. *By [@gbeyrouti](https://github.com/gbeyrouti)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds [seedance-25-prompting](https://github.com/gbeyrouti/seedance-prompting-claude-skill) — a prompt-engineering skill for ByteDance's **Seedance 2.5 / 2.0** video model (Dreamina, Jimeng, Doubao, BytePlus ModelArk, Volcano Ark, fal.ai).

**What it does:** Claude writes production-grade Seedance prompts — the official 6-block formula, explicit `@` reference roles across up to 50 materials, time staging for long clips, a realism layer so AI UGC stops reading as an ad, native audio and lip-sync syntax, and a symptom → fix debug matrix.

**Why it is not another generic video-prompt skill:** it is scoped to one model family and encodes its actual quirks — notably that Seedance backfires on negations of visible objects (`no blur` produces blur) while exclusions on references, generated tracks and manufacturing defects work reliably. Unconfirmed specs (4K output, extension ceiling, supported dialogue languages) are flagged as unconfirmed rather than repeated as fact.

- Standard Agent Skill: `SKILL.md` + 9 progressive-disclosure reference files
- Works in Claude.ai, Claude Code and the Agent SDK
- MIT licensed · skill documentation is in French, generated prompts are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)