### PR TITLE
Add which-skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
+- [which-skill](https://github.com/whichskill/whichskill) - Routes a request to an ordered chain of skills across every installed pack, with the arbitration between near-duplicates already settled — which of three debuggers, which of two TDD skills — plus an explicit list of what not to run and why. Builds its catalogue from your own machine, so it never names a command you do not have. *By [@OmarBenje](https://github.com/OmarBenje)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
Adds one entry to **Development & Code Tools**, in alphabetical position after `Webapp Testing`. No files copied.

## What it is

A router for the problem of having too many skills installed. Ask it what to run and it returns an ordered chain, a one-line reason for each step that needs one, and an explicit list of what you do *not* run and why — instead of naming every plausible skill and leaving you to arbitrate.

It settles the near-duplicates that appear once you have several packs side by side: which of three debuggers, which of two TDD skills, which of three code reviews, and at which moment each one wins.

## Why a link rather than a folder

Two reasons, both practical:

1. **It is not a single SKILL.md.** It ships `scripts/build-catalogue.sh`, which generates the catalogue of skills actually installed on the user's machine. A hard rule forbids the router from naming anything absent from that catalogue, so a copied `SKILL.md` on its own would install and then refuse to route. The link points at the working whole.
2. **Licence.** Its prose is CC BY-SA 4.0; this repository badges Apache-2.0. Linking avoids placing share-alike text under an incompatible badge.

Happy to discuss if you would rather have a folder — but it would need the script alongside it to function.

## Verified

- `npx skills add whichskill/whichskill --list` → `Found 1 skill`
- Eval suite in-repo: 18 assertions, 18 pass