### PR TITLE
Add cc-context-audit skill (Data & Analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Data & Analysis
 
+- [cc-context-audit](https://github.com/kuhung/cc-context-audit) - Audit Claude Code session context cost: what fills each turn's context, where tokens accumulate, and which best practices to follow — with evidence-level tags and actionable savings ranked by real impact. No dependencies, read-only, privacy-preserving. *By [@kuhung](https://github.com/kuhung)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research) - Execute autonomous multi-step research using Gemini Deep Research Agent for market analysis, competitive landscaping, and literature reviews. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*


### PR DESCRIPTION
## Add cc-context-audit skill

### What it does

[cc-context-audit](https://github.com/kuhung/cc-context-audit) audits Claude Code session context cost by reading local `~/.claude/projects/**/*.jsonl` logs. It answers three questions:

1. **What's in context each turn?** Fixed overhead vs accumulated content breakdown
2. **Where does cost go?** By content source (model output, tool returns, user input) and by token type (cache read/write/output)
3. **Which best practices are violated?** 10 rules with evidence-level tags (`measured` / `calibrated` / `heuristic`) and actionable savings ranked by real impact

### Why it's useful

Claude Code users often wonder "why is my session so expensive?" This skill complements [ccusage](https://ccusage.com/) (which answers "how much") by answering "why" — with data-driven, evidence-tagged recommendations sorted by measurable savings.

### Key features

- **Zero dependencies** — stdlib-only Python 3.9+
- **Read-only & privacy-preserving** — never writes to `~/.claude`, never phones home
- **Evidence levels** on every conclusion (measured / calibrated / heuristic)
- **Mutual-exclusion** grouping for cache-write rules to avoid double-counting
- **Self-checks** reported at the top of every audit (log count, chars/token calibration, thinking-token verification)

### Category

Data & Analysis — placed alphabetically before "CSV Data Summarizer"

### Attribution

By [@kuhung](https://github.com/kuhung) · Repository: https://github.com/kuhung/cc-context-audit · License: MIT

Made with [Cursor](https://cursor.com)