### PR TITLE
Add RAID and FORTRESS, a guerrilla marketing plugin pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,10 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [FORTRESS](https://github.com/Pr1m4lc0d3/FORTRESS) - Seven skills and a dependency-free Python linter that exits non-zero on any marketing claim not sourced in your own register, so an agent writing your copy cannot invent a statistic. Also sorts the assets you own from the ones you rent. *By [@Pr1m4lc0d3](https://github.com/Pr1m4lc0d3)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [RAID](https://github.com/Pr1m4lc0d3/RAID) - Ten skills for marketing a product with no budget, built on one test: never fight where the money wins. Finds ground a funded competitor cannot outbid you on, and stages every draft for a human to sign rather than publishing it. *By [@Pr1m4lc0d3](https://github.com/Pr1m4lc0d3)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
### What they do

Two Claude Code plugins for marketing a product when the budget is nothing. They are halves of one doctrine, and each runs alone.

**RAID** (10 skills) is the offensive half, built on one test: **never fight where the money wins.** Ads, head search terms, sponsorships, influencer rates. A funded competitor outbids you on all of it. What is left is surprise, timing, niche depth, and being genuinely useful in a room you do not own. The skills work that map: recon, asymmetry against an incumbent's own revenue model, stunts filtered by a carry test, ambush timing, borrowed audiences, asset multiplication, claim-safe drafting, and a stage-gated campaign read back as a daily briefing.

**FORTRESS** (7 skills) is the defensive half. A cleared/uncleared claim register with `claim_lint.py`, dependency-free Python 3, that exits non-zero on any claim-shaped sentence not sourced in your own `.monkeys/truth.md`. Wire it into CI and an agent writing your copy cannot invent a statistic without the build going red. Plus motte-and-bailey asset sorting (what you own versus what you rent), per-account standing, and a human publish gate.

### Why they are external links rather than folders

Each is a multi-skill plugin with a manifest, not a single `SKILL.md`. Copying only the front door in would ship a skill that routes to nine siblings that are not there, which is worse than not listing it. This follows the **Brand Build Skills** row already in this section. Both are MIT and installable directly:

```
/plugin marketplace add Pr1m4lc0d3/RAID
/plugin marketplace add Pr1m4lc0d3/FORTRESS
```

### Why it is a real use case

They came out of marketing my own products with no ad budget, and specifically out of two failures worth naming.

An agent I had built for marketing generated three unsourced claims: a market size, a moat, and a timeline. Nothing in its instructions had told it not to. That is FORTRESS.

Then, building FORTRESS's linter, **fourteen false negatives were found and fixed.** Claims it would have passed as verified when they were not: an unsourced `49` hiding inside a cleared `149`; a config auto-loaded from the working directory that silently disabled the whole gate; one unclosed code fence blanking the rest of a document and reporting all clear. It would have shipped clean after the second review, printing "no unsourced claims found" over invented numbers. The README says plainly that a green run is not proof.

RAID fails differently, and that shaped it: the risk is not a bad script, it is an obedient agent doing real harm while following good advice. Astroturfing a community into a permanent ban, republishing a real person's forum post as a testimonial they never gave. None of that is catchable by a test. The structural answer is that **RAID stages and never publishes.** Every output is a file a human reads and signs.

### Checklist

- Real use case, not hypothetical
- Searched existing skills, no duplicate in this section
- Tested in Claude Code; a cold run by an agent that did not build them found a real defect, which was fixed
- Built-in tools only. No other plugin, no API key, no account, no network beyond WebSearch and WebFetch
- Nothing is published, posted or sent. Both plugins prepare and stop
- MIT

### Honest note

**The system is unproven. It has not produced a sale and there is no case study behind it.** That is stated on line one of both READMEs, because a marketing plugin claiming results it had not produced would violate its own doctrine. The narrower honest pitch: it encodes what specific failures cost, so an adopter can skip paying for them.
