### PR TITLE
Add deep-security-audit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 ### Security & Systems
 
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
+- [deep-security-audit](https://github.com/ravindrakele/claude-skills) - Multi-agent security audit that maps the real attack surface of WordPress, Laravel, Next.js, or Node apps, reads the code instead of grepping, and adversarially verifies every finding with honest CVSS scoring. *By [@ravindrakele](https://github.com/ravindrakele)*
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.


### PR DESCRIPTION
## What this adds

Adds [deep-security-audit](https://github.com/ravindrakele/claude-skills) to the Security & Systems category, in alphabetical order, following the existing entry format.

## What problem it solves

Single-pass AI security reviews tend to grep for patterns and report noisy, unverified findings. This skill runs a multi-agent audit instead: it detects the framework, maps the real attack surface (routes, handlers, auth boundaries, sinks), fans out scoped finder agents that read and understand the code, then adversarially verifies every finding by proving the missing guard and tracing reachability before assigning an honest CVSS 3.1 score. Read-only by default.

## Who uses this workflow

Plugin and web developers running pre-release security passes on WordPress plugins, Laravel, Next.js, and Node/Express apps. Built from real plugin audit workflows in the Brainstorm Force ecosystem (SureRank and related products).

## Example

Install from the repo's plugin marketplace, then ask Claude Code to "run a security audit on this plugin" or "is this app secure". It produces a ranked, deduplicated report with severity and file:line references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmwGpozDyWycvuYnTrxMCt