### PR TITLE
Add Webcmd to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [Webcmd](https://github.com/agentrhq/webcmd) - Installs per-site browser skills into Claude Code with `webcmd skills add`, so Claude drives real websites through deterministic commands instead of re-exploring pages on every run. *By [@prakhar1605](https://github.com/prakhar1605)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds Webcmd to Skills > Development & Code Tools, in alphabetical order
after Webapp Testing.

Webcmd installs browser skills into Claude Code via `webcmd skills add`.
Instead of re-exploring a site on every run, it learns a site's navigation
once and exposes it as deterministic per-site commands the agent reuses.
Tested with Claude Code. Node, Apache-2.0. Docs: https://webcmd.dev/docs

Disclosure: I contribute to this project.