### PR TITLE
Add finance-video-copywriting skill: viral Chinese finance short-video copywriting (S0-S7 SOP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [finance-video-copywriting](https://github.com/SSRYLJRSS/finance-video-copywriting) - Generates viral Chinese finance short-video voiceover scripts via a 7-step SOP (S0-S7): analyzes reference copy, collects and verifies facts, drafts outlines and 1500-2000 char scripts, creates cover titles, and learns from user revisions. *By [@SSRYLJRSS](https://github.com/SSRYLJRSS)*
 
 ### Creative & Media
 


### PR DESCRIPTION
## What

Adds [finance-video-copywriting](https://github.com/SSRYLJRSS/finance-video-copywriting) to the Communication & Writing section.

A Claude-style Agent Skill (SKILL.md format, MIT licensed) that generates viral Chinese finance short-video voiceover scripts via a 7-step SOP (S0-S7):
- Analyzes reference copy and extracts structure/emotion/key-lines
- Collects and cross-verifies facts with sources
- Drafts 1500-2000 char voiceover scripts in a punchy, colloquial "wish-fulfillment / face-slapping" style
- Creates cover titles, and learns from user revisions (self-improving experience library)

## Why

- **Vertical & differentiated**: Chinese-language finance content skill is scarce in current listings
- **Pure instructions, no scripts**: only Markdown rule files + a packaging script — no network calls, no credential access, safe to install (unlike 36% of public skills flagged for prompt injection)
- **Battle-tested**: iterated over real production use, v2.1.0, includes bilingual EN/ZH description for AI matching

## Checklist
- [x] Based on real use case
- [x] No duplicates in existing listings
- [x] Follows SKILL.md structure template
- [x] MIT License included
- [x] Tested across platforms (WorkBuddy/Hermes-compatible)