### PR TITLE
Add api-friction-pass skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [api-friction-pass](https://github.com/alizas1/skills/tree/main/api-friction-pass) - Walk integrator-facing API docs and spec like a first-time user; surfaces contradictions and use-case friction. *By [@alizas1](https://github.com/alizas1)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
-- [api-friction-pass](https://github.com/alizas1/skills/tree/main/api-friction-pass) - Walk integrator-facing API docs and spec like a first-time user; surfaces contradictions and use-case friction. *By [@alizas1](https://github.com/alizas1)*
+- [api-friction-walkthrough](https://github.com/alizas1/skills/tree/main/api-friction-walkthrough) - Walk integrator-facing API docs and spec like a first-time user; surfaces contradictions and use-case friction. *By [@alizas1](https://github.com/alizas1)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
## Summary
- Adds [api-friction-pass](https://github.com/alizas1/skills/tree/main/api-friction-pass) to Development & Code Tools
- Walks integrator-facing API docs and spec like a first-time user; surfaces contradictions and use-case friction

## Test plan
- [ x] Skill tested on Claude Code / Cursor 
- [ x] README entry follows list format 