### PR TITLE
Add ITR Wala to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
+- [ITR Wala](https://github.com/karanb192/itr-wala) - Prepares Indian income tax returns (ITR-1 to 4, AY 2026-27): the model reads Form 16/AIS and interviews you, while a deterministic tested Python engine computes every rupee across both regimes.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.


### PR DESCRIPTION
Adds [ITR Wala](https://github.com/karanb192/itr-wala) (MIT, 600+ stars): prepares Indian income tax returns (ITR-1 to 4, AY 2026-27). The model reads Form 16/AIS and interviews the user; every calculation runs in a deterministic Python engine with 51 hand-derived golden tests and a 350k-case fuzzer. Placed alphabetically after Invoice Organizer. I'm the author.