### PR TITLE
Add Frontend Design Review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 - [anydesign](https://github.com/uxKero/anydesign) - Analyzes any image, URL, or Figma file and generates a structured `design.md` with the full design system, component inventory, and reconstruction notes — portable to v0, Lovable, Cursor or any AI builder. *By [@uxKero](https://github.com/uxKero)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [Frontend Design Review](https://github.com/JasonColapietro/suede-creator-skills/tree/main/vendorable/frontend-design-review) - Designs, reviews, and visually QAs web and app interfaces against numeric design laws and a banned-defaults list so shipped screens look intentional instead of generated. *By [@JasonColapietro](https://github.com/JasonColapietro)*
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.


### PR DESCRIPTION
## Supersedes #1148

I have an older open PR (#1148) that added a bare link-out bullet to an external
repo. That does not follow CONTRIBUTING.md, which asks for a vendored
`skill-name/SKILL.md` folder plus a README entry. This PR is the correct format:
one skill folder, one alphabetical README line. Please treat this as the
replacement for #1148 and close that one at your discretion.

## What problem it solves

AI-generated interfaces fail in a recognizable way. They compile, they look
plausible when you read the code, and they render as the average of every
landing page in the training data: dark blue for a developer tool, purple
gradient for a music app, three icon cards in a row, a tiny uppercase eyebrow
above every section. The output is not broken, it is anonymous, and "make it
look better" does not fix it because nothing in the instruction is falsifiable.

This skill replaces taste-by-vibes with thresholds:

- A design contract locked before any CSS is written: audience, surface job,
  primary action, register, color roles, type roles, acceptance checks.
- Numeric design laws: OKLCH color strategy, dark-mode surface lightness bands
  and contrast floors, a fluid `clamp()` type scale, line measure, z-index
  semantics, and component laws for forms, modals, tables, navigation, and
  empty states.
- A banned-defaults list where every entry ships with a BEFORE, an AFTER, and
  the narrow case where the exception is earned: gradient text, glass panels,
  orb backgrounds, ghost cards, over-rounded corners, numbered section
  scaffolding, hero-metric templates, fake statistics.
- A render-and-compare loop, so nothing is called done from reading code.
  Desktop and mobile screenshots, a `visual-qa-report.md` with P0 to P3
  findings, and a ship gate that returns `ship`, `ship-with-caveats`, or `hold`
  with the evidence behind the verdict.
- A ten-dimension design-system score out of 100 that names the two weakest
  dimensions to fix first.

## Who uses this workflow

Solo builders and small teams shipping frontend work with an agent and no
dedicated designer in the loop. It is used for new landing pages and dashboards,
design-system drift audits before a redesign, mock-versus-implementation
fidelity checks, dark-mode passes, accessibility sweeps, and app store
screenshot preparation.

## Attribution

Adapted from the `suede-design` skill in
https://github.com/JasonColapietro/suede-creator-skills (MIT), generalized for
any product. The original was written for one company; this version strips the
company-specific brand gates, internal skill routing, and private companion
references, and replaces the domain-specific examples with neutral ones. The
craft is unchanged: the laws, the banned defaults, the QA loop, and the scoring
rubric are the parts worth vendoring.

Credited in the README entry and in the SKILL.md `**Inspired by:**` line.

## Example of how it is used

```
Review the design of the dashboard at http://localhost:3000/app and tell me
what is wrong with it. Render it at desktop and mobile before answering.
```

Produces findings with file names and specific fixes rather than adjectives:

```
P0  Color is decorative, not semantic. src/styles/tokens.css:14
    Six blues, none of which encode meaning. Threshold breaches, healthy
    ranges, and stale data all render in the same accent.
    Fix: commit to Restrained strategy. Tinted neutrals plus one accent
    under 10% of surface area, reserved for threshold breaches only.

P1  Card-in-card nesting. src/components/MetricGrid.tsx:31
    Cards are for items that are independently scannable or selectable, not
    section wrappers.
    Fix: rows with a shared rule, one card level maximum.
```

A fuller worked example, including the aesthetic direction and the ship gate
output, is in the SKILL.md.

## Contents

```
frontend-design-review/
├── SKILL.md
└── references/
    ├── design-laws.md      (numeric thresholds)
    └── scoped-bans.md      (banned defaults with replacements)
```

SKILL.md follows the CONTRIBUTING.md template: When to Use This Skill, What This
Skill Does, How to Use with Basic and Advanced Usage, Example, Inspired by,
Tips, Common Use Cases. The two reference files hold the detail that would bury
the top-level document, following the same pattern as `mcp-builder/reference`.
The README entry is added to Creative & Media in alphabetical order, between
Canvas Design and imagen. No other files are touched.
