### PR TITLE
Add Awesome README skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Communication & Writing
 
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
+- [Awesome README](https://github.com/tjboudreaux/cc-skills-awesome-readme/tree/main/skills/awesome-readme) - Create, audit, revise, and standardize project README files from repository evidence.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.


### PR DESCRIPTION
## Summary

- Add the evidence-first Awesome README skill to the Communication & Writing section.
- Link directly to the canonical repository skill directory.

## Verification

- Confirmed the target repository is public.
- Confirmed the target has a standard `skills/awesome-readme/SKILL.md` layout.
- Description matches the target skill's current frontmatter capability statement.

This PR adds one entry only and does not claim marketplace approval or inclusion until maintainer review.