### PR TITLE
Add freehire — job-hunting skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Productivity & Organization
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
+- [freehire](https://github.com/strelov1/freehire-cli/tree/main/skills) - Job hunting over [freehire.me](https://freehire.me): search 3.3M+ IT roles crawled straight from 294K company career boards, score your skills against live market demand, tailor a CV against a specific posting, track applications, and triage recruiter mail. *By [@strelov1](https://github.com/strelov1)*
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.


### PR DESCRIPTION
Adds the freehire skills under **Productivity & Organization**, next to Tailored Resume Generator.

Five skills over [freehire.me](https://freehire.me), an open-source IT job aggregator that reads company career boards directly — 3.3M+ open roles across 294K companies, normalized and tagged with stack, seniority, region and work mode:

- **freehire-job-search** — faceted search over the live market
- **freehire-market-fit** — scores a skill set against real demand and names the gaps
- **freehire-tailor-cv** — rewrites a CV against a specific posting, refusing claims the experience does not support
- **freehire-track-applications** — application stages and notes
- **freehire-mail-triage** — sorts recruiter mail

Real use case, not hypothetical: they are used for actual job hunting, and each one is task-shaped rather than a general assistant prompt. They work in Claude Code today; the underlying API is public and also reachable over a CLI and an MCP server, so the same skills port to other Claude surfaces.

MIT. Repo: https://github.com/strelov1/freehire-cli