### PR TITLE
Add BundleDex — OKF bundle directory for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,8 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
 
+- [BundleDex](https://bundledex.net/) - The largest directory of 500+ Open Knowledge Format (OKF) bundles for AI agents, with llms.txt and an MCP endpoint, free to submit.
+
 ### Inspiration & Use Cases
 
 - [Lenny's Newsletter](https://www.lennysnewsletter.com/p/everyone-should-be-using-claude-code) - 50 ways people use Claude Code


### PR DESCRIPTION
Thanks for maintaining this great list!

**BundleDex** — the largest directory of 500+ Open Knowledge Format (OKF) bundles for AI agents, with llms.txt and an MCP endpoint, free to submit.

https://bundledex.net/

Added as an entry in the "Resources → Community Resources" section, matching the existing `- [Name](url) - Description` format.