### PR TITLE
Add Aeon Claude Code skills library

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [Aeon](https://github.com/aeonfun/aeon) - 70+ Claude Code Agent Skills (SKILL.md) library plus an autonomous agent framework built on `claude -p` (headless Claude Code); cron-scheduled skills run entirely on GitHub Actions, self-heal on failure, and can replicate into a fleet. Ships installable skill packs and exposes its own skills as an MCP server. *By [@aaronjmars](https://github.com/aaronjmars)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
Adding **[Aeon](https://github.com/aeonfun/aeon)** under **Development & Code Tools**.

Aeon is a library of 70+ Claude Code Agent Skills (each a standard `SKILL.md`) plus the autonomous agent framework that runs them: it's built on `claude -p` (headless Claude Code), schedules skills on cron entirely inside GitHub Actions, self-heals when a run fails, and can replicate itself into a fleet of clones. It also ships installable skill packs and can expose its own skills as an MCP server.

- Repo: https://github.com/aeonfun/aeon
- License: MIT, actively maintained (daily commits)
- Why it fits this section: like the existing "Brand Build Skills" 59-skill library entry, it's an external, real-world Claude Code skills collection for developers, not a single skill.

Placed alphabetically at the top of Development & Code Tools (before `artifacts-builder`), single entry, matching the `[Name](url) - description. *By [@handle](url)*` format of the surrounding external entries.
