### PR TITLE
Add cine-director to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [cine-director](https://github.com/socramsea/cine-director) - Film-director skill for generative AI video: shot-by-shot decupage, prompts, character bible, and cost estimates before spending API credits. *By [@socramsea](https://github.com/socramsea)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
## What does this PR add?

Adds [cine-director](https://github.com/socramsea/cine-director) to the Creative & Media section.

## What problem it solves

Generative video is priced per second and non-deterministic, so the expensive mistakes are made in pre-production: shots that can't lipsync, characters that drift between takes, audio cut mid-syllable. Most AI video tooling starts by generating clips and discovers those problems after the credits are spent.

`cine-director` front-loads the directing work instead. It turns a song, a product, or an idea into a complete cinematic pre-production package — before a single API credit is spent:

- Shot-by-shot decupage with per-shot duration, framing, action, and camera
- One generation-ready prompt per shot, with the character bible embedded
- Character consistency bible, so the same person survives across takes
- ffmpeg commands for per-shot audio cuts (lipsync-ready)
- API cost estimate with a declared source and date for every price

The skill's founding rule is that no parameter enters a deliverable without a declared source — unvalidated values are marked `PENDENTE` explicitly rather than filled with a plausible invented number. That applies to the agent too: it is instructed not to estimate API costs without consulting the provider's current pricing, and not to assert model duration/resolution limits without checking current docs.

## Who uses this workflow

- Musicians and labels planning an AI-generated music video with per-shot lipsync
- Brand and product teams storyboarding short cinematic films
- Real-estate agents producing property showcase clips
- Anyone who wants to know what a generative video will cost, and whether the plan is even executable, before generating

## How it's used

Installed via:

```bash
npx skills add socramsea/cine-director
```

Then, in a Claude Code session:

- "Use cine-director to plan a music video for this track."
- "Use cine-director to storyboard a 30s cinematic showcase of this apartment."
- "How much would a 60-second AI-generated brand film cost?"

Two modes. **Dry-run is the default and costs nothing** — it delivers the full pre-production package with no API calls. The optional execution layer runs on the user's own API keys (image-to-video + lipsync) and enforces a pilot-shot-first workflow: one shot end-to-end, approved, then batch.

The repo ships reusable shot cards (`close-up-lipsync`, `master-performance`, `plano-sequencia`, `showcase-imovel`), a character-bible reference, a pipeline reference, and a decupage template. Docs are in English with a full Portuguese version (`README_PT.md`).

## Attribution

Original skill — not based on an external workflow. Built by [Forja Criativa](https://forjacriativa.ia.br) from a pipeline validated in real production (a complete music video with per-shot lipsync): reference image → image-to-video → ffmpeg audio cuts → per-shot lipsync → final edit. The shot cards document what worked and what broke.

## Checklist

- [x] Skill is based on a real use case — a produced music video, not a hypothetical scenario.
- [x] Checked for duplicates — no existing entry covers generative-video pre-production (decupage, character consistency, lipsync-ready audio cuts, pre-generation cost estimate).
- [x] SKILL.md has proper YAML frontmatter (name, description) and documented usage.
- [x] Entry added in alphabetical order within Creative & Media (after Canvas Design, before imagen).
- [x] Entry format matches the existing external-link entries; no emojis; consistent punctuation.
- [x] Apache 2.0 licensed.
