### PR TITLE
Add MiniMax voice cloning skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [MiniMax Voice Cloning](./minimax-voice-cloning/) - Uploads consented reference audio and creates a reusable cloned voice through the MiniMax API in global or China regions.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.

--- a/minimax-voice-cloning/SKILL.md
+++ b/minimax-voice-cloning/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: minimax-voice-cloning
+description: Create a reusable MiniMax voice from consented reference audio. Use this skill when the user asks to upload an mp3, m4a, or wav sample and clone its voice through the global or China MiniMax API.
+---
+
+# MiniMax Voice Cloning
+
+Upload a reference recording and create a reusable voice ID with the MiniMax
+voice cloning API. The included command-line tool supports the complete upload
+and clone workflow, either as separate steps or as one command.
+
+Only clone a voice when the speaker has explicitly consented to that use. Do
+not use recordings obtained deceptively, or impersonate someone without their
+permission.
+
+## Setup
+
+Set the API key as an environment variable. It is sent as a Bearer token and
+is never written to disk.
+
+```bash
+export MINIMAX_API_KEY="your-api-key"
+```
+
+The tool uses only the Python standard library.
+
+## Clone a Voice in One Step
+
+Run `workflow` with the consented sample and the new voice ID:
+
+```bash
+python scripts/voice_clone.py workflow ./sample.wav my-consented-voice
+```
+
+This uploads the file with the `voice_clone` purpose, obtains its file ID,
+and submits that ID with the requested voice ID and model to the clone API.
+The result is printed as JSON containing `file_id`, `voice_id`, and the API
+response.
+
+## Run the Steps Separately
+
+Upload the sample:
+
+```bash
+python scripts/voice_clone.py upload ./sample.mp3
+```
+
+Copy the returned `file_id`, then create the voice:
+
+```bash
+python scripts/voice_clone.py clone 123456789 my-consented-voice
+```
+
+## Options
+
+### Region
+
+Use `--region global` (the default) for `api.minimax.io`, or `--region cn`
+for `api.minimaxi.com`:
+
+```bash
+python scripts/voice_clone.py workflow ./sample.m4a my-consented-voice --region cn
+```
+
+The upload and clone calls always use the same selected region.
+
+### Model
+
+The default model is `speech-2.8-hd`. The supported voice-cloning models are:
+
+- `speech-2.8-hd`
+- `speech-2.6-hd`
+- `speech-02-hd`
+- `speech-01-hd`
+
+Choose one with `--model` on `clone` or `workflow`:
+
+```bash
+python scripts/voice_clone.py clone 123456789 my-consented-voice --model speech-2.6-hd
+```
+
+## Reference Audio Requirements
+
+- Format: mp3, m4a, or wav
+- Duration: 10 seconds to 5 minutes
+- Size: no more than 20 MB
+
+The tool validates the format and size before upload. Use a clear recording
+with little background noise, and verify the speaker's consent before sending
+it.
+
+## How It Works
+
+1. `POST /v1/files/upload` sends the recording as multipart form data with
+   `purpose=voice_clone` and reads `file.file_id` from the response.
+2. `POST /v1/voice_clone` sends the required `file_id`, `voice_id`, and
+   `model` fields as JSON.
+3. Both responses are checked for a successful `base_resp.status_code` before
+   any identifier is reported.
+
+## Common Use Cases
+
+- Creating an approved brand voice from a professional voice actor's sample.
+- Preserving a speaker's delivery across authorized narration projects.
+- Preparing a reusable voice ID for a consented localization workflow.

