### PR TITLE
Add FarmDash DeFi skills to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [FarmDash DeFi Skills](https://www.farmdash.one/agents) - 10 agent skills for DeFi protocol intelligence, Trail Heat signals, risk analysis, and yield simulation with policy-bounded zero-custody workflows. *By [@Parmasanandgarlic](https://github.com/Parmasanandgarlic)*
 
 ### Business & Marketing
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [recursive-research](https://github.com/Anjos2/recursive-research) - Recursive research up to PhD level across any domain (science, tech, business, arts, humanities) with source tiering, WDM + Munger inversion for autonomous decisions, and disk checkpointing to survive context compaction. *By [@Anjos2](https://github.com/Anjos2)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
-- [FarmDash DeFi Skills](https://www.farmdash.one/agents) - 10 agent skills for DeFi protocol intelligence, Trail Heat signals, risk analysis, and yield simulation with policy-bounded zero-custody workflows. *By [@Parmasanandgarlic](https://github.com/Parmasanandgarlic)*
+- [FarmDash DeFi Skills](https://github.com/Parmasanandgarlic/farmdash-openclaw-skills) - 10 open agent skills for DeFi protocol intelligence, Trail Heat signals, risk analysis, and yield simulation with policy-bounded zero-custody workflows. Docs: https://www.farmdash.one/agents. *By [@Parmasanandgarlic](https://github.com/Parmasanandgarlic)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds 10 FarmDash agent skills (DeFi protocol intelligence, Trail Heat signals, risk analysis, yield simulation, policy-bounded zero-custody workflows) to Data & Analysis. Link points at live public docs https://www.farmdash.one/agents (OpenAPI https://www.farmdash.one/agents/openapi.yaml, MCP manifest https://www.farmdash.one/.well-known/mcp.json). Source skill repo is private during pre-release hardening; link will move to the public repo once visibility flips.