### PR TITLE
Add collection-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [collection-skill](https://github.com/Yuuqq/collection-skill) - Discovers and catalogs 150+ scraping/collection tools on GitHub into five categories, then progressively recommends the right one and starts crawling with per-tool workflows (Scrapy, Playwright, Crawl4AI, MediaCrawler). *By [@Yuuqq](https://github.com/Yuuqq)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## What problem it solves

When someone asks an agent to "scrape X", tool selection gets reinvented from scratch every time. **collection-skill** maintains a curated, self-refreshing catalog of 150+ GitHub collection tools across five categories (`web-scraper`, `dynamic-scraper`, `api-collector`, `agent-skill`, `dataset`) and walks a short funnel: category menu → tool card → per-tool workflow → confirm scope → crawl.

## Who uses this workflow

Data engineers and researchers collecting from websites, REST/GraphQL APIs, and Chinese social platforms. Ships compliance-gated crawl workflows for Scrapy, Playwright, Crawl4AI, and MediaCrawler.

## How it's used

> "I want to scrape Xiaohongshu posts"

The skill shows a category menu, recommends the MediaCrawler card, loads its compliance-gated workflow, confirms scope with the user, then crawls.

Install: `npx skills add Yuuqq/collection-skill` — works with Claude Code, Cursor, and Codex (open Agent Skills format).

## Notes

- Catalog self-refreshes weekly via GitHub Action (optional LLM judging, guarded by deterministic safe-pruning rules — the model never prunes alone)
- Respects `robots.txt`, rate limits, and ToS; scope is confirmed before the first crawl of any new domain
- MIT licensed, README in EN / 简体中文 / 日本語 / Español
- Repo: https://github.com/Yuuqq/collection-skill

Following the external-link pattern used by most community entries (aws-skills, Skill Seekers, iOS Simulator, etc.) — happy to also add a `collection-skill/SKILL.md` folder copy if you prefer that format.
