### PR TITLE
Add narrative-scroll skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [narrative-scroll](https://github.com/seongyeop1/narrative-scroll) - Builds scroll-driven landing pages that tell a story of transformation (night to morning, draft to launch), with scroll position driving one continuous visual metamorphosis across a three-act structure. *By [@seongyeop1](https://github.com/seongyeop1)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
**What it does:** narrative-scroll is an agent skill that builds landing pages as one continuous scroll-driven scene — a three-act structure over a seamless gradient where scroll position drives the transformation (night → morning, winter → spring, draft → launch).

**Real-world use case:** born from a real page — a congratulations page for a friend's first job offer, with his job-hunt nights as a labeled constellation and an acceptance sunrise you scroll into being. The method was extracted into a reusable skill after people kept asking how it was made. Useful for launch pages, milestone pages, and any product story with a before/after arc.

**Who it's for:** anyone using Claude Code (or other skill-compatible agents) to build landing pages that need to feel like a story rather than stacked sections.

**Attribution:** created and maintained by @seongyeop1. MIT licensed. Repo includes SKILL.md, a techniques reference, a dependency-free example page, and a demo GIF in the README. Placed alphabetically in Creative & Media after Image Enhancer.