### PR TITLE
Add Mamba Labs GTM Skills to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Mamba Labs GTM Skills](https://github.com/mambalabsdev/mamba-labs-skills) - 56-skill library for signal-based go-to-market: Clay enrichment builds, cold email systems, deliverability audits, live signal research, CRM operations, and knowledge ops. Skills read shared BRAND/ICP/VOICE context files so output sharpens as you add context. *By [@mambalabsdev](https://github.com/mambalabsdev)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds one entry to **Business & Marketing**, following the same external-collection pattern as the Brand Build Skills entry directly above it.

**[Mamba Labs GTM Skills](https://github.com/mambalabsdev/mamba-labs-skills)** — 56-skill library for signal-based go-to-market: Clay enrichment builds, cold email systems, deliverability audits, live signal research, CRM operations, and knowledge ops.

Against the contributing requirements:

- **Real use case, not hypothetical.** The skills are distilled from production outbound campaigns and enrichment builds, not written from first principles.
- **Documented.** Every skill states what it does, when to trigger it, its inputs, method, output and quality bar.
- **Includes examples.** The signal skills carry runnable example inputs.
- **Tested.** Each skill ships 3 to 5 eval cases; the repo has a lint gate and an eval gate that both run green.
- **Safe and portable.** MIT licensed, single `SKILL.md` per skill, no destructive operations, works across Claude Code, Codex CLI, Cursor and other MCP-compatible agents.

Also installable as a plugin marketplace: `/plugin marketplace add mambalabsdev/mamba-labs-skills`

Inserted alphabetically after Lead Research Assistant. Happy to trim the description or move it if another section fits better.