### PR TITLE
Add danshari-skill (断舍离.skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [danshari-skill (断舍离.skill)](https://github.com/swaylq/danshari-skill) - Audits every installed skill against your current model, harness built-ins, and connected MCP servers, then archives the obsolete ones: blind-test evidence for capability skills, never-rm archiving with one-command restore. The first skill that tells you to delete skills. Bilingual (EN+中文). *By [@swaylq](https://github.com/swaylq)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
Adds **[danshari-skill](https://github.com/swaylq/danshari-skill)** to *Productivity & Organization* (alphabetical position).

While the ecosystem keeps adding skills, nothing helps remove them: danshari-skill audits every installed skill against the user's current model, harness built-ins, and connected MCP servers, then archives the obsolete ones — blind-test evidence before removing capability skills, red-line protection for private-knowledge skills, never-rm archiving with one-command restore. Bilingual (EN + 中文) with an end-to-end demo audit (12 skills → 5, description tax -66%). MIT licensed, SKILL.md at repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)