### PR TITLE
Add analyzing-video-content (Creative & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
+- [analyzing-video-content](https://github.com/Aleph-J/analyzing-video-content) - Extracts what videos show on screen but never say out loud (slides, on-screen prompts, silent screencasts) by mining description, then transcript, then a few targeted frames via contact sheets. *By [@Aleph-J](https://github.com/Aleph-J)*
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
 


### PR DESCRIPTION
Adds **analyzing-video-content** — a small skill that teaches an agent to extract the information a video shows on screen but never says out loud (slides, on-screen prompts, silent screencasts and live sessions).

It works through a cheap three-layer approach — video description first, then a reduced transcript, then only a few targeted frames assembled into contact sheets — instead of reading frames naively. Frame types (table, dense text, chart, face…) are routed to per-type extraction recipes, and depth adapts to the need: exhaustive capture on short videos, selective attention on multi-hour ones.

It was built and validated on real videos (details and measured costs in the repo README). This is a first contribution — happy to adjust the entry or wording to match the list's conventions, and improvements or PRs on the skill itself are very welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r5ZXCoCshP57UzcuxAQyq