### PR TITLE
Add Zinc Universal Checkout skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Zinc Universal Checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout) - Discover, buy, track, and return products across Amazon, Walmart, Target, Best Buy, eBay, and 50+ other US retailers via the Zinc API. Install with `npx skills add zincio/skills --skill universal-checkout`. *By [@zincio](https://github.com/zincio)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## What it adds

A README entry under `### Business & Marketing` for the official [Zinc Universal Checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout) skill from [`zincio/skills`](https://github.com/zincio/skills).

## What problem it solves

AI agents need a standard way to discover, buy, track, cancel, and return products across US retailers. Zinc Universal Checkout is an [Agent Skill](https://agentskills.io) that teaches agents the Zinc API shopping lifecycle — search, place orders (with a `max_price` ceiling), track carrier checkpoints, cancel queued orders, and open returns — across Amazon, Walmart, Target, Best Buy, eBay, and 50+ other retailers.

The agent always confirms before placing an order or opening a return.

## Who uses this workflow

Anyone running Claude Code, Cursor, Gemini CLI, OpenClaw, or another Agent Skills-compatible agent that needs to shop or manage orders programmatically. Docs: [Zinc Agent Skills overview](https://www.zinc.com/docs/v2/agent-skills/overview).

## Attribution / inspiration source

Official skill from [Zinc](https://www.zinc.com) / [@zincio](https://github.com/zincio). Canonical skill: `universal-checkout`.

## Example of how it's used

```bash
npx skills add zincio/skills --skill universal-checkout
```

Then in the agent:

- "Search Amazon and Walmart for a USB-C hub under $40 and show the best-price offer"
- "Buy this product URL, max $50, and confirm before placing the order"
- "Track my last Zinc order and show the carrier checkpoints"

## Notes for the reviewer

- **README-only PR (no skill folder added).** Following the dominant pattern for external skills hosted in their own repos (e.g. merged PR #721 OpenWeb, #880 overkill). The SKILL.md ships with the official skill at [skills/universal-checkout/SKILL.md](https://github.com/zincio/skills/blob/master/skills/universal-checkout/SKILL.md).
- **This is a skill listing only** — no MCP server is being added.
- **Position:** alphabetical within `Business & Marketing`, after `Lead Research Assistant`.
- **Format:** matches existing entries (no emoji, hyphen-space separator, period, italicized attribution).