### PR TITLE
Add Screenshot Article Extractor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [xlsx](https://github.com/anthropics/skills/tree/main/skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
 - [Master Claude for Legal](https://github.com/sboghossian/master-claude-for-legal) - Skill pack for legal teams. NDA triage, multi-party version diff, citation verifier, meeting brief, and the Friday-newsletter status synthesis pattern. Includes 10 reference docs (privilege, verification, long documents, practice areas) and 3 firm templates. Built from the public Anthropic Claude for Legal Teams webinar dataset. *By [@sboghossian](https://github.com/sboghossian)*
+- [Screenshot Article Extractor](https://github.com/JunTan414/screenshot-article-extractor) - Extracts an article's full text from a series of screenshots pasted in order into a single structured Markdown file, with a strict readability gate and a tool-agnostic multimodal workflow. *By [@JunTan414](https://github.com/JunTan414)*
 
 ### Development & Code Tools
 


### PR DESCRIPTION
Add [Screenshot Article Extractor](https://github.com/JunTan414/screenshot-article-extractor) to the **Document Processing** category.

## What problem it solves
Users often paste a series of ordered screenshots of an article, document, or web page and want the full text extracted into a single structured Markdown file (headings, bold, quotes, tables preserved). Existing tools handle single files or PDFs; this skill handles the multi-screenshot-in-reading-order case.

## Who uses this workflow
Anyone archiving or reworking articles from screenshots — researchers, writers, and knowledge-base builders. The workflow was driven by a real use case: extracting two Chinese long-form articles ("索隐《牛来》" and a 《红楼梦》 essay) from ~14 sequential screenshots each, saved into a personal archive folder.

## How it works
1. Inventory images in the exact order pasted (never reorder/dedupe)
2. Read every image with multimodal vision (host-agnostic: WorkBuddy Read / any equivalent)
3. **Readability gate**: any blurry/cut-off/occluded page → report which image and STOP; never guess content
4. Merge into one structured Markdown, preserving original formatting
5. Name the file from the article title, ask for target directory if not given
6. Present the file

## Verified
- Tested on two real multi-screenshot articles (14-15 screenshots each)
- Installable via `npx skills add JunTan414/screenshot-article-extractor` (verified)
- Codex plugin manifest included (.codex-plugin/plugin.json)
- Tool-agnostic: works in any multimodal agent host