### PR TITLE
Add feishu-daily-report skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [feishu-daily-report](https://github.com/zhiqianzheng/feishu-daily-report) - Summarizes all of today's Claude Code sessions across every window and writes a concise daily report into your team's Feishu/Lark spreadsheet, targeting the correct name row and date column, automatically at 18:00 Beijing time.
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
## What problem it solves

Writing the end-of-day report is a daily chore: you have to recall what you did all day and condense it into a couple of lines in your team's Feishu (Lark) spreadsheet. But for developers who work with Claude Code, the day's work is already recorded in their session history. This skill closes the loop: it traverses all of today's Claude Code sessions (across every window and project), summarizes the work into a few short lines (filtering out any non-work/private conversations), and writes the summary into the team's Feishu spreadsheet — locating the correct row by the user's name and the correct column by today's date, never overwriting manually written content (it merges and dedupes instead).

It can be triggered manually ("写日报" / "write my daily report") or run unattended every day at 18:00 Beijing time via a cron guard that works on machines in any timezone (hourly cron trigger + TZ=Asia/Shanghai check, DST-proof).

## Who uses this workflow

Built for and used daily by an embedded-firmware development team that reports progress in a shared weekly Feishu spreadsheet (name rows × date columns). Any team using a similar Feishu/Lark daily-report template can adopt it; the cell-locating rules are documented and easy to adjust.

## Attribution

Original work by [@zhiqianzheng](https://github.com/zhiqianzheng), extracted from a real production workflow. Uses Feishu's official CLI (@larksuite/cli) with personal QR-code authorization — credentials never leave the user's machine.

## Example

**User**: "写日报" (write my daily report)

**Output**:
> Report written to sheet "日报" cell P5 (row: Cian, column: 8/11 Tue "today's work"):
> 1. Debugged printer stall after stop-print: compared against baseline firmware, captured embedded logs
> 2. Added firmware version display (embedded + host app, V2.1/V2.2/V3.0), version now read from FW_VERSION.json
> 3. Set up Feishu CLI integration and automated this daily report pipeline

Repository (MIT, bilingual README, includes one-command install via `npx skills add zhiqianzheng/feishu-daily-report` and a full `setup.sh`): https://github.com/zhiqianzheng/feishu-daily-report

🤖 Generated with [Claude Code](https://claude.com/claude-code)