### PR TITLE
Add truthbear-verify to Data & Analysis — official fact verification with cryptographic proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [truthbear-verify](https://github.com/CHANGCHINFU/mcp-gauge) - Verify official facts from 180+ government sources (FRED, USGS, SEC EDGAR, NOAA, EPA) with cryptographic proof and tamper-evident record hashes. *By [@CHANGCHINFU](https://github.com/CHANGCHINFU)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
## What does this add?

Adds **truthbear-verify** to the **Data & Analysis** section — a skill for verifying official facts from 180+ government and institutional data sources (FRED, USGS, SEC EDGAR, NOAA, EPA) with cryptographic proof and tamper-evident record hashes.

## Links

- GitHub: https://github.com/CHANGCHINFU/mcp-gauge
- Live endpoint: `https://api.truthbear.co/mcp`

## Checklist

- [x] Only modifies `README.md`
- [x] Entry placed alphabetically in the correct category
- [x] Links to external repository
- [x] Description is concise and accurate