### PR TITLE
Add unslopify (Communication & Writing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 - [Twitter Algorithm Optimizer](./twitter-algorithm-optimizer/) - Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit tweets to improve engagement and visibility.
+- [unslopify](https://github.com/youngfreezy/unslopify) - Deterministic linter and rewrite skill for AI-writing patterns: named rules with a public catalog, CI and pre-commit gates, and a phrase bank that flags repeated phrasing across documents. *By [@youngfreezy](https://github.com/youngfreezy)*
 
 ### Creative & Media
 


### PR DESCRIPTION
Adds [unslopify](https://github.com/youngfreezy/unslopify) to Communication & Writing, in alphabetical position.

unslopify is a deterministic linter and rewrite skill for AI-writing patterns: 29 named rules with a public before/after catalog (RULES.md), CI and pre-commit gates, a Claude Code plugin, and a phrase bank that flags repeated phrasing across documents. MIT, on PyPI, installable as a skill via npx skills add youngfreezy/unslopify. Calibrated against pre-LLM prose with the numbers published in the README.