### PR TITLE
Add Decoder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
+- [Decoder](https://github.com/Anmoll-W/decoder) - Explains technical concepts to PMs: drop a link or describe a situation, get live research, an analogy-based explanation, and one closing question. *By [@Anmoll-W](https://github.com/Anmoll-W)*
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*


### PR DESCRIPTION
Adds Decoder to Communication & Writing, alphabetically between Content Research Writer and family-history-research.

Decoder explains technical concepts to PMs: drop a link or describe a situation, it researches live, explains with character analogies, and closes with one smart question. Works in any Claude Code session.

Repo: https://github.com/Anmoll-W/decoder