### PR TITLE
Add skill: riffkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [riffkit](https://github.com/riffkit/skill) - Rebuilds the formula of a short video that already performed — hook, pacing, emotional beats — into a brand-new video for your own product, character and language. Nine output languages, multiple aspect ratios; the source clip is never reused. *By [@riffkit](https://github.com/riffkit)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds **riffkit** to Creative & Media.

Repo: https://github.com/riffkit/skill · Live skill: https://riffkit.ai/SKILL.md

**What it does:** give it one short video that already performed, and it rebuilds that video's *formula* — the hook, the pacing, the emotional beats — into brand-new footage around your own product, character and language. The source clip is never reused; the output is an original video. Nine output languages, multiple aspect ratios.

**Real use case, not hypothetical:** it runs in production behind riffkit.ai for DTC and TikTok Shop sellers making ad creative. MIT licensed, SKILL.md with YAML frontmatter, worked examples in the repo, tagged release v1.3.1 kept in sync with the live SKILL.md.

**Tested on:** Claude Code and Cursor — any agent that can read a URL (`Read https://riffkit.ai/SKILL.md and follow the instructions`) — plus the OpenClaw CLI.

**Safety:** device-approval auth, so no API key or token is ever pasted into chat; the agent confirms the plan before anything renders or bills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)