### PR TITLE
Add Visualizer (video understanding) to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
+- [Visualizer](https://github.com/TomSchoe/visualizer) - Lets Claude actually watch videos: Gemini-native video understanding (visuals + audio + timestamps) plus transcript, description-link and frame extraction for YouTube, 100+ platforms, and local files. *By [@TomSchoe](https://github.com/TomSchoe)*
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages


### PR DESCRIPTION
Adds **[Visualizer](https://github.com/TomSchoe/visualizer)** — a video-understanding skill: Gemini-native video eyes (visuals + audio + timestamps, YouTube URLs directly without download) plus transcript & description-link extraction via yt-dlp. MIT licensed. Works in Claude Code/Claude.ai and via `npx skills` in Codex, Cursor and Gemini CLI. Transcript-only mode works without any API key; the Gemini free tier covers ~8h of YouTube per day.

First video-analysis skill in this section — entry placed alphabetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)