### PR TITLE
Add WaveSpeed Media Generation skill (Creative & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [WaveSpeed Media Generation](https://github.com/WaveSpeedAI/wavespeed-cli/tree/main/skills) - Generate and edit images, video, audio, and 3D through the WaveSpeed platform via the open-source `wavespeed` CLI: live model catalog search, per-model schema introspection, local-file upload, and price quotes before running. *By [WaveSpeedAI](https://github.com/WaveSpeedAI)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds the WaveSpeed skill to Creative & Media.

- **Skill**: https://github.com/WaveSpeedAI/wavespeed-cli/tree/main/skills (SKILL.md; what `wavespeed skill install` writes for Claude Code / Cursor / Codex)
- **Real use case**: agents generating hero images, editing assets, animating stills or upscaling clips mid-task via the [WaveSpeed](https://wavespeed.ai) platform — every model is one `wavespeed run <id>` call, with `--json` output and price quotes (`wavespeed price`) before spending.
- **Tested**: the CLI ships this exact skill; it is exercised daily with Claude Code.
- **Safe**: destructive ops require `--yes`; auth is handled by `wavespeed login` (the skill explicitly forbids pasting API keys into chat).
- Maintained by the WaveSpeedAI org (MIT).