### PR TITLE
Add ats-resume-skill skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Productivity & Organization
 
+- [ats-resume-skill](https://github.com/msdanyg/ats-resume-skill) - Formats and audits resumes so ATS platforms (Workday, Greenhouse, Lever, iCIMS) parse them correctly — no more blank Company/Dates/Title fields. *By [@msdanyg](https://github.com/msdanyg)*
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.


### PR DESCRIPTION
**What problem it solves:** ATS platforms (Workday, Greenhouse, Lever, iCIMS) silently fail to parse many resumes — blank Company/Dates/Title fields the candidate never sees. This skill formats and audits resumes so the parsers extract them correctly.

**Who uses this workflow:** Job seekers submitting through corporate application portals, and career coaches preparing candidates.

**Example:** Paste a resume, get a parse-safety audit (what each major ATS will read into each field) plus a corrected version.

**Attribution:** Original work. MIT licensed, with worked examples and a packaged `.skill` file in the repo.
