### PR TITLE
Add AI Skill Studio to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 
 ### Development & Code Tools
 
+- [AI Skill Studio](https://www.devscratchpad.tech/ai-skill-studio) - Interactive browser-based builder to generate production-grade Claude Code skills (SKILL.md), CLAUDE.md guidelines, and Cursor .mdc rules with 100% client-side privacy. *By [@Saad-web-spec](https://github.com/Saad-web-spec)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) - Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via a 40-question intake, a one-page plan, and a 20-section spec. Includes a generator for AI hero images via Gemini 3 Pro Image (Nano Banana Pro). *By [@BuildShipGrowRepeat](https://github.com/BuildShipGrowRepeat)*


### PR DESCRIPTION
## What problem it solves

Creating robust, production-grade configuration files for Claude Code (`SKILL.md`), Claude projects (`CLAUDE.md`), and Cursor (`.mdc`) typically requires reading extensive documentation, memorizing schema structures, and hand-crafting prompts.

[AI Skill Studio](https://www.devscratchpad.tech/ai-skill-studio) provides a dedicated, 100% client-side workbench for developers to visually configure, generate, test, and export production-ready Claude Code skills and agent guidelines with zero server transmission and zero API key requirements.

## Who uses this workflow

- Developers building custom skills and tool integrations for Claude Code and Claude.ai.
- Teams defining repository-level `CLAUDE.md`, `AGENTS.md`, and Cursor `.mdc` coding guidelines.
- Engineers who prioritize data privacy and need client-side tooling without sending prompt architecture to third-party servers.

## Key Capabilities (Latest Upgrades)

- **13 AI Formats**: Claude Code `SKILL.md`, `CLAUDE.md`, `AGENTS.md`, Cursor `.mdc`, Windsurf Cascade, GitHub Copilot, Gemini Prompts, and MCP server schemas.
- **5-Layer Agent Suite**: Scaffolds context shields (`.cursorignore`, `.claudeignore`), `llms.txt` roadmap, and `ARCHITECTURE.md` specs.
- **Zero-Install CLI**: Terminal scaffolding available via `npx devscratchpad init`.
- **333+ Preset Matrix**: Instant 1-click ZIP export for Next.js 15, React 19, FastAPI, Supabase, Tailwind v4, and more.

## Repository / Tool Link

- Tool: https://www.devscratchpad.tech/ai-skill-studio
- Open-source Repository: https://github.com/Saad-web-spec/DevScratchPad (BUSL-1.1 Source-Available)

## Attribution

**Credit:** Built by [@Saad-web-spec](https://github.com/Saad-web-spec) as part of the open-source DevScratchpad suite.