### PR TITLE
Add sell-unused-tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
-- [sell-unused-tokens](https://github.com/ADWilkinson/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC. *By [@ADWilkinson](https://github.com/ADWilkinson)*
+- [sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC. *By [@ADWilkinson](https://github.com/ADWilkinson)*
 
 ### Communication & Writing
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [sell-unused-tokens](https://github.com/ADWilkinson/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC. *By [@ADWilkinson](https://github.com/ADWilkinson)*
 
 ### Communication & Writing
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
-- [sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC. *By [@ADWilkinson](https://github.com/ADWilkinson)*
+- [sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle direct; Venmo, Cash App, Wise, PayPal after a one-time USDCtoFiat Verify registration). *By [@ADWilkinson](https://github.com/ADWilkinson)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
## Summary
Adds [sell-unused-tokens](https://github.com/ADWilkinson/sell-unused-tokens) under Business & Marketing.

The skill walks an agent through listing leftover LLM API capacity on [tokensto.cash](https://tokensto.cash) (Surplus Intelligence seller front door) and cashing out USDC.

## Test plan
- [ ] GitHub link resolves
- [ ] SKILL.md exists at repo root