### PR TITLE
Add publish-webpage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [publish-webpage](https://github.com/nerkn/goclawgo/tree/main/agent-pack/agentskills/publish-webpage) - Turns a non-technical user's idea into a live, shareable webpage: writes a self-contained one-page site, packages it, and deploys to goclawgo with a single POST, then returns the link. *By [@nerkn](https://github.com/nerkn)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds `publish-webpage` to **Creative & Media**.

A skill for non-technical users: turns an idea into a live, shareable webpage. The agent writes a self-contained `index.html`, packages it, and deploys to [goclawgo](https://goclawgo.com) via a single `POST /d/{key}`, then polls until live and returns the link.

- Format: standard Agent Skills `SKILL.md` (works in Claude Code, OpenCode, Cursor, etc.)
- Real use case: publishing a one-pager / landing page / portfolio with zero setup
- Source: https://github.com/nerkn/goclawgo/tree/main/agent-pack/agentskills/publish-webpage

Entry follows the existing external-skill format (`*By @author*`).