### PR TITLE
Add repo-cover skill (Creative & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
+- [repo-cover](https://github.com/sjh9714/repo-cover) - Designs GitHub social-preview cards (og:image) as one self-contained HTML file with four editorial moods, CJK-first typography, and deterministic design checks. *By [@sjh9714](https://github.com/sjh9714)*
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.


### PR DESCRIPTION
Adds [repo-cover](https://github.com/sjh9714/repo-cover) to Creative & Media, in alphabetical position.

repo-cover is an agent skill that designs a repository's GitHub social-preview card (og:image, 1280x640) as one self-contained HTML file. The agent writes the HTML itself following a constrained design system with a 4px grid, one accent color darkened until it passes WCAG contrast, and title size tiers by name length. It ships four moods (editorial, poster, blueprint, gallery), CJK-first typography with Korean keep-all and Noto stacks, a deterministic checker that validates canvas, self-containment, contrast, and CJK line-breaking, and a bundled composite Action that re-renders the PNG in CI. MIT licensed, tested in Claude Code and via the Agent Skills CLI, and works with any agent that can write files.

The use case is real. The repo's own social preview is a card the skill generated, and every shipped example passes the checker in CI.