### PR TITLE
Add Atomic Mail skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Communication & Writing
 
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
+- [Atomic Mail](https://github.com/Atomic-Mail/atomic-mail-agentic/tree/main/integrations/skill/atomicmail) - Read, send, and manage email from an AI agent over JMAP, with autonomous proof-of-work inbox registration. *By [@Atomic-Mail](https://github.com/Atomic-Mail)*
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.


### PR DESCRIPTION
Adds the **Atomic Mail** skill to the **Communication & Writing** category.

[Atomic Mail](https://atomicmail.ai) is an email service built for AI agents. The skill lets Claude read, send, and manage email over the open **JMAP** standard (RFC 8620/8621), and can autonomously register an inbox via proof-of-work (no email verification, domain, or card). Custom domains supported.

- Skill (SKILL.md): https://github.com/Atomic-Mail/atomic-mail-agentic/tree/main/integrations/skill/atomicmail
- Works in Claude Code / CLI agents (Agent Skill) and via the hosted MCP server

Checklist:
- One entry, added in alphabetical order within Communication & Writing (between `article-extractor` and `brainstorming`)
- Follows the existing external-skill format with `*By [@handle]*` attribution — no emojis, consistent punctuation
- Links to a real, documented skill; no trailing whitespace