### PR TITLE
Add hello-boss skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [hello-boss](https://github.com/babyGao/agent-pilot-skills/tree/main/skills/hello-boss) - Turns the agent into an outbound salesperson: maps every industry that could buy what you do, resolves each prospect company and email from public business registries, and writes one cold email that earns replies. *By [@babyGao](https://github.com/babyGao)*
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
## What problem it solves

Cold outreach breaks at both ends, and almost every existing tool helps only with the middle.

**First end: you don't know which industries could buy what you do.** A logistics operator
asked to name customers says "other logistics companies." This skill reframes the capability as
a *job* — "I move things with volume and weight from A to B and carry the time and damage risk"
— then runs five independent enumeration paths: value-chain via input-output coefficients, the
official industry classification tree, same-job-different-industry transfer, hiring-signal
reverse lookup, and constraint reverse lookup. Output typically goes from 4 candidate industries
to 30+, ranked by evidence instead of feeling.

**Second end: you don't know who actually operates a brand.** Registry data is dirty —
identical names, outsourced operators, dissolved shells, contract manufacturers posing as
operators. The skill converges four independent signals (brand-to-company, trademark holder,
address match, store tier) into three confidence grades, and refuses to guess on weak ones.

## Who uses this workflow

A five-year software studio doing outbound to marketplace sellers. The same pipeline applies to
logistics reaching manufacturers, design or data teams reaching sellers, and reseller
recruitment in a new vertical.

## How it differs from Lead Research Assistant

That skill qualifies leads once you know your target market. This one starts a step earlier — it
*defines* the target market — and ends a step later, with an entity-resolution contract and
three named deliverables.

## Attribution

Written after a real 58-company outreach run in September 2026. The throttling threshold
(temporary rejection at the 11th message at ~2.5s spacing, clean at 60-90s), the bounce rate,
and the per-domain delivery split are measurements from that run — including the parts that
went wrong.

## Example

> **User:** "I run a logistics company. Who can I actually sell to?"

The skill returns 31 candidates across five paths, including ones intuition misses: plastics and
glass rank highest on purchase intensity because they are bulky and cheap per unit, so freight
is a large share of cost — readable from the input-output table, not guessable. It flags 17
furniture makers currently hiring "delivery coordinators" as active demand, and excludes 9
industries with reasons (state-owned construction: the registered mailbox is tender-only).

## Notes

Single `SKILL.md`, roughly 4,400 tokens, no external dependencies and no paid services. Three
hard rules run throughout: never invent a number, only the brand name goes into outbound copy,
and human-facing prose is model-generated rather than string-concatenated.
