### PR TITLE
Add Bullshit Detector skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [Bullshit Detector](https://github.com/SerhiiKorniienko/bullshit-detector) - Extracts every factual claim from a YouTube video, article, tweet, or PDF, verifies each against independent sources via web search, and produces a per-claim report card with a 0-10 BS score. *By [@SerhiiKorniienko](https://github.com/SerhiiKorniienko)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
**What problem it solves:** Viral videos and articles make factual claims faster than anyone can check them. This skill set turns an agent into a fact-checker: point it at a YouTube video, article, tweet, or PDF and it extracts every discrete factual claim, verifies each one against independent sources via web search, and returns a report card with per-claim verdicts, linked sources, and an overall 0-10 BS score. A core integrity rule is enforced by script, not prompt: verdicts require sources — the skill refuses to confirm or refute a claim from model memory, and a bundled tally script rejects any report whose own arithmetic doesn't reconcile.

**Who uses this workflow:** Anyone deciding whether a piece of content deserves trust before sharing or acting on it — journalists checking sources, researchers screening claims, or anyone whose feed keeps serving "10 WAYS TO MAKE MONEY WITH AI" videos. Works in Claude Code, Claude.ai (analysis skills), Codex, Cursor, Gemini CLI, Copilot, and other agents that read the SKILL.md format — MIT licensed, no API keys, no accounts.

**Attribution/inspiration:** Inspired by Matt Pocock's skills — his repos showed how much workflow you can ship as plain, portable SKILL.md files, and this project follows that pattern.

**Example of how it's used:**

> **User:** "is this bullshit? https://youtube.com/watch?v=..."
>
> The agent pulls the transcript, extracts ~20 discrete claims, searches each one, and returns a report: ✅ confirmed with sources, ❌ contradicted with sources, ❓ unverifiable — plus a BS score and a one-line run footer with search counts. Example reports produced by the skill are in the repo's `examples/` directory.

Entry added alphabetically to **Data & Analysis**, matching the existing row format.