### PR TITLE
Add claw-hwp (Korean HWP .hwp/.hwpx editing skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Document Processing
 
+- [claw-hwp](https://github.com/DoHyun468/claw-hwp) - Reads, creates, and edits Korean HWP (.hwp/.hwpx) documents in place, without Hancom Office or format conversion. *By [@DoHyun468](https://github.com/DoHyun468)*
 - [docx](https://github.com/anthropics/skills/tree/main/skills/docx) - Create, edit, analyze Word docs with tracked changes, comments, formatting.
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
-- [claw-hwp](https://github.com/DoHyun468/claw-hwp) - Reads, creates, and edits Korean HWP (.hwp/.hwpx) documents in place, without Hancom Office or format conversion. *By [@DoHyun468](https://github.com/DoHyun468)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
+- [claw-hwp](https://github.com/DoHyun468/claw-hwp) - Reads, creates, and edits Korean HWP (.hwp/.hwpx) documents in place, without Hancom Office or format conversion. *By [@DoHyun468](https://github.com/DoHyun468)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 


### PR DESCRIPTION
Adds **claw-hwp** under Skills → Document Processing (alphabetical among external entries).

claw-hwp is a Claude Code (and Codex) skill that reads, creates, and edits Korean Hangul Word Processor documents (.hwp/.hwpx) in place at the byte level, without Hancom Office or format conversion, preserving tables and styling. It verifies that edited files open uncorrupted in Hancom Office / Hancom Docs, and runs locally on macOS and Windows. Built on the rhwp WASM core; MIT-licensed.

Repo: https://github.com/DoHyun468/claw-hwp