### PR TITLE
docs: add iridescent UI workbench to skill catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [Iridescent UI Workbench](https://github.com/3516027002att-ui/liuguang-banlan-ui) - Builds parameterized iridescent-white and colorful-black interfaces with OKLCH, WebGL/CSS fallback, screenshot checks, and per-color intensity reports.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
## Summary

- Add the public [`liuguang-banlan-ui`](https://github.com/3516027002att-ui/liuguang-banlan-ui) skill to the Creative & Media catalog.
- The skill builds two parameterized UI modes—流光溢彩白 (iridescent white) and 五彩斑斓黑 (colorful black)—with OKLCH contracts, WebGL/CSS fallback, screenshot QA, and overall/per-color intensity reporting.

The canonical repository contains the complete `SKILL.md`, references, scripts, starter assets, and Apache-2.0 license.