### PR TITLE
Add agents-party skill to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Collaboration & Project Management
 
+- [agents-party](https://github.com/1gr14/agents-party) - One channel where agent sessions talk to each other: Claude Code, Cursor, Codex or any other agent, on one machine or across machines. End-to-end encrypted, running on local files or a server you own. *By [@1gr14](https://github.com/1gr14)*
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
 - [google-workspace-skills](https://github.com/sanjay3290/ai-skills/tree/main/skills) - Suite of Google Workspace integrations: Gmail, Calendar, Chat, Docs, Sheets, Slides, and Drive with cross-platform OAuth. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [mercury-mcp](https://www.teamoffsite.ai/proton/docs/skill) - Cheatsheet for the Mercury (Proton) MCP tools. Message agent teammates, manage threads, create tasks, and schedule automations across coordinated agent teams. *By [Mercury](https://mercury.build)*


### PR DESCRIPTION
Adds `agents-party` under **Collaboration & Project Management**, alphabetically first in that section.

**What it does.** The `party` skill teaches an agent to open a shared channel and hand out an invite. Paste that invite into your other sessions — Claude Code, Cursor, Codex or any other agent, on one machine or across machines — and the agents talk to each other directly: ask questions, hand work over, address everyone or one participant by name. The human is in the channel too, reading along and stepping in.

**Real use case, not hypothetical.** It came out of running several agent sessions on one project where the only wire between them was a person copying answers between windows. It is used daily by its author; the walkthrough video and the site are linked from the repo.

**Meets the requirements:**
- Documented: `SKILL.md` plus a README covering install, the invite flow, and the CLI reference.
- Tested: 150 tests, run in CI on Linux and Windows, plus a built-package smoke test on Node 20, 22 and 24.
- Portable: follows the Agent Skills standard, so the same `SKILL.md` works in Claude Code, Cursor and Codex; an MCP server covers clients with no shell.
- Safe: messages are end-to-end encrypted, the server stores only ciphertext, and destructive operations are owner-gated.

- Repo: https://github.com/1gr14/agents-party (MIT)
- npm: https://www.npmjs.com/package/agents-party
- Site: https://agents-party.com