### PR TITLE
Add TableBI skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [TableBI](https://github.com/cooldk/tablebi-skill) - Gives Claude Code a standing SQL connection to Search Console, GA4, Google Ads and Meta Ads, then pins analyses as live self-refreshing dashboards. *By [@cooldk](https://github.com/cooldk)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds **TableBI** to Business & Marketing.

**What it does:** gives Claude Code a standing SQL connection to marketing sources (Search Console, GA4, Google Ads, Meta Ads, CSV) instead of the export-upload-re-explain loop. The agent queries at two altitudes — unified cross-channel metrics with correctly-aggregating `roas()`/`ctr()`/`cpa()` macros, or lossless per-platform raw tables — and can pin any analysis as a public read-only dashboard URL that re-runs its SQL against current data.

**Real use case:** I use it weekly to monitor a portfolio of sites in Search Console and to catch ad spend with no conversions. Every answer carries per-source freshness metadata, so the agent won't compare a finalized Search Console day (multi-day lag) against a half-synced ads day and report a drop that isn't real.

**Notes against the contributing guidelines:**
- Skill file: https://github.com/cooldk/tablebi-skill/blob/main/SKILL.md
- No MCP server required — the skill drives a CLI (`npm i -g @tablebi/cli && tablebi install`).
- Safe by construction: user SQL is read-only and sandboxed (one SELECT/WITH, no filesystem or network reach).
- Requires a TableBI account; free tier includes connected sources, both query altitudes and one live dashboard.
- Live dashboard example, no signup needed to view: https://dk.tablebi.com/d/dsh_d0a471a4f9ba6754