### PR TITLE
Add DeepRead skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Document Processing
 
+- [DeepRead](https://github.com/xiehuan123/dsh-deepread) - Evidence-first deep reading for articles, books, PDFs, and document sets, with traceable claims, confidence levels, knowledge maps, Feynman learning, and real output examples. *By [@xiehuan123](https://github.com/xiehuan123)*
 - [docx](https://github.com/anthropics/skills/tree/main/skills/docx) - Create, edit, analyze Word docs with tracked changes, comments, formatting.
 - [pdf](https://github.com/anthropics/skills/tree/main/skills/pdf) - Extract text, tables, metadata, merge & annotate PDFs.
 - [pptx](https://github.com/anthropics/skills/tree/main/skills/pptx) - Read, generate, and adjust slides, layouts, templates.


### PR DESCRIPTION
## What this adds

Adds DeepRead to Document Processing as an external, portable Agent Skill.

## Real-world problem

Long-document summaries often flatten an author's argument and present unsupported statements with the same confidence as sourced claims. DeepRead is used to turn articles, books, PDFs, and small document sets into reports that pair important claims with evidence and source locations, mark uncertainty explicitly, and generate knowledge maps or recall questions when requested.

## Who uses this workflow

- Developers and researchers reviewing technical articles or architecture documents
- Students learning long-form material with the Feynman technique
- Writers and analysts checking whether a source actually supports a claim before citing it

## Example

```text
Deep-read architecture.pdf in knowledge-map mode. For every important claim,
show the supporting evidence and page location. Mark anything the source does
not support instead of filling the gap.
```

The project README links three real output reports and supports Codex, Claude Code, and DeepSeek Harness. The portable skill has no runtime dependencies and treats document content as untrusted data rather than instructions.

## Attribution

Created and maintained by [@xiehuan123](https://github.com/xiehuan123). MIT licensed.
