### PR TITLE
Add Influencer Skills (TikTok/Instagram/YouTube creator data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [Influencer Skills](https://github.com/chengyu-xixihaha/influencer-skills) - Influencer-marketing skills across TikTok, Instagram, and YouTube: creator discovery, audience-fit scoring, and follower-authenticity checks for building outreach-ready shortlists. Zero-config free tier. *By [@chengyu-xixihaha](https://github.com/chengyu-xixihaha)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
Adds **Influencer Skills** to the Business & Marketing section.

- Repo: https://github.com/chengyu-xixihaha/influencer-skills
- Two SKILL.md skills: `influencer-lead-discovery` (creator/content search, similar-creator expansion, profile enrichment, outreach-ready shortlists) and `influencer-audience-fit-scoring` (audience geography/language/age/gender/interests + follower authenticity, creator comparison).
- Covers TikTok, Instagram, and YouTube. Portable across Claude Code / Codex / Cursor via the open Agent Skills standard.
- Zero-config free tier (no key required to try).

🤖 Generated with [Claude Code](https://claude.com/claude-code)