### PR TITLE
Add unflat (Creative & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Skills are not MCP servers and not tools. MCP defines how an agent connects to e
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 - [swiftui-design-skill](https://github.com/wholiver/swiftui-design-skill) - SwiftUI 前端设计 skill — 反 AI Slop 六条铁律、设计方向顾问、品牌资产协议、五维评审。支持 Claude Code / Cursor / Codex / OpenCode 等全部 AI agent 平台。 *By [@wholiver](https://github.com/wholiver)*
 - [Pixelbin-Media-Generation](https://github.com/anandpareek-hub/pixelbin-claude-skill) - Generate and edit images & videos with 85+ API portfolio and build visually appealing website pages
+- [unflat](https://github.com/merturl4576/unflat) - Fixes flat, single-tone AI-built sites with one reversible CSS block derived from the site's own colors: a ground, one light source and a few mounted surfaces, no markup changes. *By [@merturl4576](https://github.com/merturl4576)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
Adds **unflat**: an Agent Skill that fixes the flat, single-tone look of AI-built marketing pages with one reversible CSS block derived from the site's own colors — a ground, one light source, a few mounted surfaces (the hero and strips stay on the ground), no markup changes, delete the block to revert.

- Repo: https://github.com/merturl4576/unflat (MIT, SKILL.md + references, works in Claude Code, Cursor, Codex; `npx skills add merturl4576/unflat`)
- Before/after gallery: https://merturl4576.github.io/unflat/gallery/
- Real use case: every example page in the repo was produced by the skill itself; a checker proves each after page is the before page plus the block.

One entry, added at the end of Creative & Media.

Supersedes #1839, which was closed by an accidental push to its branch; the branch is restored and the diff is the same one-line addition.