### PR TITLE
Add simmer-tennis-live-gate to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [simmer-tennis-live-gate](https://github.com/livetennisapi/simmer-tennis-live-gate) - Observe-only gate for Simmer/Polymarket tennis event-market entries: reads live match state (score, who is serving, break-point flag, retirement/walkover) from the Live Tennis API free tier and returns a trade/no-trade decision plus a suggested size — it places no orders. *By [@livetennisapi](https://github.com/livetennisapi)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds **simmer-tennis-live-gate** as a one-line entry under **Data & Analysis**, matching the list's actual format (bullet + repo link + *By [@author]*), linking to the external repo rather than vendoring a folder.

**Disclosure:** we run the Live Tennis API — this is a vendor-authored integration, so please judge it on the merits.

**What it is:** an observe-only, MIT-licensed Claude Code skill that gates Simmer/Polymarket tennis *event-market* entries on the live match state (score, who's serving, break-point flag, retirement/walkover/suspension) read from the Live Tennis API's **free** tier. It returns a trade/no-trade decision plus a suggested size and **places no orders** — execution stays with the caller. Modeled on simmer-sdk's regime_gate_skill.py; fails closed on anything it cannot verify.

- Repo (MIT, tested, has SKILL.md; also on ClawHub): https://github.com/livetennisapi/simmer-tennis-live-gate
- Free key, no card: https://livetennisapi.com/subscribe/free