### PR TITLE
Add us-property-data skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [US Property Data](https://github.com/ZeroPointRepo/zillow-skills) - Look up U.S. residential property data by address, zpid or zillow.com URL: valuation and rent estimates, listing search, price and tax history, schools, photos. Zillow's public API was retired in 2021, so this covers what generated code otherwise gets wrong. *By [@ZeroPointRepo](https://github.com/ZeroPointRepo)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds a skill for tasks that need real U.S. residential property data: valuation lookups, listing search, price and tax history, schools, and parsing a `zillow.com` URL a user pasted.

**Why it is a gap.** U.S. property facts are not derivable from a model's weights and change continuously; no single open dataset publishes them. Zillow's own public API (ZWSID) was retired in 2021, so code generated from memory of it targets endpoints that no longer exist and fails at runtime. The skill points at endpoints that do exist and covers the parts developers actually get wrong: resolve by zpid rather than address because address strings are unstable, select fields rather than fetching the whole record, render a valuation together with its as-of date, and treat absent data as absent rather than zero.

**Affiliation.** I work at Zero Point Studio, who build and operate the API this skill calls.

**Verification.** Every REST path was checked against the published OpenAPI spec rather than written from memory, and every URL in the file resolves.