### PR TITLE
Add two marketing skills: A/B Test Playbook and Lifecycle Marketing Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,14 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
+- [A/B Test Playbook](https://github.com/ali-demirbas/ab-test-playbook) - Picks A/B test scenarios from an archive of 179, designs single-variable experiments for a page you share, checks existing test plans for confounds and missing guardrails, and runs the z-test on results you paste in. Each scenario comes out as a one-file HTML card. *By [@ali-demirbas](https://github.com/ali-demirbas)*
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Lifecycle Marketing Engine](https://github.com/ali-demirbas/claude-lifecycle) - Scores what your analytics data supports before designing anything, then builds lifecycle journeys for onboarding, retention, churn and win-back. Copy for each step is checked against channel rules, and whatever the data cannot support becomes a tracking plan. *By [@ali-demirbas](https://github.com/ali-demirbas)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adding two skills to Business & Marketing, both alphabetically placed.

A/B Test Playbook covers experiment design and CRO: a scenario archive, single-variable test design, plan auditing, and the statistics for reading results.

Lifecycle Marketing Engine covers CRM journeys: it scores data quality first and sizes the journeys to what the data can actually trigger and measure.

Both are MIT, public, and have working CI and docs.