### PR TITLE
Add loop-design-skill skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
 - [kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen/skills/kaizen) - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
+- [loop-design-skill](https://github.com/msdanyg/loop-design-skill) - Turns a recurring business deliverable into a designed AI loop — interviews you in management language, refuses vague success criteria, and outputs a completed Loop Design Canvas plus a runnable loop spec. *By [@msdanyg](https://github.com/msdanyg)*
 - [n8n-skills](https://github.com/haunchen/n8n-skills) - Enables AI assistants to directly understand and operate n8n workflows.
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.


### PR DESCRIPTION
**What problem it solves:** Recurring business deliverables (weekly reports, QA passes, content pipelines) get handed to AI ad hoc, with vague success criteria and no stop conditions. This skill interviews you in management language, refuses vague success criteria, and outputs a completed Loop Design Canvas plus a runnable loop spec.

**Who uses this workflow:** Managers and operators turning repeated deliverables into bounded, checkable AI loops.

**Example:** "I want competitive briefs updated monthly" becomes a designed loop with success criteria, checks, stop rules, and an escalation owner.

**Attribution:** Original work. MIT licensed.
