### PR TITLE
Add USDCtoFiat cash-out skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [USDCtoFiat cash-out](https://github.com/ADWilkinson/galleonlabs-zkp2p/tree/main/packages/usdctofiat-plugin/skills/cashout) - Integrate non-custodial Base USDC-to-fiat cash-out with `@usdctofiat/offramp` via `cashout({ mode: "fast" | "best" })`. Install with `npx skills add ADWilkinson/galleonlabs-zkp2p --skill cashout`. *By [@ADWilkinson](https://github.com/ADWilkinson)*
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
-- [USDCtoFiat cash-out](https://github.com/ADWilkinson/galleonlabs-zkp2p/tree/main/packages/usdctofiat-plugin/skills/cashout) - Integrate non-custodial Base USDC-to-fiat cash-out with `@usdctofiat/offramp` via `cashout({ mode: "fast" | "best" })`. Install with `npx skills add ADWilkinson/galleonlabs-zkp2p --skill cashout`. *By [@ADWilkinson](https://github.com/ADWilkinson)*
+- [USDCtoFiat cash-out](https://github.com/ADWilkinson/usdctofiat-skills) - Integrate non-custodial Base USDC-to-fiat cash-out with `@usdctofiat/offramp` via `cashout({ mode: "fast" | "best" })`. Install with `npx skills add ADWilkinson/usdctofiat-skills --skill cashout`. *By [@ADWilkinson](https://github.com/ADWilkinson)*
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [software-architecture](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd/skills/software-architecture) - Implements design patterns including Clean Architecture, SOLID principles, and comprehensive software design best practices.
 - [subagent-driven-development](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd/skills/subagent-driven-development) - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
+- [USDCtoFiat cash-out](https://github.com/ADWilkinson/usdctofiat-skills) - Integrate non-custodial Base USDC-to-fiat cash-out with `@usdctofiat/offramp` via `cashout({ mode: "fast" | "best" })`. Install with `npm exec --package=skills@1.5.23 -- skills add ADWilkinson/usdctofiat-skills --skill cashout`. *By [@ADWilkinson](https://github.com/ADWilkinson)*
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
-- [USDCtoFiat cash-out](https://github.com/ADWilkinson/usdctofiat-skills) - Integrate non-custodial Base USDC-to-fiat cash-out with `@usdctofiat/offramp` via `cashout({ mode: "fast" | "best" })`. Install with `npx skills add ADWilkinson/usdctofiat-skills --skill cashout`. *By [@ADWilkinson](https://github.com/ADWilkinson)*
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis


### PR DESCRIPTION
## Summary
Adds the USDCtoFiat cash-out skill under Development & Code Tools.

- **Problem:** Agents keep inventing custodial or exchange-account off-ramps when a user wants Base USDC in Venmo, Cash App, Revolut, or similar payment apps.
- **Who uses it:** App, bot, and agent integrators wiring `@usdctofiat/offramp`.
- **Install:** `npx skills add ADWilkinson/usdctofiat-skills --skill cashout`
- **Source:** https://github.com/ADWilkinson/usdctofiat-skills
- **Product:** https://usdctofiat.xyz/developers

Placed alphabetically after `using-git-worktrees`.