### PR TITLE
Add 4 practical skills: video-to-text, doc-ocr, de-ai-writer, ecommerce-material-studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Document Processing
 
-- [video-to-text](https://github.com/jiawood2006/hermes-skills/tree/main/skills/video-to-text) - Extract transcripts from Douyin video links or local video files with auto-download. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [doc-ocr](https://github.com/jiawood2006/hermes-skills/tree/main/skills/doc-ocr) - Fully local OCR for PDFs, scans, and images — private, no upload required. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [docx](https://github.com/anthropics/skills/tree/main/skills/docx) - Create, edit, analyze Word docs with tracked changes, comments, formatting.
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
+- [video-to-text](https://github.com/jiawood2006/hermes-skills/tree/main/skills/video-to-text) - Extract transcripts from Douyin video links or local video files with auto-download. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
@@ -171,10 +171,10 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Communication & Writing
 
-- [de-ai-writer](https://github.com/jiawood2006/hermes-skills/tree/main/skills/de-ai-writer) - Rewrite AI-generated copy into natural human tone — removes robotic phrasing. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
+- [de-ai-writer](https://github.com/jiawood2006/hermes-skills/tree/main/skills/de-ai-writer) - Rewrite AI-generated copy into natural human tone — removes robotic phrasing. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
@@ -182,9 +182,9 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Creative & Media
 
-- [ecommerce-material-studio](https://github.com/jiawood2006/hermes-skills/tree/main/skills/ecommerce-material-studio) - Batch e-commerce product images (main/detail/scene) with auto product scaling and brand overlay. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [ecommerce-material-studio](https://github.com/jiawood2006/hermes-skills/tree/main/skills/ecommerce-material-studio) - Batch e-commerce product images (main/detail/scene) with auto product scaling and brand overlay. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Document Processing
 
+- [video-to-text](https://github.com/jiawood2006/hermes-skills/tree/main/skills/video-to-text) - Extract transcripts from Douyin video links or local video files with auto-download. *By [@jiawood2006](https://github.com/jiawood2006)*
+- [doc-ocr](https://github.com/jiawood2006/hermes-skills/tree/main/skills/doc-ocr) - Fully local OCR for PDFs, scans, and images — private, no upload required. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [docx](https://github.com/anthropics/skills/tree/main/skills/docx) - Create, edit, analyze Word docs with tracked changes, comments, formatting.
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.
@@ -169,6 +171,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Communication & Writing
 
+- [de-ai-writer](https://github.com/jiawood2006/hermes-skills/tree/main/skills/de-ai-writer) - Rewrite AI-generated copy into natural human tone — removes robotic phrasing. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
@@ -179,6 +182,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Creative & Media
 
+- [ecommerce-material-studio](https://github.com/jiawood2006/hermes-skills/tree/main/skills/ecommerce-material-studio) - Batch e-commerce product images (main/detail/scene) with auto product scaling and brand overlay. *By [@jiawood2006](https://github.com/jiawood2006)*
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## What
Add 4 production-ready skills from [hermes-skills](https://github.com/jiawood2006/hermes-skills):

- **video-to-text**: Extract transcripts from Douyin video links or local videos (auto-download included)
- **doc-ocr**: Fully local OCR for PDFs/scans/images — private, no upload
- **de-ai-writer**: Rewrite AI copy into natural human tone
- **ecommerce-material-studio**: Batch e-commerce product images with auto scaling + brand overlay

## Why
All 4 solve real, daily problems (video transcription, document OCR, AI-text humanizing, e-commerce image production) and are documented with examples. Works across Claude Code / any Agent Skills-compatible tool.

## Tested
Each skill has been used in production workflows (e-commerce material pipeline, content workflows).