### PR TITLE
Add pmm-impact-audit-skill skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [pmm-impact-audit-skill](https://github.com/msdanyg/pmm-impact-audit-skill) - Audits product marketing's real impact — 19 evidence-gated criteria across five layers, CMMI-style 0–4 maturity scores, RACI fix owners, and an attribution gate. No evidence, no score. *By [@msdanyg](https://github.com/msdanyg)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
**What problem it solves:** Product marketing impact is notoriously hard to assess honestly. This skill audits it against 19 evidence-gated criteria across five layers, with CMMI-style 0–4 maturity scores, RACI fix owners, and an attribution gate. The rule is "no evidence, no score" — it will not flatter.

**Who uses this workflow:** PMM leaders self-assessing their function, CMOs evaluating teams, consultants running marketing audits.

**Example:** Answer the evidence prompts for each criterion; get a maturity scorecard, gaps ranked by impact, and named fix owners.

**Attribution:** Original work. MIT licensed.