--- a/minimax-voice-cloning/scripts/voice_clone.py
+++ b/minimax-voice-cloning/scripts/voice_clone.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Upload consented reference audio and create a MiniMax cloned voice."""
+
+import argparse
+import json
+import mimetypes
+import os
+from pathlib import Path
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+
+REGIONS = {
+    "global": {
+        "upload": "https://api.minimax.io/v1/files/upload",
+        "clone": "https://api.minimax.io/v1/voice_clone",
+    },
+    "cn": {
+        "upload": "https://api.minimaxi.com/v1/files/upload",
+        "clone": "https://api.minimaxi.com/v1/voice_clone",
+    },
+}
+MODELS = ["speech-2.8-hd", "speech-2.6-hd", "speech-02-hd", "speech-01-hd"]
+AUDIO_FORMATS = {".mp3", ".m4a", ".wav"}
+MAX_AUDIO_BYTES = 20 * 1024 * 1024
+
+
+def get_api_key():
+    """Return the API key from the environment without logging it."""
+    api_key = os.environ.get("MINIMAX_API_KEY")
+    if not api_key:
+        raise ValueError("Set MINIMAX_API_KEY before running this command")
+    return api_key
+
+
+def validate_audio(audio_path):
+    """Validate the local requirements that do not need an audio decoder."""
+    path = Path(audio_path)
+    if not path.is_file():
+        raise ValueError(f"Audio file does not exist: {path}")
+    if path.suffix.lower() not in AUDIO_FORMATS:
+        raise ValueError("Reference audio must be mp3, m4a, or wav")
+    if path.stat().st_size > MAX_AUDIO_BYTES:
+        raise ValueError("Reference audio must not exceed 20 MB")
+    return path
+
+
+def build_multipart(audio_path, boundary):
+    """Build the multipart body for a voice-clone audio upload."""
+    path = validate_audio(audio_path)
+    filename = path.name.replace('"', "")
+    content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    lines = [
+        f"--{boundary}\r\n".encode(),
+        b'Content-Disposition: form-data; name="purpose"\r\n\r\n',
+        b"voice_clone\r\n",
+        f"--{boundary}\r\n".encode(),
+        (
+            'Content-Disposition: form-data; name="file"; '
+            f'filename="{filename}"\r\n'
+        ).encode(),
+        f"Content-Type: {content_type}\r\n\r\n".encode(),
+        path.read_bytes(),
+        b"\r\n",
+        f"--{boundary}--\r\n".encode(),
+    ]
+    return b"".join(lines)
+
+
+def check_response(response):
+    """Raise when the API reports a nonzero status code."""
+    base_resp = response.get("base_resp") or {}
+    status_code = base_resp.get("status_code")
+    if status_code is None:
+        raise RuntimeError("API response did not include base_resp.status_code")
+    if status_code != 0:
+        status_msg = base_resp.get("status_msg", "unknown error")
+        raise RuntimeError(f"API error {status_code}: {status_msg}")
+    return response
+
+
+def request_json(url, api_key, data, content_type):
+    """Send an authenticated POST request and decode its JSON response."""
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": content_type,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            parsed = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", "replace")
+        raise RuntimeError(
+            f"API request failed with HTTP {error.code}: {detail}"
+        ) from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(f"API request failed: {error.reason}") from error
+    except json.JSONDecodeError as error:
+        raise RuntimeError("API returned invalid JSON") from error
+    return check_response(parsed)
+
+
+def upload_audio(audio_path, region, api_key):
+    """Upload reference audio and return its file ID."""
+    boundary = f"----minimax-{uuid.uuid4().hex}"
+    body = build_multipart(audio_path, boundary)
+    response = request_json(
+        REGIONS[region]["upload"],
+        api_key,
+        body,
+        f"multipart/form-data; boundary={boundary}",
+    )
+    file_id = (response.get("file") or {}).get("file_id")
+    if file_id is None:
+        raise RuntimeError("Upload response did not include file.file_id")
+    return file_id
+
+
+def build_clone_payload(file_id, voice_id, model):
+    """Build the required voice cloning request body."""
+    return {"file_id": file_id, "voice_id": voice_id, "model": model}
+
+
+def clone_voice(file_id, voice_id, model, region, api_key):
+    """Create a cloned voice from an uploaded reference file."""
+    payload = build_clone_payload(file_id, voice_id, model)
+    return request_json(
+        REGIONS[region]["clone"],
+        api_key,
+        json.dumps(payload).encode("utf-8"),
+        "application/json",
+    )
+
+
+def add_common_options(parser, include_model=False):
+    """Add the region and optional model arguments to a subcommand."""
+    parser.add_argument("--region", choices=REGIONS, default="global")
+    if include_model:
+        parser.add_argument("--model", choices=MODELS, default=MODELS[0])
+
+
+def build_parser():
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Upload consented reference audio and create a MiniMax cloned voice."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    upload_parser = subparsers.add_parser("upload", help="upload reference audio")
+    upload_parser.add_argument("audio", help="path to an mp3, m4a, or wav file")
+    add_common_options(upload_parser)
+
+    clone_parser = subparsers.add_parser("clone", help="create a cloned voice")
+    clone_parser.add_argument("file_id", type=int, help="uploaded reference file ID")
+    clone_parser.add_argument("voice_id", help="new reusable voice ID")
+    add_common_options(clone_parser, include_model=True)
+
+    workflow_parser = subparsers.add_parser(
+        "workflow", help="upload reference audio and create a cloned voice"
+    )
+    workflow_parser.add_argument("audio", help="path to an mp3, m4a, or wav file")
+    workflow_parser.add_argument("voice_id", help="new reusable voice ID")
+    add_common_options(workflow_parser, include_model=True)
+    return parser
+
+
+def main(argv=None):
+    """Run the selected upload, clone, or combined workflow."""
+    args = build_parser().parse_args(argv)
+    api_key = get_api_key()
+
+    if args.command == "upload":
+        file_id = upload_audio(args.audio, args.region, api_key)
+        result = {"file_id": file_id, "purpose": "voice_clone"}
+    elif args.command == "clone":
+        response = clone_voice(
+            args.file_id, args.voice_id, args.model, args.region, api_key
+        )
+        result = {"voice_id": args.voice_id, "response": response}
+    else:
+        file_id = upload_audio(args.audio, args.region, api_key)
+        response = clone_voice(file_id, args.voice_id, args.model, args.region, api_key)
+        result = {
+            "file_id": file_id,
+            "voice_id": args.voice_id,
+            "response": response,
+        }
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/minimax-voice-cloning/tests/test_voice_clone.py
+++ b/minimax-voice-cloning/tests/test_voice_clone.py
@@ -1,0 +1,110 @@
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "voice_clone.py"
+SPEC = importlib.util.spec_from_file_location("voice_clone", SCRIPT_PATH)
+voice_clone = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(voice_clone)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class VoiceCloneTests(unittest.TestCase):
+    def test_regional_endpoints_cover_upload_and_clone(self):
+        self.assertEqual(
+            voice_clone.REGIONS["global"]["clone"],
+            "https://api.minimax.io/v1/voice_clone",
+        )
+        self.assertEqual(
+            voice_clone.REGIONS["cn"]["clone"],
+            "https://api.minimaxi.com/v1/voice_clone",
+        )
+        self.assertTrue(voice_clone.REGIONS["global"]["upload"].endswith("/v1/files/upload"))
+        self.assertTrue(voice_clone.REGIONS["cn"]["upload"].endswith("/v1/files/upload"))
+
+    def test_multipart_contains_required_purpose_and_audio(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "sample.wav"
+            path.write_bytes(b"audio-bytes")
+            body = voice_clone.build_multipart(path, "test-boundary")
+
+        self.assertIn(b'name="purpose"', body)
+        self.assertIn(b"voice_clone", body)
+        self.assertIn(b'name="file"; filename="sample.wav"', body)
+        self.assertIn(b"audio-bytes", body)
+
+    def test_clone_payload_has_only_required_fields(self):
+        self.assertEqual(
+            voice_clone.build_clone_payload(123, "approved-voice", "speech-2.8-hd"),
+            {
+                "file_id": 123,
+                "voice_id": "approved-voice",
+                "model": "speech-2.8-hd",
+            },
+        )
+
+    @mock.patch.object(voice_clone.urllib.request, "urlopen")
+    def test_upload_reads_file_id_and_uses_bearer_auth(self, urlopen):
+        urlopen.return_value = FakeResponse(
+            {"file": {"file_id": 987}, "base_resp": {"status_code": 0}}
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "sample.mp3"
+            path.write_bytes(b"audio-bytes")
+            file_id = voice_clone.upload_audio(path, "global", "test-key")
+
+        self.assertEqual(file_id, 987)
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.get_header("Authorization"), "Bearer test-key")
+        self.assertIn(b"voice_clone", request.data)
+
+    @mock.patch.object(voice_clone.urllib.request, "urlopen")
+    def test_clone_posts_required_json_and_checks_response(self, urlopen):
+        urlopen.return_value = FakeResponse({"base_resp": {"status_code": 0}})
+        response = voice_clone.clone_voice(
+            123, "approved-voice", "speech-2.6-hd", "cn", "test-key"
+        )
+
+        self.assertEqual(response["base_resp"]["status_code"], 0)
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, "https://api.minimaxi.com/v1/voice_clone")
+        self.assertEqual(
+            json.loads(request.data),
+            {
+                "file_id": 123,
+                "voice_id": "approved-voice",
+                "model": "speech-2.6-hd",
+            },
+        )
+
+    def test_nonzero_api_status_raises(self):
+        with self.assertRaisesRegex(RuntimeError, "API error 1004"):
+            voice_clone.check_response(
+                {"base_resp": {"status_code": 1004, "status_msg": "invalid file"}}
+            )
+
+    def test_missing_api_status_raises(self):
+        with self.assertRaisesRegex(RuntimeError, "base_resp.status_code"):
+            voice_clone.check_response({})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: Add the missing clone-audio upload and voice cloning workflow for the MiniMax API.

## Changes

- Add a Creative & Media skill for uploading consented mp3, m4a, or wav reference audio with the `voice_clone` purpose.
- Add separate and combined CLI workflows for the required file upload and voice clone requests.
- Support the documented global and China endpoints and the current HD voice-cloning models.
- Validate local audio format and size, surface API status errors, and return the resulting file and voice identifiers as JSON.
- Add focused tests for multipart uploads, regional endpoints, required clone fields, Bearer authentication, and response handling.

## Checks

- `python3 -m py_compile minimax-voice-cloning/scripts/voice_clone.py minimax-voice-cloning/tests/test_voice_clone.py`
- `python3 -B -m unittest discover -s minimax-voice-cloning/tests -p 'test_*.py'`
- CLI `--help` checks for the root command and all three subcommands
- `git diff --check`
- Secret scan clean
