### PR TITLE
Add elevenlabs-v3-text-optimization skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [elevenlabs-v3-text-optimization](https://github.com/msdanyg/elevenlabs-v3-text-optimization) - Rewrites any text into ElevenLabs V3-optimized scripts — audio tags, pacing, phonetic respelling, and acronym/number normalization for better AI voice synthesis. *By [@msdanyg](https://github.com/msdanyg)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
**What problem it solves:** Text written for the eye synthesizes poorly: ElevenLabs V3 needs audio tags, deliberate pacing, phonetic respelling of hard names, and normalized acronyms/numbers. This skill rewrites any text into a V3-optimized script.

**Who uses this workflow:** Anyone producing AI voiceover — podcast and video creators, product demo narration, audio versions of written content.

**Example:** Paste a blog paragraph, get a script with audio tags, pacing breaks, "S-Q-L" style acronym normalization, and numbers written out for speech.

**Attribution:** Original work. MIT licensed, with worked examples and a packaged `.skill` file in the repo.
