### PR TITLE
Add HumanPen under Document Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
+- [HumanPen](https://github.com/humanpen/humanpen-skill) - Lower the AI-detection score on a Word/PowerPoint/PDF document so it reads as human-written, keeping every fact, number, table and all formatting intact. *By [@humanpen](https://github.com/humanpen)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
-- [HumanPen](https://github.com/humanpen/humanpen-skill) - Lower the AI-detection score on a Word/PowerPoint/PDF document so it reads as human-written, keeping every fact, number, table and all formatting intact. *By [@humanpen](https://github.com/humanpen)*
+- [HumanPen](https://github.com/humanpen/humanpen-skill) - A document-level AI humanizer — rewrite a whole .docx/.pptx, only selected passages, or just the text flagged by a Turnitin/iThenticate report, in place, keeping formatting, tables, images, citations and formulas intact. *By [@humanpen](https://github.com/humanpen)*
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
 


### PR DESCRIPTION
Adds [HumanPen](https://github.com/humanpen/humanpen-skill) under **Document Processing**.

A real, published Agent Skill that lowers the AI-detection score on a Word/PowerPoint/PDF document so it reads as human-written, keeping every fact, number, table and all formatting intact. Works in Claude Code, Codex, Cursor and other SKILL.md clients; Apache-2.0. Install: `/plugin marketplace add humanpen/humanpen-skill`.