### PR TITLE
Add take-notes to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [solo-skills](https://github.com/rockscy/solo-skills) - 7 bilingual (EN+中文) skills for solo founders and indie devs: launch tweets, customer emails, decision frameworks, postmortems. Each skill includes an explicit "When NOT to use" section.
 - [Tailored Resume Generator](./tailored-resume-generator/) - Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances.
+- [take-notes](https://github.com/davertor/take-notes) - Turns a video, article, arXiv paper, or GitHub repo into a self-contained HTML study note, with a gallery, tag vocabulary, and Markdown/Anki export.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
 


### PR DESCRIPTION
Adds davertor/take-notes under Productivity & Organization.

Turns a video, article, arXiv paper, or GitHub repo into a self-contained
HTML study note — executive summary, key points, and a sectioned or
timestamped outline. Also includes a browsable gallery, a closed tag
vocabulary, and Markdown/Anki export, all as plain scripts with no model
involved. Works as an Agent Skill across Claude Code, Codex, Cursor,
OpenCode, and Gemini CLI from one SKILL.md. MIT licensed.

I am the author.