### PR TITLE
Add Converly (server-side conversion tracking) to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Converly](https://github.com/converlyio/converly-agent) - Sets up server-side conversion tracking end to end: connects Google Ads, Meta, GA4, LinkedIn or TikTok, builds and publishes the conversion flow, installs the tracking snippet, and verifies real conversions. *By [@converlyio](https://github.com/converlyio)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds one entry to **Business & Marketing**, matching the format used by the other external entries in that section.

**Skill:** [converlyio/converly-agent](https://github.com/converlyio/converly-agent)

Sets up server-side conversion tracking end to end without writing tracking code: connects the ad platform (Google Ads, Meta, GA4, LinkedIn, TikTok and more), builds and publishes the conversion flow, installs the tracking snippet, and verifies with a test event plus real conversions. Drives the open-source [@converly/cli](https://www.npmjs.com/package/@converly/cli).

Against the requirements in CONTRIBUTING.md:
- **Real use case** — marketers tracking form submissions as ad conversions; the skill is built from real customer setups, not a hypothetical
- **Well documented** — SKILL.md plus reference docs for triggers, destinations, and a REST fallback
- **Accessible** — written for non-technical marketers; the agent asks for the site, the form tool, and what counts as a conversion
- **Tested** — verified against Claude Code and the Claude API
- **Safe** — destructive actions require explicit confirmation, and a real test conversion needs an explicit opt-in flag
- **Portable** — works anywhere the CLI runs; a headless device-code login is included for remote agents

Disclosure: I maintain this skill.