### PR TITLE
Add MCP Security Preflight skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
+- [MCP Security Preflight](https://github.com/Abanoub-Rodolf/mcp-security-review-preview/tree/main/skills/mcp-security-preflight) - Runs a safe MCP configuration scan while keeping raw untrusted scanner evidence out of model-facing output. *By [@Abanoub-Rodolf](https://github.com/Abanoub-Rodolf)*
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
 


### PR DESCRIPTION
## What problem it solves

MCP configuration scans can expose untrusted configuration, URLs, arguments, and scanner text directly to the model. This skill runs mcp-scan in a restricted evidence directory and emits only a fixed-schema count summary.

## Who uses this workflow

Developers reviewing an MCP server before installation or approval in Claude Code.

## Attribution

Created and maintained by [Abanoub Rodolf Boctor](https://github.com/Abanoub-Rodolf) as the free preflight from the MCP Security Review Kit.

## Example

Ask Claude Code to run the skill against an explicit MCP configuration path. It separates a valid findings report from an operational failure, even though mcp-scan 2.0.2 can use exit code 1 for both.