### PR TITLE
Add TranscriptOut YouTube skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
+- [YouTube Skills (TranscriptOut)](https://github.com/artemchuikin/youtube-skills) - 12 skills for YouTube transcripts in five formats, video and channel search, playlists, and 4,000-video batch jobs through a hosted API with a free tier.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages


### PR DESCRIPTION
Adds a set of 12 YouTube skills to Creative & Media, next to the existing youtube-transcript entry.

The skills cover transcripts in five formats (text, JSON, SRT, VTT, raw srv3) with adjustable segment sizes for RAG, video and channel search, channel and playlist listings, and asynchronous batch jobs for up to 4,000 videos. They call a hosted API with a free tier (100 credits on signup, no card), and the repo documents every request, cost and error recovery so agents get calls right on the first try.