### PR TITLE
Add Cinematic Composition project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [Cinematic Composition](https://github.com/TimTsung/cinematic-composition-skill) - 64 film composition techniques with film-school theory (Bruce Block's visual components, the Five C's) plus official prompt adapters for Seedance/Kling/Runway/Veo and a 7-step QC loop that fixes slideshow-look AI video. By [@TimTsung](https://github.com/TimTsung)
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
## What this adds

Adds **Cinematic Composition** to the Creative & Media section (alphabetical order, after Canvas Design).

Repo: https://github.com/TimTsung/cinematic-composition-skill (MIT)

## Why it's a fit

- Real use case: turns scene intent into composition plans and model-ready prompts for AI filmmaking (Seedance / Kling / Runway / Veo)
- Follows the standard skill structure: SKILL.md router + 9 progressive-disclosure reference files
- Not a duplicate: existing entries cover image generation and design; none covers cinematographic composition theory (64 techniques, Bruce Block's visual components, Mascelli's Five C's) or a QC diagnostic loop for slideshow-look / character-drift failures
- Tested on Claude.ai (via .skill upload) and Claude Code; a packaged .skill is attached to the repo's v2.0 release

Thanks for maintaining this list!