### PR TITLE
Add Skillselion to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [Skillselion](https://skillselion.com) - Community directory indexing 59,000+ skills and 8,400+ MCP servers, ranked by install counts
 
 ### Inspiration & Use Cases
 


### PR DESCRIPTION
Adds [Skillselion](https://skillselion.com) to the Community Resources section: a community directory indexing 59,000+ Claude Code skills and 8,400+ MCP servers, ranked by install counts. It fits alongside the existing discovery links in that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)