### PR TITLE
Add Austrian Judgment Protocol (Business & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Business & Marketing
 
+- [Austrian Judgment Protocol](https://github.com/gootf/austrian-judgment-protocol) - Six executable Austrian School judgment protocols for AI agents: opportunity discovery, demand validation, strategy diagnosis, knowledge distribution, judgment authority, and uncertainty design — traceable claims from Kirzner, Mises, Hayek, and Foss & Klein for founders, CEOs & CTOs.
 - [Brand Build Skills](https://github.com/rampstackco/claude-skills) - 59-skill library covering the full website lifecycle: brand, design, content, SEO, dev, ops, growth, and research. Stack-agnostic with an Ahrefs MCP-powered SEO audit suite. Includes a meta-skill for writing your own. *By [@rampstackco](https://github.com/rampstackco)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.


### PR DESCRIPTION
Add [Austrian Judgment Protocol](https://github.com/gootf/austrian-judgment-protocol) to Business & Marketing.

Six executable Austrian School judgment protocols for AI agents (opportunity discovery, demand validation, strategy diagnosis, knowledge distribution, judgment authority, uncertainty design). 84 claims traceable to 9 primary sources (Kirzner, Mises, Hayek, Foss & Klein, Rumelt, Packard, Taleb, O'Driscoll & Rizzo, Christensen). Designed for founders, CEOs & CTOs; MIT licensed.